### PR TITLE
feat(server): supporting Codex CLI

### DIFF
--- a/src/RoslynMcp.Server/McpServerHost.cs
+++ b/src/RoslynMcp.Server/McpServerHost.cs
@@ -180,7 +180,7 @@ public sealed class McpServerHost : IAsyncDisposable
 
     private McpResponse HandleInitialized(McpRequest request)
     {
-        // Notification messages are handled in RunAsync by skipping responses when id is null.
+        // Notification, no response needed (but we return success for compatibility)
         return McpResponse.Success(request.Id, new { });
     }
 

--- a/src/RoslynMcp.Server/McpServerHost.cs
+++ b/src/RoslynMcp.Server/McpServerHost.cs
@@ -114,7 +114,12 @@ public sealed class McpServerHost : IAsyncDisposable
 
                 FileLogger.Log($"Received request: method={request.Method}, id={request.Id}");
                 var response = await HandleRequestAsync(request, cancellationToken);
-                await _transport.WriteMessageAsync(response, cancellationToken);
+
+                // JSON-RPC notifications do not include an id and must not receive a response.
+                if (request.Id != null)
+                {
+                    await _transport.WriteMessageAsync(response, cancellationToken);
+                }
             }
             catch (OperationCanceledException)
             {
@@ -148,6 +153,7 @@ public sealed class McpServerHost : IAsyncDisposable
         {
             "initialize" => HandleInitialize(request),
             "initialized" => HandleInitialized(request),
+            "notifications/initialized" => HandleInitialized(request),
             "tools/list" => HandleToolsList(request),
             "tools/call" => await HandleToolCallAsync(request, cancellationToken),
             "shutdown" => HandleShutdown(request),
@@ -174,7 +180,7 @@ public sealed class McpServerHost : IAsyncDisposable
 
     private McpResponse HandleInitialized(McpRequest request)
     {
-        // Notification, no response needed (but we return success for compatibility)
+        // Notification messages are handled in RunAsync by skipping responses when id is null.
         return McpResponse.Success(request.Id, new { });
     }
 


### PR DESCRIPTION
## 📝 Description

<!-- Provide a clear and concise description of your changes -->

Apparently `codex cli` wants an answer to request message "notifications/initialized" for it to work, so added, otherwise it fails to start the mcp server.

## 🎯 Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ✅ Test additions or updates
- [ ] 🏗️ Build/CI changes

## 🧪 Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [x] All existing tests pass
- [ ] New tests added for new functionality
- [x] Manual testing performed

**Test Configuration**:
- OS: Windows 11
- .NET Version: 9.0.311

## ✅ Checklist

<!-- Mark completed items with an 'x' -->

- [ ] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added XML documentation for public APIs
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
