### PR TITLE
feat: Roslyn 5.0.0 upgrade and .slnx support

### DIFF
--- a/src/RoslynMcp.Cli/CliArgs.cs
+++ b/src/RoslynMcp.Cli/CliArgs.cs
@@ -5,7 +5,7 @@ namespace RoslynMcp.Cli;
 /// </summary>
 public sealed class ParsedArgs
 {
-    /// <summary>Path to .sln or .csproj file (null for global help).</summary>
+    /// <summary>Path to .sln, .slnx, or .csproj file (null for global help).</summary>
     public string? SolutionPath { get; init; }
 
     /// <summary>Tool name in kebab-case (null for global help).</summary>
@@ -142,6 +142,7 @@ public static class CliArgs
 
     private static bool LooksLikeFilePath(string value) =>
         value.EndsWith(".sln", StringComparison.OrdinalIgnoreCase) ||
+        value.EndsWith(".slnx", StringComparison.OrdinalIgnoreCase) ||
         value.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase) ||
         value.Contains(Path.DirectorySeparatorChar) ||
         value.Contains(Path.AltDirectorySeparatorChar);

--- a/src/RoslynMcp.Core/FileSystem/PathResolver.cs
+++ b/src/RoslynMcp.Core/FileSystem/PathResolver.cs
@@ -80,6 +80,7 @@ public static class PathResolver
             return false;
 
         return path.EndsWith(".sln", StringComparison.OrdinalIgnoreCase) ||
+               path.EndsWith(".slnx", StringComparison.OrdinalIgnoreCase) ||
                path.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase);
     }
 

--- a/src/RoslynMcp.Core/RoslynMcp.Core.csproj
+++ b/src/RoslynMcp.Core/RoslynMcp.Core.csproj
@@ -30,8 +30,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Locator" Version="1.6.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/RoslynMcp.Core/Workspace/MSBuildWorkspaceProvider.cs
+++ b/src/RoslynMcp.Core/Workspace/MSBuildWorkspaceProvider.cs
@@ -67,7 +67,7 @@ public sealed class MSBuildWorkspaceProvider : IWorkspaceProvider
         {
             throw new RefactoringException(
                 ErrorCodes.InvalidSourcePath,
-                "Path must be a .sln or .csproj file.");
+                "Path must be a .sln, .slnx, or .csproj file.");
         }
 
         if (!File.Exists(projectOrSolutionPath))
@@ -115,7 +115,8 @@ public sealed class MSBuildWorkspaceProvider : IWorkspaceProvider
 
         try
         {
-            if (normalizedPath.EndsWith(".sln", StringComparison.OrdinalIgnoreCase))
+            if (normalizedPath.EndsWith(".sln", StringComparison.OrdinalIgnoreCase) ||
+                normalizedPath.EndsWith(".slnx", StringComparison.OrdinalIgnoreCase))
             {
                 LogCallback?.Invoke($"Opening solution: {normalizedPath}");
                 solution = await workspace.OpenSolutionAsync(normalizedPath, cancellationToken: linkedCts.Token);

--- a/src/RoslynMcp.Core/Workspace/MSBuildWorkspaceProvider.cs
+++ b/src/RoslynMcp.Core/Workspace/MSBuildWorkspaceProvider.cs
@@ -93,7 +93,7 @@ public sealed class MSBuildWorkspaceProvider : IWorkspaceProvider
         // Collect workspace diagnostics but don't fail on warnings
         // Using ConcurrentBag for thread-safe collection as events may fire from multiple threads
         var diagnostics = new ConcurrentBag<WorkspaceDiagnostic>();
-        workspace.WorkspaceFailed += (_, args) =>
+        workspace.RegisterWorkspaceFailedHandler(args =>
         {
             if (args.Diagnostic.Kind == WorkspaceDiagnosticKind.Failure)
             {
@@ -104,7 +104,7 @@ public sealed class MSBuildWorkspaceProvider : IWorkspaceProvider
                 LogCallback?.Invoke($"Workspace warning: {args.Diagnostic.Message}");
             }
             diagnostics.Add(args.Diagnostic);
-        };
+        });
 
         Solution solution;
         var normalizedPath = PathResolver.NormalizePath(projectOrSolutionPath);

--- a/testdata/TestSolution/TestSolution.slnx
+++ b/testdata/TestSolution/TestSolution.slnx
@@ -1,0 +1,3 @@
+<Solution>
+  <Project Path="TestProject/TestProject.csproj" />
+</Solution>

--- a/tests/RoslynMcp.Cli.Tests/CliArgsTests.cs
+++ b/tests/RoslynMcp.Cli.Tests/CliArgsTests.cs
@@ -37,70 +37,86 @@ public class CliArgsTests
         Assert.False(result.ShowHelp);
     }
 
-    [Fact]
-    public void SolutionAndTool_ParsesCorrectly()
+    [Theory]
+    [InlineData("MySolution.sln")]
+    [InlineData("MySolution.slnx")]
+    public void SolutionAndTool_ParsesCorrectly(string solutionFile)
     {
-        var result = CliArgs.Parse(["MySolution.sln", "rename-symbol", "--source-file", "Foo.cs", "--symbol-name", "Bar"]);
+        var result = CliArgs.Parse([solutionFile, "rename-symbol", "--source-file", "Foo.cs", "--symbol-name", "Bar"]);
 
         Assert.False(result.ShowHelp);
         Assert.False(result.ShowToolHelp);
-        Assert.Equal("MySolution.sln", result.SolutionPath);
+        Assert.Equal(solutionFile, result.SolutionPath);
         Assert.Equal("rename-symbol", result.ToolName);
         Assert.Equal("Foo.cs", result.Options["source-file"]);
         Assert.Equal("Bar", result.Options["symbol-name"]);
     }
 
-    [Fact]
-    public void BooleanFlag_ParsesAsTrue()
+    [Theory]
+    [InlineData("My.sln")]
+    [InlineData("My.slnx")]
+    public void BooleanFlag_ParsesAsTrue(string solutionFile)
     {
-        var result = CliArgs.Parse(["My.sln", "extract-method", "--preview"]);
+        var result = CliArgs.Parse([solutionFile, "extract-method", "--preview"]);
         Assert.Equal("true", result.Options["preview"]);
     }
 
-    [Fact]
-    public void FormatFlag_StrippedFromToolOptions()
+    [Theory]
+    [InlineData("My.sln")]
+    [InlineData("My.slnx")]
+    public void FormatFlag_StrippedFromToolOptions(string solutionFile)
     {
-        var result = CliArgs.Parse(["My.sln", "get-diagnostics", "--severity-filter", "Error", "--format", "text"]);
+        var result = CliArgs.Parse([solutionFile, "get-diagnostics", "--severity-filter", "Error", "--format", "text"]);
         Assert.Equal("text", result.Format);
         Assert.False(result.Options.ContainsKey("format"));
         Assert.Equal("Error", result.Options["severity-filter"]);
     }
 
-    [Fact]
-    public void VerboseFlag_StrippedFromToolOptions()
+    [Theory]
+    [InlineData("My.sln")]
+    [InlineData("My.slnx")]
+    public void VerboseFlag_StrippedFromToolOptions(string solutionFile)
     {
-        var result = CliArgs.Parse(["My.sln", "diagnose", "--verbose"]);
+        var result = CliArgs.Parse([solutionFile, "diagnose", "--verbose"]);
         Assert.True(result.Verbose);
         Assert.False(result.Options.ContainsKey("verbose"));
     }
 
-    [Fact]
-    public void DefaultFormat_IsJson()
+    [Theory]
+    [InlineData("My.sln")]
+    [InlineData("My.slnx")]
+    public void DefaultFormat_IsJson(string solutionFile)
     {
-        var result = CliArgs.Parse(["My.sln", "diagnose"]);
+        var result = CliArgs.Parse([solutionFile, "diagnose"]);
         Assert.Equal("json", result.Format);
     }
 
-    [Fact]
-    public void HelpInOptions_ShowsToolHelp()
+    [Theory]
+    [InlineData("My.sln")]
+    [InlineData("My.slnx")]
+    public void HelpInOptions_ShowsToolHelp(string solutionFile)
     {
-        var result = CliArgs.Parse(["My.sln", "rename-symbol", "--help"]);
+        var result = CliArgs.Parse([solutionFile, "rename-symbol", "--help"]);
         Assert.True(result.ShowToolHelp);
         Assert.Equal("rename-symbol", result.ToolName);
     }
 
-    [Fact]
-    public void SolutionPathLookingLikeFile_NotTreatedAsToolName()
+    [Theory]
+    [InlineData("MySolution.sln")]
+    [InlineData("MySolution.slnx")]
+    public void SolutionPathLookingLikeFile_NotTreatedAsToolName(string solutionFile)
     {
-        var result = CliArgs.Parse(["MySolution.sln", "--help"]);
+        var result = CliArgs.Parse([solutionFile, "--help"]);
         Assert.True(result.ShowHelp);
     }
 
-    [Fact]
-    public void MultipleOptions_AllParsed()
+    [Theory]
+    [InlineData("My.sln")]
+    [InlineData("My.slnx")]
+    public void MultipleOptions_AllParsed(string solutionFile)
     {
         var result = CliArgs.Parse([
-            "My.sln", "change-signature",
+            solutionFile, "change-signature",
             "--source-file", "Foo.cs",
             "--line", "42",
             "--new-name", "DoStuff",

--- a/tests/RoslynMcp.Core.Tests/FileSystem/PathResolverTests.cs
+++ b/tests/RoslynMcp.Core.Tests/FileSystem/PathResolverTests.cs
@@ -56,6 +56,7 @@ public class PathResolverTests
     public static TheoryData<string, bool> IsValidSolutionOrProjectPathData => new()
     {
         { WinOrUnix(@"C:\project\Solution.sln", "/project/Solution.sln"), true },
+        { WinOrUnix(@"C:\project\Solution.slnx", "/project/Solution.slnx"), true },
         { WinOrUnix(@"C:\project\Project.csproj", "/project/Project.csproj"), true },
         { WinOrUnix(@"C:\project\File.cs", "/project/File.cs"), false },
         { @"relative\Solution.sln", false }


### PR DESCRIPTION
## Summary

- **Upgrade Roslyn to 5.0.0** for C# 13 support (from 4.8.0 which only supported C# 12)
- **Add .slnx solution format support** (the new XML-based solution format)

## Why

Roslyn 4.8.0 reports false positive errors when analyzing projects using C# 13 features like `params IEnumerable<T>` (introduced in C# 13). This affects .NET 9 projects which default to C# 13.

## Changes

- `Microsoft.CodeAnalysis.CSharp.Workspaces`: 4.8.0 → 5.0.0
- `Microsoft.CodeAnalysis.Workspaces.MSBuild`: 4.8.0 → 5.0.0
- `PathResolver.IsValidSolutionOrProjectPath()`: accepts `.slnx`
- `MSBuildWorkspaceProvider`: opens `.slnx` as solutions
- `CliArgs`: recognizes `.slnx` files
- Added `TestSolution.slnx` for testing
- Updated tests

## Test plan

- [x] All 566 tests pass
- [x] Verified `.slnx` opens correctly via CLI
- [x] Verified C# 13 features no longer cause false errors

🤖 Generated with [Claude Code](https://claude.ai/code)