### PR TITLE
Add setup command to install .NET global tool

### DIFF
--- a/commands/setup.md
+++ b/commands/setup.md
@@ -1,0 +1,62 @@
+---
+description: Install the Roslyn MCP Server .NET global tool
+allowed-tools: Bash(dotnet tool:*), Bash(roslyn-mcp:*), Bash(which:*)
+---
+
+# Roslyn MCP Server Setup
+
+Install and verify the Roslyn MCP Server .NET global tool.
+
+## Step 1: Check Prerequisites
+
+Verify .NET SDK is installed (9.0+ required):
+
+```
+dotnet --version
+```
+
+If not installed, direct the user to https://dotnet.microsoft.com/download/dotnet/9.0
+
+## Step 2: Check Existing Installation
+
+Check if roslyn-mcp is already installed:
+
+```
+dotnet tool list -g | grep -i roslyn
+```
+
+## Step 3: Install the Tool
+
+If not installed:
+
+```
+dotnet tool install -g RoslynMcp.Server
+```
+
+If already installed and needs updating:
+
+```
+dotnet tool update -g RoslynMcp.Server
+```
+
+## Step 4: Verify Installation
+
+Confirm the tool is available on PATH:
+
+```
+which roslyn-mcp
+```
+
+Then verify it runs:
+
+```
+roslyn-mcp --version
+```
+
+## Troubleshooting
+
+If `roslyn-mcp` is not found after install:
+1. Ensure `~/.dotnet/tools` is on your PATH
+2. For zsh: `export PATH="$HOME/.dotnet/tools:$PATH"` in `~/.zshrc`
+3. For bash: `export PATH="$HOME/.dotnet/tools:$PATH"` in `~/.bashrc`
+4. Restart your terminal after PATH changes

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -1,6 +1,6 @@
 ---
 description: Install the Roslyn MCP Server .NET global tool
-allowed-tools: Bash(dotnet tool:*), Bash(roslyn-mcp:*), Bash(which:*)
+allowed-tools: Bash(dotnet:*), Bash(roslyn-mcp:*), Bash(which:*)
 ---
 
 # Roslyn MCP Server Setup
@@ -50,7 +50,7 @@ which roslyn-mcp
 Then verify it runs:
 
 ```
-roslyn-mcp --version
+roslyn-mcp --help
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary
- Adds `/setup` slash command that guides users through installing the `RoslynMcp.Server` .NET global tool
- Fixes the issue where plugin installation clones the repo but doesn't install the `roslyn-mcp` CLI, leaving the MCP server unable to start

## Test plan
- [ ] Install the plugin fresh, verify `/setup` command appears
- [ ] Run `/setup`, verify it installs `RoslynMcp.Server` global tool
- [ ] Verify `roslyn-mcp` MCP server connects after setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)