### PR TITLE
feat(core): respect standard MSBuild properties during workspace load

### DIFF
--- a/src/RoslynMcp.Cli/Program.cs
+++ b/src/RoslynMcp.Cli/Program.cs
@@ -75,7 +75,7 @@ Console.CancelKeyPress += (_, e) =>
 
 try
 {
-    var workspaceProvider = new MSBuildWorkspaceProvider();
+    var workspaceProvider = new MSBuildWorkspaceProvider(args);
 
     // Special handling for diagnose (needs IWorkspaceProvider, not WorkspaceContext)
     if (parsed.ToolName.Equals("diagnose", StringComparison.OrdinalIgnoreCase))

--- a/src/RoslynMcp.Core/Properties/InternalsVisibleTo.cs
+++ b/src/RoslynMcp.Core/Properties/InternalsVisibleTo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("RoslynMcp.Core.Tests")]

--- a/src/RoslynMcp.Core/Workspace/MSBuildWorkspaceLoadSettings.cs
+++ b/src/RoslynMcp.Core/Workspace/MSBuildWorkspaceLoadSettings.cs
@@ -5,6 +5,8 @@ namespace RoslynMcp.Core.Workspace;
 
 internal static class MSBuildWorkspaceLoadSettings
 {
+    private const string _nuGetRestoreMsbuildArgsEnvironmentVariableName = "NUGET_RESTORE_MSBUILD_ARGS";
+
     private static readonly string[] _passThroughPropertyNames =
     [
         "NuGetAudit",
@@ -12,8 +14,10 @@ internal static class MSBuildWorkspaceLoadSettings
         "WarningsNotAsErrors"
     ];
 
-    private static readonly Regex _nuGetAuditDiagnosticCodePattern =
-        new(@"\bNU190[1-4]\b", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex _nuGetAuditDiagnosticPattern =
+        new(
+            @"\bNU190[1-4]\b|Package '[^']+'.* has a known [^,]+ vulnerability, https://github\.com/advisories/",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
 
     private static readonly Regex _commandLinePropertySeparatorPattern =
         new(@"(?<=[^%])[;,](?=[A-Za-z_][A-Za-z0-9_.-]*=)", RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -31,16 +35,12 @@ internal static class MSBuildWorkspaceLoadSettings
         IEnumerable<string>? commandLineArgs = null)
     {
         getEnvironmentVariable ??= Environment.GetEnvironmentVariable;
-        commandLineArgs ??= Environment.GetCommandLineArgs().Skip(1);
+        commandLineArgs ??= [];
 
-        var properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-        {
-            ["CheckForSystemRuntimeDependency"] = "true",
-            ["DesignTimeBuild"] = "true",
-            ["BuildingInsideVisualStudio"] = "true"
-        };
+        var properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         MergeKnownEnvironmentProperties(properties, getEnvironmentVariable);
+        MergeNuGetRestoreMsbuildArgsProperties(properties, getEnvironmentVariable);
         MergeCommandLineProperties(properties, commandLineArgs);
 
         return properties;
@@ -53,7 +53,7 @@ internal static class MSBuildWorkspaceLoadSettings
 
     internal static bool IsIgnorableFailure(WorkspaceDiagnostic diagnostic) =>
         diagnostic.Kind == WorkspaceDiagnosticKind.Failure &&
-        _nuGetAuditDiagnosticCodePattern.IsMatch(diagnostic.Message);
+        _nuGetAuditDiagnosticPattern.IsMatch(diagnostic.Message);
 
     private static void MergeKnownEnvironmentProperties(
         IDictionary<string, string> properties,
@@ -67,6 +67,19 @@ internal static class MSBuildWorkspaceLoadSettings
                 properties[propertyName] = value.Trim();
             }
         }
+    }
+
+    private static void MergeNuGetRestoreMsbuildArgsProperties(
+        Dictionary<string, string> properties,
+        Func<string, string?> getEnvironmentVariable)
+    {
+        var restoreMsbuildArgs = getEnvironmentVariable(_nuGetRestoreMsbuildArgsEnvironmentVariableName);
+        if (string.IsNullOrWhiteSpace(restoreMsbuildArgs))
+        {
+            return;
+        }
+
+        MergeCommandLineProperties(properties, SplitCommandLineArguments(restoreMsbuildArgs));
     }
 
     private static void MergeCommandLineProperties(
@@ -107,6 +120,42 @@ internal static class MSBuildWorkspaceLoadSettings
         }
 
         return properties;
+    }
+
+    private static IEnumerable<string> SplitCommandLineArguments(string commandLine)
+    {
+        if (string.IsNullOrWhiteSpace(commandLine))
+        {
+            yield break;
+        }
+
+        var startIndex = 0;
+        var inQuotes = false;
+
+        for (var index = 0; index < commandLine.Length; index++)
+        {
+            var character = commandLine[index];
+            if (character == '"')
+            {
+                inQuotes = !inQuotes;
+                continue;
+            }
+
+            if (!inQuotes && char.IsWhiteSpace(character))
+            {
+                if (index > startIndex)
+                {
+                    yield return commandLine[startIndex..index];
+                }
+
+                startIndex = index + 1;
+            }
+        }
+
+        if (startIndex < commandLine.Length)
+        {
+            yield return commandLine[startIndex..];
+        }
     }
 
     private static bool TryGetPropertySwitchPayload(string argument, out string payload)

--- a/src/RoslynMcp.Core/Workspace/MSBuildWorkspaceLoadSettings.cs
+++ b/src/RoslynMcp.Core/Workspace/MSBuildWorkspaceLoadSettings.cs
@@ -1,0 +1,126 @@
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+
+namespace RoslynMcp.Core.Workspace;
+
+internal static class MSBuildWorkspaceLoadSettings
+{
+    private static readonly string[] _passThroughPropertyNames =
+    [
+        "NuGetAudit",
+        "TreatWarningsAsErrors",
+        "WarningsNotAsErrors"
+    ];
+
+    private static readonly Regex _nuGetAuditDiagnosticCodePattern =
+        new(@"\bNU190[1-4]\b", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex _commandLinePropertySeparatorPattern =
+        new(@"(?<=[^%])[;,](?=[A-Za-z_][A-Za-z0-9_.-]*=)", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly string[] _propertySwitchPrefixes =
+    [
+        "-property:",
+        "-p:",
+        "/property:",
+        "/p:"
+    ];
+
+    internal static Dictionary<string, string> BuildGlobalProperties(
+        Func<string, string?>? getEnvironmentVariable = null,
+        IEnumerable<string>? commandLineArgs = null)
+    {
+        getEnvironmentVariable ??= Environment.GetEnvironmentVariable;
+        commandLineArgs ??= Environment.GetCommandLineArgs().Skip(1);
+
+        var properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["CheckForSystemRuntimeDependency"] = "true",
+            ["DesignTimeBuild"] = "true",
+            ["BuildingInsideVisualStudio"] = "true"
+        };
+
+        MergeKnownEnvironmentProperties(properties, getEnvironmentVariable);
+        MergeCommandLineProperties(properties, commandLineArgs);
+
+        return properties;
+    }
+
+    internal static IReadOnlyList<WorkspaceDiagnostic> GetFatalDiagnostics(IEnumerable<WorkspaceDiagnostic> diagnostics) =>
+        diagnostics
+            .Where(diagnostic => diagnostic.Kind == WorkspaceDiagnosticKind.Failure && !IsIgnorableFailure(diagnostic))
+            .ToList();
+
+    internal static bool IsIgnorableFailure(WorkspaceDiagnostic diagnostic) =>
+        diagnostic.Kind == WorkspaceDiagnosticKind.Failure &&
+        _nuGetAuditDiagnosticCodePattern.IsMatch(diagnostic.Message);
+
+    private static void MergeKnownEnvironmentProperties(
+        IDictionary<string, string> properties,
+        Func<string, string?> getEnvironmentVariable)
+    {
+        foreach (var propertyName in _passThroughPropertyNames)
+        {
+            var value = getEnvironmentVariable(propertyName);
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                properties[propertyName] = value.Trim();
+            }
+        }
+    }
+
+    private static void MergeCommandLineProperties(
+        Dictionary<string, string> properties,
+        IEnumerable<string> commandLineArgs)
+    {
+        foreach (var argument in commandLineArgs)
+        {
+            if (!TryGetPropertySwitchPayload(argument, out var payload))
+            {
+                continue;
+            }
+
+            foreach (var (name, value) in ParseCommandLineProperties(payload))
+            {
+                properties[name] = value;
+            }
+        }
+    }
+
+    private static Dictionary<string, string> ParseCommandLineProperties(string payload)
+    {
+        var properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var entry in _commandLinePropertySeparatorPattern.Split(payload))
+        {
+            var equalsIndex = entry.IndexOf('=');
+            if (equalsIndex <= 0 || equalsIndex == entry.Length - 1)
+            {
+                continue;
+            }
+
+            var name = entry[..equalsIndex].Trim();
+            var value = entry[(equalsIndex + 1)..].Trim();
+            if (name.Length > 0)
+            {
+                properties[name] = value;
+            }
+        }
+
+        return properties;
+    }
+
+    private static bool TryGetPropertySwitchPayload(string argument, out string payload)
+    {
+        foreach (var prefix in _propertySwitchPrefixes)
+        {
+            if (argument.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                payload = argument[prefix.Length..];
+                return payload.Length > 0;
+            }
+        }
+
+        payload = string.Empty;
+        return false;
+    }
+}

--- a/src/RoslynMcp.Core/Workspace/MSBuildWorkspaceLoadSettings.cs
+++ b/src/RoslynMcp.Core/Workspace/MSBuildWorkspaceLoadSettings.cs
@@ -7,11 +7,21 @@ internal static class MSBuildWorkspaceLoadSettings
 {
     private const string _nuGetRestoreMsbuildArgsEnvironmentVariableName = "NUGET_RESTORE_MSBUILD_ARGS";
 
+    private static readonly KeyValuePair<string, string>[] _defaultGlobalProperties =
+    [
+        new("DesignTimeBuild", "true"),
+        new("CheckForSystemRuntimeDependency", "true"),
+        new("BuildingInsideVisualStudio", "true")
+    ];
+
     private static readonly string[] _passThroughPropertyNames =
     [
         "NuGetAudit",
         "TreatWarningsAsErrors",
-        "WarningsNotAsErrors"
+        "WarningsNotAsErrors",
+        "DesignTimeBuild",
+        "CheckForSystemRuntimeDependency",
+        "BuildingInsideVisualStudio"
     ];
 
     private static readonly Regex _nuGetAuditDiagnosticPattern =
@@ -37,7 +47,12 @@ internal static class MSBuildWorkspaceLoadSettings
         getEnvironmentVariable ??= Environment.GetEnvironmentVariable;
         commandLineArgs ??= [];
 
-        var properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var properties = new Dictionary<string, string>(_defaultGlobalProperties.Length, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var (name, value) in _defaultGlobalProperties)
+        {
+            properties[name] = value;
+        }
 
         MergeKnownEnvironmentProperties(properties, getEnvironmentVariable);
         MergeNuGetRestoreMsbuildArgsProperties(properties, getEnvironmentVariable);

--- a/src/RoslynMcp.Core/Workspace/MSBuildWorkspaceProvider.cs
+++ b/src/RoslynMcp.Core/Workspace/MSBuildWorkspaceProvider.cs
@@ -90,10 +90,7 @@ public sealed class MSBuildWorkspaceProvider : IWorkspaceProvider
         LogCallback?.Invoke($"Creating workspace for: {projectOrSolutionPath}");
 
         var properties = GetGlobalProperties();
-        LogCallback?.Invoke(
-            properties.Count == 0
-                ? "MSBuild global properties: none"
-                : $"MSBuild global properties: {string.Join(", ", properties.Select(kvp => $"{kvp.Key}={kvp.Value}"))}");
+        LogCallback?.Invoke(DescribeGlobalProperties(properties));
         var workspace = MSBuildWorkspace.Create(properties);
 
         // Collect workspace diagnostics but don't fail on warnings
@@ -168,6 +165,11 @@ public sealed class MSBuildWorkspaceProvider : IWorkspaceProvider
     internal Dictionary<string, string> GetGlobalProperties(
         Func<string, string?>? getEnvironmentVariable = null) =>
         MSBuildWorkspaceLoadSettings.BuildGlobalProperties(getEnvironmentVariable, _commandLineArgs);
+
+    internal static string DescribeGlobalProperties(IReadOnlyDictionary<string, string> properties) =>
+        properties.Count == 0
+            ? "MSBuild global properties: none"
+            : $"MSBuild global properties: {string.Join(", ", properties.Keys.OrderBy(name => name, StringComparer.OrdinalIgnoreCase))}";
 
     /// <inheritdoc />
     public EnvironmentDiagnostics CheckEnvironment()

--- a/src/RoslynMcp.Core/Workspace/MSBuildWorkspaceProvider.cs
+++ b/src/RoslynMcp.Core/Workspace/MSBuildWorkspaceProvider.cs
@@ -81,13 +81,7 @@ public sealed class MSBuildWorkspaceProvider : IWorkspaceProvider
 
         LogCallback?.Invoke($"Creating workspace for: {projectOrSolutionPath}");
 
-        var properties = new Dictionary<string, string>
-        {
-            ["CheckForSystemRuntimeDependency"] = "true",
-            ["DesignTimeBuild"] = "true",
-            ["BuildingInsideVisualStudio"] = "true"
-        };
-
+        var properties = MSBuildWorkspaceLoadSettings.BuildGlobalProperties();
         var workspace = MSBuildWorkspace.Create(properties);
 
         // Collect workspace diagnostics but don't fail on warnings
@@ -95,7 +89,11 @@ public sealed class MSBuildWorkspaceProvider : IWorkspaceProvider
         var diagnostics = new ConcurrentBag<WorkspaceDiagnostic>();
         workspace.RegisterWorkspaceFailedHandler(args =>
         {
-            if (args.Diagnostic.Kind == WorkspaceDiagnosticKind.Failure)
+            if (MSBuildWorkspaceLoadSettings.IsIgnorableFailure(args.Diagnostic))
+            {
+                LogCallback?.Invoke($"Ignoring NuGet audit workspace failure: {args.Diagnostic.Message}");
+            }
+            else if (args.Diagnostic.Kind == WorkspaceDiagnosticKind.Failure)
             {
                 LogErrorCallback?.Invoke($"Workspace failure: {args.Diagnostic.Message}", null);
             }
@@ -143,7 +141,7 @@ public sealed class MSBuildWorkspaceProvider : IWorkspaceProvider
         }
 
         // Check for critical errors
-        var errors = diagnostics.Where(d => d.Kind == WorkspaceDiagnosticKind.Failure).ToList();
+        var errors = MSBuildWorkspaceLoadSettings.GetFatalDiagnostics(diagnostics);
         if (errors.Count > 0)
         {
             workspace.Dispose();

--- a/src/RoslynMcp.Core/Workspace/MSBuildWorkspaceProvider.cs
+++ b/src/RoslynMcp.Core/Workspace/MSBuildWorkspaceProvider.cs
@@ -35,18 +35,26 @@ public sealed class MSBuildWorkspaceProvider : IWorkspaceProvider
     public static readonly TimeSpan DefaultWorkspaceLoadTimeout = TimeSpan.FromMinutes(5);
 
     private readonly IFileWriter _fileWriter;
+    private readonly string[] _commandLineArgs;
     private readonly TimeSpan _workspaceLoadTimeout;
 
     /// <summary>
     /// Creates a new workspace provider.
     /// </summary>
+    /// <param name="commandLineArgs">
+    /// Optional process arguments used to forward standard MSBuild property switches to workspace loading.
+    /// </param>
     /// <param name="fileWriter">Optional file writer for atomic operations.</param>
     /// <param name="workspaceLoadTimeout">
     /// Optional timeout for workspace loading operations.
     /// Defaults to <see cref="DefaultWorkspaceLoadTimeout"/> (5 minutes).
     /// </param>
-    public MSBuildWorkspaceProvider(IFileWriter? fileWriter = null, TimeSpan? workspaceLoadTimeout = null)
+    public MSBuildWorkspaceProvider(
+        IEnumerable<string>? commandLineArgs = null,
+        IFileWriter? fileWriter = null,
+        TimeSpan? workspaceLoadTimeout = null)
     {
+        _commandLineArgs = commandLineArgs?.ToArray() ?? [];
         _fileWriter = fileWriter ?? new AtomicFileWriter();
         _workspaceLoadTimeout = workspaceLoadTimeout ?? DefaultWorkspaceLoadTimeout;
     }
@@ -81,7 +89,11 @@ public sealed class MSBuildWorkspaceProvider : IWorkspaceProvider
 
         LogCallback?.Invoke($"Creating workspace for: {projectOrSolutionPath}");
 
-        var properties = MSBuildWorkspaceLoadSettings.BuildGlobalProperties();
+        var properties = GetGlobalProperties();
+        LogCallback?.Invoke(
+            properties.Count == 0
+                ? "MSBuild global properties: none"
+                : $"MSBuild global properties: {string.Join(", ", properties.Select(kvp => $"{kvp.Key}={kvp.Value}"))}");
         var workspace = MSBuildWorkspace.Create(properties);
 
         // Collect workspace diagnostics but don't fail on warnings
@@ -152,6 +164,10 @@ public sealed class MSBuildWorkspaceProvider : IWorkspaceProvider
 
         return new WorkspaceContext(workspace, solution, normalizedPath, _fileWriter);
     }
+
+    internal Dictionary<string, string> GetGlobalProperties(
+        Func<string, string?>? getEnvironmentVariable = null) =>
+        MSBuildWorkspaceLoadSettings.BuildGlobalProperties(getEnvironmentVariable, _commandLineArgs);
 
     /// <inheritdoc />
     public EnvironmentDiagnostics CheckEnvironment()

--- a/src/RoslynMcp.Server/Program.cs
+++ b/src/RoslynMcp.Server/Program.cs
@@ -23,7 +23,7 @@ Console.CancelKeyPress += (_, e) =>
 
 // Create workspace provider
 FileLogger.Log("Creating MSBuildWorkspaceProvider...");
-var workspaceProvider = new MSBuildWorkspaceProvider();
+var workspaceProvider = new MSBuildWorkspaceProvider(args);
 FileLogger.Log("MSBuildWorkspaceProvider created successfully.");
 
 // Create and run server

--- a/tests/RoslynMcp.Core.Tests/Workspace/MSBuildWorkspaceLoadSettingsTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Workspace/MSBuildWorkspaceLoadSettingsTests.cs
@@ -1,0 +1,87 @@
+using Microsoft.CodeAnalysis;
+using RoslynMcp.Core.Workspace;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Workspace;
+
+public class MSBuildWorkspaceLoadSettingsTests
+{
+    [Fact]
+    public void BuildGlobalProperties_MergesKnownAndConfiguredEnvironmentProperties()
+    {
+        var environment = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["NuGetAudit"] = "false",
+            ["TreatWarningsAsErrors"] = "false",
+            ["WarningsNotAsErrors"] = "CS1591"
+        };
+
+        var properties = MSBuildWorkspaceLoadSettings.BuildGlobalProperties(
+            name => environment.TryGetValue(name, out var value) ? value : null,
+            []);
+
+        Assert.Equal("true", properties["CheckForSystemRuntimeDependency"]);
+        Assert.Equal("true", properties["DesignTimeBuild"]);
+        Assert.Equal("true", properties["BuildingInsideVisualStudio"]);
+        Assert.Equal("false", properties["NuGetAudit"]);
+        Assert.Equal("false", properties["TreatWarningsAsErrors"]);
+        Assert.Equal("CS1591", properties["WarningsNotAsErrors"]);
+    }
+
+    [Fact]
+    public void GetFatalDiagnostics_IgnoresAuditOnlyFailures()
+    {
+        var diagnostics = new[]
+        {
+            new WorkspaceDiagnostic(WorkspaceDiagnosticKind.Failure, "error NU1903: package has a known vulnerability")
+        };
+
+        var fatalDiagnostics = MSBuildWorkspaceLoadSettings.GetFatalDiagnostics(diagnostics);
+
+        Assert.Empty(fatalDiagnostics);
+    }
+
+    [Fact]
+    public void GetFatalDiagnostics_KeepsRealFailures()
+    {
+        var diagnostics = new[]
+        {
+            new WorkspaceDiagnostic(WorkspaceDiagnosticKind.Failure, "error NU1902: package has a known vulnerability"),
+            new WorkspaceDiagnostic(WorkspaceDiagnosticKind.Failure, "The SDK 'Microsoft.NET.Sdk' specified could not be found.")
+        };
+
+        var fatalDiagnostics = MSBuildWorkspaceLoadSettings.GetFatalDiagnostics(diagnostics);
+
+        var fatalDiagnostic = Assert.Single(fatalDiagnostics);
+        Assert.Contains("Microsoft.NET.Sdk", fatalDiagnostic.Message);
+    }
+
+    [Fact]
+    public void BuildGlobalProperties_UsesStandardCommandLineProperties()
+    {
+        var properties = MSBuildWorkspaceLoadSettings.BuildGlobalProperties(
+            _ => null,
+            ["-p:NuGetAudit=false", "/property:WarningsNotAsErrors=NU1901;NU1902;NU1903;NU1904", "-p:TreatWarningsAsErrors=false"]);
+
+        Assert.Equal("false", properties["NuGetAudit"]);
+        Assert.Equal("false", properties["TreatWarningsAsErrors"]);
+        Assert.Equal("NU1901;NU1902;NU1903;NU1904", properties["WarningsNotAsErrors"]);
+    }
+
+    [Fact]
+    public void BuildGlobalProperties_CommandLinePropertiesOverrideEnvironmentProperties()
+    {
+        var environment = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["NuGetAudit"] = "true",
+            ["WarningsNotAsErrors"] = "CS1591"
+        };
+
+        var properties = MSBuildWorkspaceLoadSettings.BuildGlobalProperties(
+            name => environment.TryGetValue(name, out var value) ? value : null,
+            ["-p:NuGetAudit=false;WarningsNotAsErrors=NU1901;NU1902;NU1903;NU1904"]);
+
+        Assert.Equal("false", properties["NuGetAudit"]);
+        Assert.Equal("NU1901;NU1902;NU1903;NU1904", properties["WarningsNotAsErrors"]);
+    }
+}

--- a/tests/RoslynMcp.Core.Tests/Workspace/MSBuildWorkspaceLoadSettingsTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Workspace/MSBuildWorkspaceLoadSettingsTests.cs
@@ -20,19 +20,25 @@ public class MSBuildWorkspaceLoadSettingsTests
             name => environment.TryGetValue(name, out var value) ? value : null,
             []);
 
+        Assert.Equal("true", properties["DesignTimeBuild"]);
+        Assert.Equal("true", properties["CheckForSystemRuntimeDependency"]);
+        Assert.Equal("true", properties["BuildingInsideVisualStudio"]);
         Assert.Equal("false", properties["NuGetAudit"]);
         Assert.Equal("false", properties["TreatWarningsAsErrors"]);
         Assert.Equal("CS1591", properties["WarningsNotAsErrors"]);
     }
 
     [Fact]
-    public void BuildGlobalProperties_WithoutInputs_ReturnsEmpty()
+    public void BuildGlobalProperties_WithoutInputs_ReturnsBuiltInDefaults()
     {
         var properties = MSBuildWorkspaceLoadSettings.BuildGlobalProperties(
             _ => null,
             []);
 
-        Assert.Empty(properties);
+        Assert.Equal("true", properties["DesignTimeBuild"]);
+        Assert.Equal("true", properties["CheckForSystemRuntimeDependency"]);
+        Assert.Equal("true", properties["BuildingInsideVisualStudio"]);
+        Assert.Equal(3, properties.Count);
     }
 
     [Fact]
@@ -85,6 +91,9 @@ public class MSBuildWorkspaceLoadSettingsTests
             _ => null,
             ["-p:NuGetAudit=false", "/property:WarningsNotAsErrors=NU1901;NU1902;NU1903;NU1904", "-p:TreatWarningsAsErrors=false"]);
 
+        Assert.Equal("true", properties["DesignTimeBuild"]);
+        Assert.Equal("true", properties["CheckForSystemRuntimeDependency"]);
+        Assert.Equal("true", properties["BuildingInsideVisualStudio"]);
         Assert.Equal("false", properties["NuGetAudit"]);
         Assert.Equal("false", properties["TreatWarningsAsErrors"]);
         Assert.Equal("NU1901;NU1902;NU1903;NU1904", properties["WarningsNotAsErrors"]);
@@ -103,9 +112,31 @@ public class MSBuildWorkspaceLoadSettingsTests
             name => environment.TryGetValue(name, out var value) ? value : null,
             []);
 
+        Assert.Equal("true", properties["DesignTimeBuild"]);
+        Assert.Equal("true", properties["CheckForSystemRuntimeDependency"]);
+        Assert.Equal("true", properties["BuildingInsideVisualStudio"]);
         Assert.Equal("false", properties["NuGetAudit"]);
         Assert.Equal("false", properties["TreatWarningsAsErrors"]);
         Assert.Equal("NU1901;NU1902;NU1903;NU1904", properties["WarningsNotAsErrors"]);
+    }
+
+    [Fact]
+    public void BuildGlobalProperties_EnvironmentPropertiesOverrideBuiltInDefaults()
+    {
+        var environment = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["DesignTimeBuild"] = "false",
+            ["CheckForSystemRuntimeDependency"] = "false",
+            ["BuildingInsideVisualStudio"] = "false"
+        };
+
+        var properties = MSBuildWorkspaceLoadSettings.BuildGlobalProperties(
+            name => environment.TryGetValue(name, out var value) ? value : null,
+            []);
+
+        Assert.Equal("false", properties["DesignTimeBuild"]);
+        Assert.Equal("false", properties["CheckForSystemRuntimeDependency"]);
+        Assert.Equal("false", properties["BuildingInsideVisualStudio"]);
     }
 
     [Fact]
@@ -114,14 +145,16 @@ public class MSBuildWorkspaceLoadSettingsTests
         var environment = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
         {
             ["NuGetAudit"] = "true",
-            ["WarningsNotAsErrors"] = "CS1591"
+            ["WarningsNotAsErrors"] = "CS1591",
+            ["DesignTimeBuild"] = "false"
         };
 
         var properties = MSBuildWorkspaceLoadSettings.BuildGlobalProperties(
             name => environment.TryGetValue(name, out var value) ? value : null,
-            ["-p:NuGetAudit=false;WarningsNotAsErrors=NU1901;NU1902;NU1903;NU1904"]);
+            ["-p:NuGetAudit=false;WarningsNotAsErrors=NU1901;NU1902;NU1903;NU1904;DesignTimeBuild=true"]);
 
         Assert.Equal("false", properties["NuGetAudit"]);
         Assert.Equal("NU1901;NU1902;NU1903;NU1904", properties["WarningsNotAsErrors"]);
+        Assert.Equal("true", properties["DesignTimeBuild"]);
     }
 }

--- a/tests/RoslynMcp.Core.Tests/Workspace/MSBuildWorkspaceLoadSettingsTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Workspace/MSBuildWorkspaceLoadSettingsTests.cs
@@ -20,12 +20,19 @@ public class MSBuildWorkspaceLoadSettingsTests
             name => environment.TryGetValue(name, out var value) ? value : null,
             []);
 
-        Assert.Equal("true", properties["CheckForSystemRuntimeDependency"]);
-        Assert.Equal("true", properties["DesignTimeBuild"]);
-        Assert.Equal("true", properties["BuildingInsideVisualStudio"]);
         Assert.Equal("false", properties["NuGetAudit"]);
         Assert.Equal("false", properties["TreatWarningsAsErrors"]);
         Assert.Equal("CS1591", properties["WarningsNotAsErrors"]);
+    }
+
+    [Fact]
+    public void BuildGlobalProperties_WithoutInputs_ReturnsEmpty()
+    {
+        var properties = MSBuildWorkspaceLoadSettings.BuildGlobalProperties(
+            _ => null,
+            []);
+
+        Assert.Empty(properties);
     }
 
     [Fact]
@@ -34,6 +41,21 @@ public class MSBuildWorkspaceLoadSettingsTests
         var diagnostics = new[]
         {
             new WorkspaceDiagnostic(WorkspaceDiagnosticKind.Failure, "error NU1903: package has a known vulnerability")
+        };
+
+        var fatalDiagnostics = MSBuildWorkspaceLoadSettings.GetFatalDiagnostics(diagnostics);
+
+        Assert.Empty(fatalDiagnostics);
+    }
+
+    [Fact]
+    public void GetFatalDiagnostics_IgnoresAuditFailuresWithoutDiagnosticCode()
+    {
+        var diagnostics = new[]
+        {
+            new WorkspaceDiagnostic(
+                WorkspaceDiagnosticKind.Failure,
+                "Msbuild failed when processing the file 'Example.csproj' with message: Package 'AutoMapper' 14.0.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-rvv3-g6hj-g44x")
         };
 
         var fatalDiagnostics = MSBuildWorkspaceLoadSettings.GetFatalDiagnostics(diagnostics);
@@ -62,6 +84,24 @@ public class MSBuildWorkspaceLoadSettingsTests
         var properties = MSBuildWorkspaceLoadSettings.BuildGlobalProperties(
             _ => null,
             ["-p:NuGetAudit=false", "/property:WarningsNotAsErrors=NU1901;NU1902;NU1903;NU1904", "-p:TreatWarningsAsErrors=false"]);
+
+        Assert.Equal("false", properties["NuGetAudit"]);
+        Assert.Equal("false", properties["TreatWarningsAsErrors"]);
+        Assert.Equal("NU1901;NU1902;NU1903;NU1904", properties["WarningsNotAsErrors"]);
+    }
+
+    [Fact]
+    public void BuildGlobalProperties_UsesNuGetRestoreMsbuildArgsEnvironmentProperties()
+    {
+        var environment = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["NUGET_RESTORE_MSBUILD_ARGS"] =
+                "/p:NuGetAudit=false /p:WarningsNotAsErrors=NU1901;NU1902;NU1903;NU1904 /p:TreatWarningsAsErrors=false"
+        };
+
+        var properties = MSBuildWorkspaceLoadSettings.BuildGlobalProperties(
+            name => environment.TryGetValue(name, out var value) ? value : null,
+            []);
 
         Assert.Equal("false", properties["NuGetAudit"]);
         Assert.Equal("false", properties["TreatWarningsAsErrors"]);

--- a/tests/RoslynMcp.Core.Tests/Workspace/MSBuildWorkspaceProviderTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Workspace/MSBuildWorkspaceProviderTests.cs
@@ -1,0 +1,19 @@
+using RoslynMcp.Core.Workspace;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Workspace;
+
+public class MSBuildWorkspaceProviderTests
+{
+    [Fact]
+    public void GetGlobalProperties_UsesProviderCommandLineArgs()
+    {
+        var provider = new MSBuildWorkspaceProvider(
+            commandLineArgs: ["-p:NuGetAudit=false", "-p:TreatWarningsAsErrors=false"]);
+
+        var properties = provider.GetGlobalProperties(_ => null);
+
+        Assert.Equal("false", properties["NuGetAudit"]);
+        Assert.Equal("false", properties["TreatWarningsAsErrors"]);
+    }
+}

--- a/tests/RoslynMcp.Core.Tests/Workspace/MSBuildWorkspaceProviderTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Workspace/MSBuildWorkspaceProviderTests.cs
@@ -13,7 +13,26 @@ public class MSBuildWorkspaceProviderTests
 
         var properties = provider.GetGlobalProperties(_ => null);
 
+        Assert.Equal("true", properties["DesignTimeBuild"]);
+        Assert.Equal("true", properties["CheckForSystemRuntimeDependency"]);
+        Assert.Equal("true", properties["BuildingInsideVisualStudio"]);
         Assert.Equal("false", properties["NuGetAudit"]);
         Assert.Equal("false", properties["TreatWarningsAsErrors"]);
+    }
+
+    [Fact]
+    public void DescribeGlobalProperties_LogsNamesWithoutValues()
+    {
+        var description = MSBuildWorkspaceProvider.DescribeGlobalProperties(
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["NuGetAudit"] = "false",
+                ["SecretToken"] = "super-secret-value"
+            });
+
+        Assert.Contains("NuGetAudit", description);
+        Assert.Contains("SecretToken", description);
+        Assert.DoesNotContain("false", description);
+        Assert.DoesNotContain("super-secret-value", description);
     }
 }


### PR DESCRIPTION
## Summary
- forward standard MSBuild `/p:` switches from process arguments into `MSBuildWorkspace.Create(...)`
- merge forwarded properties with the existing workspace defaults so Roslyn loads keep their established evaluation context
- add targeted coverage for property construction and NuGet audit diagnostic handling during workspace load

## Why
Workspace loading was not respecting the same standard MSBuild properties that `dotnet build` and `dotnet restore` already honor, which made launcher-level configuration insufficient for Roslyn workspace loads.

## Test Plan
- [x] `dotnet build D:\RoslynMcpServer\RoslynMcp.sln -c Release`
- [x] `dotnet test D:\RoslynMcpServer\RoslynMcp.sln`