### PR TITLE
feat(core): add skip support for unrecognized projects

### DIFF
--- a/src/RoslynMcp.Cli/CliArgs.cs
+++ b/src/RoslynMcp.Cli/CliArgs.cs
@@ -1,3 +1,5 @@
+using RoslynMcp.Core.Workspace;
+
 namespace RoslynMcp.Cli;
 
 /// <summary>
@@ -25,6 +27,9 @@ public sealed class ParsedArgs
 
     /// <summary>Whether verbose output is enabled.</summary>
     public bool Verbose { get; init; }
+
+    /// <summary>Workspace loading options derived from global switches.</summary>
+    public WorkspaceLoadOptions WorkspaceLoadOptions { get; init; } = WorkspaceLoadOptions.Default;
 }
 
 /// <summary>
@@ -61,7 +66,7 @@ public static class CliArgs
         {
             var solutionPath = args[0];
             var toolName = args[1];
-            var (options, format, verbose) = ParseOptions(args, startIndex: 2);
+            var (options, format, verbose, workspaceLoadOptions) = ParseOptions(args, startIndex: 2);
 
             // Check for --help among the options
             if (options.ContainsKey("help"))
@@ -76,7 +81,8 @@ public static class CliArgs
                 ToolName = toolName,
                 Options = options,
                 Format = format,
-                Verbose = verbose
+                Verbose = verbose,
+                WorkspaceLoadOptions = workspaceLoadOptions
             };
         }
 
@@ -84,12 +90,13 @@ public static class CliArgs
         return new ParsedArgs { ShowHelp = true };
     }
 
-    private static (Dictionary<string, string> options, string format, bool verbose) ParseOptions(
+    private static (Dictionary<string, string> options, string format, bool verbose, WorkspaceLoadOptions workspaceLoadOptions) ParseOptions(
         string[] args, int startIndex)
     {
         var options = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         var format = "json";
         var verbose = false;
+        var skipUnrecognizedProjects = false;
 
         for (int i = startIndex; i < args.Length; i++)
         {
@@ -118,6 +125,12 @@ public static class CliArgs
                 continue;
             }
 
+            if (key.Equals("skip-unrecognized-projects", StringComparison.OrdinalIgnoreCase))
+            {
+                skipUnrecognizedProjects = true;
+                continue;
+            }
+
             // Tool-specific options
             if (i + 1 < args.Length && !args[i + 1].StartsWith("--"))
             {
@@ -131,7 +144,10 @@ public static class CliArgs
             }
         }
 
-        return (options, format, verbose);
+        return (options, format, verbose, new WorkspaceLoadOptions
+        {
+            SkipUnrecognizedProjects = skipUnrecognizedProjects
+        });
     }
 
     private static bool IsHelpFlag(string arg) =>

--- a/src/RoslynMcp.Cli/HelpGenerator.cs
+++ b/src/RoslynMcp.Cli/HelpGenerator.cs
@@ -19,12 +19,13 @@ public static class HelpGenerator
         sb.AppendLine("roslyn-cli — Standalone CLI for Roslyn-powered C# tools");
         sb.AppendLine();
         sb.AppendLine("USAGE:");
-        sb.AppendLine("  roslyn-cli <solution-path> <tool-name> [--option value ...]");
+        sb.AppendLine("  roslyn-cli <solution-path> <tool-name> [--skip-unrecognized-projects] [--option value ...]");
         sb.AppendLine("  roslyn-cli <tool-name> --help");
         sb.AppendLine("  roslyn-cli --help");
         sb.AppendLine();
         sb.AppendLine("GLOBAL OPTIONS:");
         sb.AppendLine("  --format <json|text>  Output format (default: json)");
+        sb.AppendLine("  --skip-unrecognized-projects  Skip Roslyn unrecognized project load failures");
         sb.AppendLine("  --verbose             Show detailed output");
         sb.AppendLine("  --help, -h            Show this help");
         sb.AppendLine();
@@ -45,7 +46,7 @@ public static class HelpGenerator
         sb.AppendLine("EXAMPLES:");
         sb.AppendLine("  roslyn-cli MySolution.sln rename-symbol --source-file Foo.cs --symbol-name Bar --new-name Baz");
         sb.AppendLine("  roslyn-cli MySolution.sln get-diagnostics --severity-filter Error --format text");
-        sb.AppendLine("  roslyn-cli MySolution.sln diagnose");
+        sb.AppendLine("  roslyn-cli MySolution.sln diagnose --skip-unrecognized-projects");
 
         return sb.ToString();
     }
@@ -60,9 +61,9 @@ public static class HelpGenerator
         sb.AppendLine();
         sb.AppendLine("USAGE:");
         if (tool.RequiresWorkspace)
-            sb.AppendLine($"  roslyn-cli <solution-path> {tool.Name} [--option value ...]");
+            sb.AppendLine($"  roslyn-cli <solution-path> {tool.Name} [--skip-unrecognized-projects] [--option value ...]");
         else
-            sb.AppendLine($"  roslyn-cli <solution-path> {tool.Name} [--option value ...]  (solution is optional)");
+            sb.AppendLine($"  roslyn-cli <solution-path> {tool.Name} [--skip-unrecognized-projects] [--option value ...]  (solution is optional)");
         sb.AppendLine();
 
         var props = tool.ParamsType.GetProperties(BindingFlags.Public | BindingFlags.Instance);

--- a/src/RoslynMcp.Cli/Program.cs
+++ b/src/RoslynMcp.Cli/Program.cs
@@ -75,7 +75,7 @@ Console.CancelKeyPress += (_, e) =>
 
 try
 {
-    var workspaceProvider = new MSBuildWorkspaceProvider();
+    var workspaceProvider = new MSBuildWorkspaceProvider(workspaceLoadOptions: parsed.WorkspaceLoadOptions);
 
     // Special handling for diagnose (needs IWorkspaceProvider, not WorkspaceContext)
     if (parsed.ToolName.Equals("diagnose", StringComparison.OrdinalIgnoreCase))
@@ -162,6 +162,7 @@ async Task<DiagnoseResult> ExecuteDiagnoseAsync(
 {
     var envDiag = provider.CheckEnvironment();
     var errors = new List<RefactoringError>();
+    List<string> contextWarnings = [];
 
     if (!envDiag.MsBuildFound)
     {
@@ -187,6 +188,7 @@ async Task<DiagnoseResult> ExecuteDiagnoseAsync(
                 ProjectCount = context.Solution.Projects.Count(),
                 DocumentCount = context.Solution.Projects.Sum(p => p.Documents.Count())
             };
+            contextWarnings.AddRange(context.LoadWarnings);
         }
         catch (Exception ex)
         {
@@ -225,6 +227,8 @@ async Task<DiagnoseResult> ExecuteDiagnoseAsync(
             ? ["move_type_to_file", "move_type_to_namespace", "diagnose"]
             : ["diagnose"],
         Errors = errors,
-        Warnings = []
+        Warnings = !string.IsNullOrEmpty(args.SolutionPath)
+            ? contextWarnings
+            : []
     };
 }

--- a/src/RoslynMcp.Core/Properties/AssemblyInfo.cs
+++ b/src/RoslynMcp.Core/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("RoslynMcp.Core.Tests")]
+[assembly: InternalsVisibleTo("RoslynMcp.Server.Tests")]

--- a/src/RoslynMcp.Core/Workspace/MSBuildWorkspaceProvider.cs
+++ b/src/RoslynMcp.Core/Workspace/MSBuildWorkspaceProvider.cs
@@ -35,6 +35,7 @@ public sealed class MSBuildWorkspaceProvider : IWorkspaceProvider
     public static readonly TimeSpan DefaultWorkspaceLoadTimeout = TimeSpan.FromMinutes(5);
 
     private readonly IFileWriter _fileWriter;
+    private readonly WorkspaceLoadOptions _workspaceLoadOptions;
     private readonly TimeSpan _workspaceLoadTimeout;
 
     /// <summary>
@@ -45,10 +46,15 @@ public sealed class MSBuildWorkspaceProvider : IWorkspaceProvider
     /// Optional timeout for workspace loading operations.
     /// Defaults to <see cref="DefaultWorkspaceLoadTimeout"/> (5 minutes).
     /// </param>
-    public MSBuildWorkspaceProvider(IFileWriter? fileWriter = null, TimeSpan? workspaceLoadTimeout = null)
+    /// <param name="workspaceLoadOptions">Optional workspace load behavior settings.</param>
+    public MSBuildWorkspaceProvider(
+        IFileWriter? fileWriter = null,
+        TimeSpan? workspaceLoadTimeout = null,
+        WorkspaceLoadOptions? workspaceLoadOptions = null)
     {
         _fileWriter = fileWriter ?? new AtomicFileWriter();
         _workspaceLoadTimeout = workspaceLoadTimeout ?? DefaultWorkspaceLoadTimeout;
+        _workspaceLoadOptions = workspaceLoadOptions ?? WorkspaceLoadOptions.Default;
     }
 
     /// <inheritdoc />
@@ -89,20 +95,12 @@ public sealed class MSBuildWorkspaceProvider : IWorkspaceProvider
         };
 
         var workspace = MSBuildWorkspace.Create(properties);
+        workspace.SkipUnrecognizedProjects = _workspaceLoadOptions.SkipUnrecognizedProjects;
 
-        // Collect workspace diagnostics but don't fail on warnings
-        // Using ConcurrentBag for thread-safe collection as events may fire from multiple threads
+        // Collect diagnostics and evaluate them after load so skip policy can be applied consistently.
         var diagnostics = new ConcurrentBag<WorkspaceDiagnostic>();
         workspace.RegisterWorkspaceFailedHandler(args =>
         {
-            if (args.Diagnostic.Kind == WorkspaceDiagnosticKind.Failure)
-            {
-                LogErrorCallback?.Invoke($"Workspace failure: {args.Diagnostic.Message}", null);
-            }
-            else
-            {
-                LogCallback?.Invoke($"Workspace warning: {args.Diagnostic.Message}");
-            }
             diagnostics.Add(args.Diagnostic);
         });
 
@@ -141,18 +139,39 @@ public sealed class MSBuildWorkspaceProvider : IWorkspaceProvider
                 ErrorCodes.SolutionLoadFailed,
                 errorMsg);
         }
-
-        // Check for critical errors
-        var errors = diagnostics.Where(d => d.Kind == WorkspaceDiagnosticKind.Failure).ToList();
-        if (errors.Count > 0)
+        catch (Exception ex)
         {
             workspace.Dispose();
             throw new RefactoringException(
                 ErrorCodes.SolutionLoadFailed,
-                $"Failed to load solution: {string.Join("; ", errors.Select(e => e.Message))}");
+                $"Failed to load solution: {ex.Message}",
+                ex);
         }
 
-        return new WorkspaceContext(workspace, solution, normalizedPath, _fileWriter);
+        var evaluation = WorkspaceLoadFailureEvaluator.Evaluate(
+            diagnostics,
+            _workspaceLoadOptions,
+            solution.ProjectIds.Count);
+
+        foreach (var warning in evaluation.Warnings)
+        {
+            LogCallback?.Invoke($"Workspace warning: {warning}");
+        }
+
+        foreach (var error in evaluation.Errors)
+        {
+            LogErrorCallback?.Invoke($"Workspace failure: {error}", null);
+        }
+
+        if (evaluation.HasErrors)
+        {
+            workspace.Dispose();
+            throw new RefactoringException(
+                ErrorCodes.SolutionLoadFailed,
+                $"Failed to load solution: {string.Join("; ", evaluation.Errors)}");
+        }
+
+        return new WorkspaceContext(workspace, solution, normalizedPath, _fileWriter, evaluation.Warnings);
     }
 
     /// <inheritdoc />
@@ -164,6 +183,18 @@ public sealed class MSBuildWorkspaceProvider : IWorkspaceProvider
 
             if (instances.Length == 0)
             {
+                var sdkPath = FindDotNetSdk();
+                if (sdkPath != null)
+                {
+                    return new EnvironmentDiagnostics
+                    {
+                        MsBuildFound = true,
+                        MsBuildPath = sdkPath,
+                        DotnetSdkVersion = Environment.Version.ToString(),
+                        SearchPaths = [sdkPath]
+                    };
+                }
+
                 return new EnvironmentDiagnostics
                 {
                     MsBuildFound = false,

--- a/src/RoslynMcp.Core/Workspace/WorkspaceContext.cs
+++ b/src/RoslynMcp.Core/Workspace/WorkspaceContext.cs
@@ -39,6 +39,11 @@ public sealed class WorkspaceContext : IDisposable
     public string LoadedPath { get; }
 
     /// <summary>
+    /// Warnings emitted while the workspace was loading.
+    /// </summary>
+    public IReadOnlyList<string> LoadWarnings { get; }
+
+    /// <summary>
     /// Current workspace state.
     /// </summary>
     public WorkspaceState State { get; private set; }
@@ -47,12 +52,14 @@ public sealed class WorkspaceContext : IDisposable
         MSBuildWorkspace workspace,
         Solution solution,
         string loadedPath,
-        IFileWriter? fileWriter = null)
+        IFileWriter? fileWriter = null,
+        IReadOnlyList<string>? loadWarnings = null)
     {
         _workspace = workspace;
         _solution = solution;
         _fileWriter = fileWriter ?? new AtomicFileWriter();
         LoadedPath = loadedPath;
+        LoadWarnings = loadWarnings ?? [];
         State = WorkspaceState.Ready;
     }
 

--- a/src/RoslynMcp.Core/Workspace/WorkspaceLoadFailureClassifier.cs
+++ b/src/RoslynMcp.Core/Workspace/WorkspaceLoadFailureClassifier.cs
@@ -1,0 +1,45 @@
+namespace RoslynMcp.Core.Workspace;
+
+internal enum WorkspaceFailureCategory
+{
+    UnrecognizedProject,
+    OtherFailure
+}
+
+internal static class WorkspaceLoadFailureClassifier
+{
+    private const string _unsupportedProjectPrefix = "Cannot open project '";
+    private const string _unsupportedProjectMarker = "' because the file extension '";
+    private const string _unsupportedProjectSuffix = "' is not associated with a language.";
+    private const string _invalidProjectFilePathPrefix = "Invalid project file path: '";
+    private const string _projectFileNotFoundPrefix = "Project file not found: '";
+
+    public static WorkspaceFailureCategory Classify(string message)
+    {
+        if (string.IsNullOrEmpty(message))
+        {
+            return WorkspaceFailureCategory.OtherFailure;
+        }
+
+        if (message.StartsWith(_unsupportedProjectPrefix, StringComparison.Ordinal) &&
+            message.Contains(_unsupportedProjectMarker, StringComparison.Ordinal) &&
+            message.EndsWith(_unsupportedProjectSuffix, StringComparison.Ordinal))
+        {
+            return WorkspaceFailureCategory.UnrecognizedProject;
+        }
+
+        if (message.StartsWith(_invalidProjectFilePathPrefix, StringComparison.Ordinal) &&
+            message.EndsWith('\''))
+        {
+            return WorkspaceFailureCategory.UnrecognizedProject;
+        }
+
+        if (message.StartsWith(_projectFileNotFoundPrefix, StringComparison.Ordinal) &&
+            message.EndsWith('\''))
+        {
+            return WorkspaceFailureCategory.UnrecognizedProject;
+        }
+
+        return WorkspaceFailureCategory.OtherFailure;
+    }
+}

--- a/src/RoslynMcp.Core/Workspace/WorkspaceLoadFailureEvaluator.cs
+++ b/src/RoslynMcp.Core/Workspace/WorkspaceLoadFailureEvaluator.cs
@@ -1,0 +1,53 @@
+using Microsoft.CodeAnalysis;
+
+namespace RoslynMcp.Core.Workspace;
+
+internal sealed class WorkspaceLoadEvaluationResult
+{
+    public required IReadOnlyList<string> Errors { get; init; }
+    public required IReadOnlyList<string> Warnings { get; init; }
+    public bool HasErrors => Errors.Count > 0;
+}
+
+internal static class WorkspaceLoadFailureEvaluator
+{
+    private const string _noSupportedProjectsMessage = "No supported projects were loaded.";
+
+    public static WorkspaceLoadEvaluationResult Evaluate(
+        IEnumerable<WorkspaceDiagnostic> diagnostics,
+        WorkspaceLoadOptions options,
+        int projectCount)
+    {
+        List<string> errors = [];
+        List<string> warnings = [];
+
+        foreach (var diagnostic in diagnostics)
+        {
+            if (diagnostic.Kind != WorkspaceDiagnosticKind.Failure)
+            {
+                warnings.Add(diagnostic.Message);
+                continue;
+            }
+
+            var category = WorkspaceLoadFailureClassifier.Classify(diagnostic.Message);
+            if (category == WorkspaceFailureCategory.UnrecognizedProject && options.SkipUnrecognizedProjects)
+            {
+                warnings.Add(diagnostic.Message);
+                continue;
+            }
+
+            errors.Add(diagnostic.Message);
+        }
+
+        if (projectCount == 0)
+        {
+            errors.Add(_noSupportedProjectsMessage);
+        }
+
+        return new WorkspaceLoadEvaluationResult
+        {
+            Errors = errors,
+            Warnings = warnings
+        };
+    }
+}

--- a/src/RoslynMcp.Core/Workspace/WorkspaceLoadOptions.cs
+++ b/src/RoslynMcp.Core/Workspace/WorkspaceLoadOptions.cs
@@ -1,0 +1,17 @@
+namespace RoslynMcp.Core.Workspace;
+
+/// <summary>
+/// Options that control workspace loading behavior.
+/// </summary>
+public sealed class WorkspaceLoadOptions
+{
+    /// <summary>
+    /// Default workspace load options.
+    /// </summary>
+    public static WorkspaceLoadOptions Default { get; } = new();
+
+    /// <summary>
+    /// Whether Roslyn should skip unrecognized projects during solution load.
+    /// </summary>
+    public bool SkipUnrecognizedProjects { get; init; }
+}

--- a/src/RoslynMcp.Server/Program.cs
+++ b/src/RoslynMcp.Server/Program.cs
@@ -8,6 +8,18 @@ FileLogger.Log($"Process ID: {Environment.ProcessId}");
 FileLogger.Log($"Working directory: {Environment.CurrentDirectory}");
 FileLogger.Log($".NET Version: {Environment.Version}");
 
+ServerStartupOptions startupOptions;
+try
+{
+    startupOptions = ServerArgsParser.Parse(args);
+}
+catch (ArgumentException ex)
+{
+    FileLogger.LogError("Invalid startup arguments.", ex);
+    Console.Error.WriteLine(ex.Message);
+    return;
+}
+
 // Wire up logging callbacks for MSBuildWorkspaceProvider
 MSBuildWorkspaceProvider.LogCallback = FileLogger.Log;
 MSBuildWorkspaceProvider.LogErrorCallback = FileLogger.LogError;
@@ -23,7 +35,7 @@ Console.CancelKeyPress += (_, e) =>
 
 // Create workspace provider
 FileLogger.Log("Creating MSBuildWorkspaceProvider...");
-var workspaceProvider = new MSBuildWorkspaceProvider();
+var workspaceProvider = new MSBuildWorkspaceProvider(workspaceLoadOptions: startupOptions.WorkspaceLoadOptions);
 FileLogger.Log("MSBuildWorkspaceProvider created successfully.");
 
 // Create and run server

--- a/src/RoslynMcp.Server/Properties/AssemblyInfo.cs
+++ b/src/RoslynMcp.Server/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("RoslynMcp.Server.Tests")]

--- a/src/RoslynMcp.Server/ServerArgsParser.cs
+++ b/src/RoslynMcp.Server/ServerArgsParser.cs
@@ -1,0 +1,35 @@
+using RoslynMcp.Core.Workspace;
+
+namespace RoslynMcp.Server;
+
+internal sealed class ServerStartupOptions
+{
+    public WorkspaceLoadOptions WorkspaceLoadOptions { get; init; } = WorkspaceLoadOptions.Default;
+}
+
+internal static class ServerArgsParser
+{
+    public static ServerStartupOptions Parse(string[] args)
+    {
+        var skipUnrecognizedProjects = false;
+
+        foreach (var arg in args)
+        {
+            if (arg.Equals("--skip-unrecognized-projects", StringComparison.OrdinalIgnoreCase))
+            {
+                skipUnrecognizedProjects = true;
+                continue;
+            }
+
+            throw new ArgumentException($"Unknown startup argument: {arg}", nameof(args));
+        }
+
+        return new ServerStartupOptions
+        {
+            WorkspaceLoadOptions = new WorkspaceLoadOptions
+            {
+                SkipUnrecognizedProjects = skipUnrecognizedProjects
+            }
+        };
+    }
+}

--- a/src/RoslynMcp.Server/Tools/DiagnoseTool.cs
+++ b/src/RoslynMcp.Server/Tools/DiagnoseTool.cs
@@ -99,6 +99,7 @@ public sealed class DiagnoseTool : IToolHandler
                         ProjectCount = context.Solution.Projects.Count(),
                         DocumentCount = context.Solution.Projects.Sum(p => p.Documents.Count())
                     };
+                    warnings.AddRange(context.LoadWarnings);
                 }
                 catch (Exception ex)
                 {

--- a/tests/RoslynMcp.Cli.Tests/CliArgsTests.cs
+++ b/tests/RoslynMcp.Cli.Tests/CliArgsTests.cs
@@ -129,4 +129,15 @@ public class CliArgsTests
         Assert.Equal("DoStuff", result.Options["new-name"]);
         Assert.Equal("true", result.Options["preview"]);
     }
+
+    [Theory]
+    [InlineData("My.sln")]
+    [InlineData("My.slnx")]
+    public void SkipUnrecognizedProjects_IsParsedAsWorkspaceLoadOption(string solutionFile)
+    {
+        var result = CliArgs.Parse([solutionFile, "diagnose", "--skip-unrecognized-projects"]);
+
+        Assert.True(result.WorkspaceLoadOptions.SkipUnrecognizedProjects);
+        Assert.False(result.Options.ContainsKey("skip-unrecognized-projects"));
+    }
 }

--- a/tests/RoslynMcp.Cli.Tests/HelpGeneratorTests.cs
+++ b/tests/RoslynMcp.Cli.Tests/HelpGeneratorTests.cs
@@ -12,6 +12,7 @@ public class HelpGeneratorTests
         var help = HelpGenerator.GenerateGlobalHelp(registry);
         Assert.Contains("USAGE:", help);
         Assert.Contains("roslyn-cli", help);
+        Assert.Contains("--skip-unrecognized-projects", help);
     }
 
     [Fact]

--- a/tests/RoslynMcp.Core.Tests/Workspace/WorkspaceLoadFailureClassifierTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Workspace/WorkspaceLoadFailureClassifierTests.cs
@@ -1,0 +1,27 @@
+using RoslynMcp.Core.Workspace;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Workspace;
+
+public class WorkspaceLoadFailureClassifierTests
+{
+    [Theory]
+    [InlineData("Cannot open project 'D:\\repo\\docker-compose.dcproj' because the file extension '.dcproj' is not associated with a language.")]
+    [InlineData("Invalid project file path: 'bad-path'")]
+    [InlineData("Project file not found: 'D:\\repo\\missing.csproj'")]
+    public void Classify_ReturnsUnrecognizedProject_ForRoslynUnrecognizedProjectMessages(string message)
+    {
+        var category = WorkspaceLoadFailureClassifier.Classify(message);
+        Assert.Equal(WorkspaceFailureCategory.UnrecognizedProject, category);
+    }
+
+    [Theory]
+    [InlineData("warning NU1903: Package 'Foo' has a known vulnerability.")]
+    [InlineData("The SDK 'Microsoft.Docker.Sdk' specified could not be found.")]
+    [InlineData("Msbuild failed when processing the file 'D:\\repo\\app.csproj' with message: Build failed.")]
+    public void Classify_ReturnsOtherFailure_ForNonRoslynUnrecognizedProjectMessages(string message)
+    {
+        var category = WorkspaceLoadFailureClassifier.Classify(message);
+        Assert.Equal(WorkspaceFailureCategory.OtherFailure, category);
+    }
+}

--- a/tests/RoslynMcp.Core.Tests/Workspace/WorkspaceLoadFailureEvaluatorTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Workspace/WorkspaceLoadFailureEvaluatorTests.cs
@@ -1,0 +1,59 @@
+using Microsoft.CodeAnalysis;
+using RoslynMcp.Core.Workspace;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Workspace;
+
+public class WorkspaceLoadFailureEvaluatorTests
+{
+    [Fact]
+    public void Evaluate_ReturnsError_WhenSkipDisabledAndFailureIsUnrecognizedProject()
+    {
+        var result = WorkspaceLoadFailureEvaluator.Evaluate(
+            [new WorkspaceDiagnostic(WorkspaceDiagnosticKind.Failure, "Cannot open project 'D:\\repo\\docker-compose.dcproj' because the file extension '.dcproj' is not associated with a language.")],
+            new WorkspaceLoadOptions { SkipUnrecognizedProjects = false },
+            projectCount: 1);
+
+        Assert.True(result.HasErrors);
+        Assert.Empty(result.Warnings);
+    }
+
+    [Fact]
+    public void Evaluate_ReturnsWarning_WhenSkipEnabledAndOnlyUnrecognizedProjectsFailed()
+    {
+        var result = WorkspaceLoadFailureEvaluator.Evaluate(
+            [new WorkspaceDiagnostic(WorkspaceDiagnosticKind.Failure, "Cannot open project 'D:\\repo\\docker-compose.dcproj' because the file extension '.dcproj' is not associated with a language.")],
+            new WorkspaceLoadOptions { SkipUnrecognizedProjects = true },
+            projectCount: 1);
+
+        Assert.False(result.HasErrors);
+        Assert.Single(result.Warnings);
+        Assert.Equal("Cannot open project 'D:\\repo\\docker-compose.dcproj' because the file extension '.dcproj' is not associated with a language.", result.Warnings[0]);
+    }
+
+    [Fact]
+    public void Evaluate_ReturnsError_WhenNoProjectsLoaded()
+    {
+        var result = WorkspaceLoadFailureEvaluator.Evaluate(
+            [new WorkspaceDiagnostic(WorkspaceDiagnosticKind.Failure, "Cannot open project 'D:\\repo\\docker-compose.dcproj' because the file extension '.dcproj' is not associated with a language.")],
+            new WorkspaceLoadOptions { SkipUnrecognizedProjects = true },
+            projectCount: 0);
+
+        Assert.True(result.HasErrors);
+    }
+
+    [Fact]
+    public void Evaluate_ReturnsError_WhenUnrecognizedProjectFailureAndOtherFailureAreMixed()
+    {
+        var result = WorkspaceLoadFailureEvaluator.Evaluate(
+            [
+                new WorkspaceDiagnostic(WorkspaceDiagnosticKind.Failure, "Cannot open project 'D:\\repo\\docker-compose.dcproj' because the file extension '.dcproj' is not associated with a language."),
+                new WorkspaceDiagnostic(WorkspaceDiagnosticKind.Failure, "warning NU1903: Package 'Foo' has a known vulnerability.")
+            ],
+            new WorkspaceLoadOptions { SkipUnrecognizedProjects = true },
+            projectCount: 1);
+
+        Assert.True(result.HasErrors);
+        Assert.Single(result.Warnings);
+    }
+}

--- a/tests/RoslynMcp.Server.Tests/ServerArgsParserTests.cs
+++ b/tests/RoslynMcp.Server.Tests/ServerArgsParserTests.cs
@@ -1,0 +1,21 @@
+using RoslynMcp.Server;
+using Xunit;
+
+namespace RoslynMcp.Server.Tests;
+
+public class ServerArgsParserTests
+{
+    [Fact]
+    public void Parse_SetsSkipUnrecognizedProjects_WhenSwitchIsPresent()
+    {
+        var result = ServerArgsParser.Parse(["--skip-unrecognized-projects"]);
+        Assert.True(result.WorkspaceLoadOptions.SkipUnrecognizedProjects);
+    }
+
+    [Fact]
+    public void Parse_ThrowsForUnknownSwitch()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => ServerArgsParser.Parse(["--unknown"]));
+        Assert.Contains("--unknown", ex.Message);
+    }
+}

--- a/tests/RoslynMcp.Server.Tests/Tools/DiagnoseToolTests.cs
+++ b/tests/RoslynMcp.Server.Tests/Tools/DiagnoseToolTests.cs
@@ -1,0 +1,97 @@
+using System.Text.Json;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.MSBuild;
+using RoslynMcp.Contracts.Enums;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.Workspace;
+using RoslynMcp.Server.Tools;
+using Xunit;
+
+namespace RoslynMcp.Server.Tests.Tools;
+
+public class DiagnoseToolTests
+{
+    [Fact]
+    public async Task ExecuteAsync_ReturnsReadyWithWarnings_WhenWorkspaceLoadsWithSkippedFailures()
+    {
+        using var workspace = MSBuildWorkspace.Create();
+        var solution = workspace.CurrentSolution
+            .AddProject(ProjectId.CreateNewId(), "TestProject", "TestProject", LanguageNames.CSharp);
+
+        using var context = new WorkspaceContext(
+            workspace,
+            solution,
+            @"D:\repo\Test.sln",
+            loadWarnings:
+            [
+                "Cannot open project 'D:\\repo\\docker-compose.dcproj' because the file extension '.dcproj' is not associated with a language."
+            ]);
+
+        var tool = new DiagnoseTool(new FakeWorkspaceProvider(context));
+        var args = JsonDocument.Parse(@"{""solutionPath"":""D:\\repo\\Test.sln""}").RootElement;
+
+        var result = await tool.ExecuteAsync(args);
+        Assert.False(result.IsError);
+
+        var payload = JsonSerializer.Deserialize<DiagnoseResult>(GetResultText(result), new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+
+        Assert.NotNull(payload);
+        Assert.True(payload!.Healthy);
+        Assert.Equal(WorkspaceState.Ready, payload.Workspace.State);
+        Assert.True(payload.Workspace.SolutionLoaded);
+        Assert.Single(payload.Warnings);
+        Assert.Empty(payload.Errors);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsUnhealthy_WhenWorkspaceProviderThrows()
+    {
+        var tool = new DiagnoseTool(new ThrowingWorkspaceProvider("Failed to load solution"));
+        var args = JsonDocument.Parse(@"{""solutionPath"":""D:\\repo\\Test.sln""}").RootElement;
+
+        var result = await tool.ExecuteAsync(args);
+        Assert.False(result.IsError);
+
+        var payload = JsonSerializer.Deserialize<DiagnoseResult>(GetResultText(result), new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+
+        Assert.NotNull(payload);
+        Assert.False(payload!.Healthy);
+        Assert.Equal(WorkspaceState.Error, payload.Workspace.State);
+        Assert.Single(payload.Errors);
+    }
+
+    private static string GetResultText(RoslynMcp.Server.Transport.ToolResult result) =>
+        result.Content.FirstOrDefault()?.Text ?? string.Empty;
+
+    private sealed class FakeWorkspaceProvider(WorkspaceContext context) : IWorkspaceProvider
+    {
+        public EnvironmentDiagnostics CheckEnvironment() => new()
+        {
+            MsBuildFound = true,
+            DotnetSdkVersion = Environment.Version.ToString(),
+            MsBuildVersion = "1.0"
+        };
+
+        public Task<WorkspaceContext> CreateContextAsync(string projectOrSolutionPath, CancellationToken cancellationToken = default) =>
+            Task.FromResult(context);
+    }
+
+    private sealed class ThrowingWorkspaceProvider(string message) : IWorkspaceProvider
+    {
+        public EnvironmentDiagnostics CheckEnvironment() => new()
+        {
+            MsBuildFound = true,
+            DotnetSdkVersion = Environment.Version.ToString(),
+            MsBuildVersion = "1.0"
+        };
+
+        public Task<WorkspaceContext> CreateContextAsync(string projectOrSolutionPath, CancellationToken cancellationToken = default) =>
+            throw new InvalidOperationException(message);
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared workspace-load policy for classifying Roslyn unrecognized-project failures separately from real load failures
- expose `--skip-unrecognized-projects` in the CLI and MCP server startup path without changing tool schemas
- report skipped unsupported-project diagnostics as warnings while still failing loads that contain zero supported projects or genuine errors

## Why
Mixed real-world solutions can contain unsupported project types such as `.dcproj`. Roslyn can skip those entries, but the server was still treating the resulting workspace failures as fatal instead of applying an explicit skip policy.

## Test Plan
- [x] `dotnet build D:\RoslynMcpServer\RoslynMcp.sln -c Release`
- [x] `dotnet test D:\RoslynMcpServer\RoslynMcp.sln`