### PR TITLE
fix(core): align diagnose MSBuild discovery with SDK fallback

### DIFF
--- a/src/RoslynMcp.Core/Properties/AssemblyInfo.cs
+++ b/src/RoslynMcp.Core/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("RoslynMcp.Core.Tests")]

--- a/src/RoslynMcp.Core/Workspace/MSBuildWorkspaceProvider.cs
+++ b/src/RoslynMcp.Core/Workspace/MSBuildWorkspaceProvider.cs
@@ -164,11 +164,9 @@ public sealed class MSBuildWorkspaceProvider : IWorkspaceProvider
 
             if (instances.Length == 0)
             {
-                return new EnvironmentDiagnostics
-                {
-                    MsBuildFound = false,
-                    ErrorMessage = "MSBuild not found. Install Visual Studio, Build Tools, or .NET SDK."
-                };
+                return CreateEnvironmentDiagnosticsForNoInstances(
+                    FindDotNetSdk(),
+                    Environment.Version.ToString());
             }
 
             var preferred = SelectPreferredInstance(instances);
@@ -190,6 +188,28 @@ public sealed class MSBuildWorkspaceProvider : IWorkspaceProvider
                 ErrorMessage = ex.Message
             };
         }
+    }
+
+    internal static EnvironmentDiagnostics CreateEnvironmentDiagnosticsForNoInstances(
+        string? sdkPath,
+        string dotnetSdkVersion)
+    {
+        if (!string.IsNullOrEmpty(sdkPath))
+        {
+            return new EnvironmentDiagnostics
+            {
+                MsBuildFound = true,
+                MsBuildPath = sdkPath,
+                DotnetSdkVersion = dotnetSdkVersion,
+                SearchPaths = [sdkPath]
+            };
+        }
+
+        return new EnvironmentDiagnostics
+        {
+            MsBuildFound = false,
+            ErrorMessage = "MSBuild not found. Install Visual Studio, Build Tools, or .NET SDK."
+        };
     }
 
     private static void EnsureMsBuildRegistered()

--- a/tests/RoslynMcp.Core.Tests/Workspace/MSBuildWorkspaceProviderEnvironmentTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Workspace/MSBuildWorkspaceProviderEnvironmentTests.cs
@@ -1,0 +1,31 @@
+using RoslynMcp.Core.Workspace;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Workspace;
+
+public class MSBuildWorkspaceProviderEnvironmentTests
+{
+    [Fact]
+    public void CreateEnvironmentDiagnosticsForNoInstances_ReturnsMsBuildFound_WhenSdkPathExists()
+    {
+        var result = MSBuildWorkspaceProvider.CreateEnvironmentDiagnosticsForNoInstances(
+            @"C:\Program Files\dotnet\sdk\9.0.308",
+            "9.0.16");
+
+        Assert.True(result.MsBuildFound);
+        Assert.Equal(@"C:\Program Files\dotnet\sdk\9.0.308", result.MsBuildPath);
+        Assert.Equal("9.0.16", result.DotnetSdkVersion);
+        Assert.Contains(@"C:\Program Files\dotnet\sdk\9.0.308", result.SearchPaths!);
+    }
+
+    [Fact]
+    public void CreateEnvironmentDiagnosticsForNoInstances_ReturnsMsBuildNotFound_WhenSdkPathMissing()
+    {
+        var result = MSBuildWorkspaceProvider.CreateEnvironmentDiagnosticsForNoInstances(
+            null,
+            "9.0.16");
+
+        Assert.False(result.MsBuildFound);
+        Assert.Equal("MSBuild not found. Install Visual Studio, Build Tools, or .NET SDK.", result.ErrorMessage);
+    }
+}


### PR DESCRIPTION
## Summary
- reuse the same .NET SDK fallback logic for `diagnose` that workspace registration already uses when `MSBuildLocator` returns no Visual Studio instances
- report the discovered SDK-backed MSBuild path in environment diagnostics instead of incorrectly marking the environment as missing MSBuild
- add regression coverage for the no-instance fallback path
- potential fix for #20 

## Why
`diagnose` could report an unhealthy MSBuild environment even when workspace loading succeeded via the .NET SDK fallback path. This change brings the diagnostic view back into line with the runtime behavior.

## Test Plan
- [x] `dotnet build D:\RoslynMcpServer\RoslynMcp.sln -c Release`
- [x] `dotnet test D:\RoslynMcpServer\RoslynMcp.sln`