### PR TITLE
feat(server): enable major runtime roll-forward

### DIFF
--- a/src/RoslynMcp.Cli/RoslynMcp.Cli.csproj
+++ b/src/RoslynMcp.Cli/RoslynMcp.Cli.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net9.0</TargetFramework>
+    <RollForward>Major</RollForward>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/RoslynMcp.Server/RoslynMcp.Server.csproj
+++ b/src/RoslynMcp.Server/RoslynMcp.Server.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net9.0</TargetFramework>
+    <RollForward>Major</RollForward>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
## Summary
- set `RollForward` to `Major` for the CLI and server executable projects
- carry the newer-runtime policy in the generated runtime configuration instead of relying only on external launchers
- preserve the existing `net9.0` target framework while allowing execution on newer installed runtimes when .NET 9 is absent

## Why
This keeps the shipped tools framework-dependent on .NET 9 while making them usable on machines that only have a newer runtime installed, such as a .NET 10-only environment.

## Test Plan
- [x] `dotnet build D:\RoslynMcpServer\RoslynMcp.sln -c Release`
- [x] `dotnet test D:\RoslynMcpServer\RoslynMcp.sln`