### PR TITLE
fix(core): correct .NET SDK version selection

### DIFF
--- a/src/RoslynMcp.Core/Properties/AssemblyInfo.cs
+++ b/src/RoslynMcp.Core/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("RoslynMcp.Core.Tests")]

--- a/src/RoslynMcp.Core/Workspace/DotNetSdkResolver.cs
+++ b/src/RoslynMcp.Core/Workspace/DotNetSdkResolver.cs
@@ -1,0 +1,53 @@
+namespace RoslynMcp.Core.Workspace;
+
+internal static class DotNetSdkResolver
+{
+    public static string? FindLatestSdkPath(string sdkBasePath)
+    {
+        if (!Directory.Exists(sdkBasePath))
+        {
+            return null;
+        }
+
+        return TryFindLatestSdkPath(Directory.GetDirectories(sdkBasePath));
+    }
+
+    internal static string? TryFindLatestSdkPath(IEnumerable<string> sdkDirectories)
+    {
+        return sdkDirectories
+            .Select(CreateCandidate)
+            .Where(candidate => candidate is not null)
+            .OrderByDescending(candidate => candidate!.NumericVersion)
+            .ThenBy(candidate => candidate!.IsPrerelease)
+            .ThenByDescending(candidate => candidate!.OriginalVersion, StringComparer.OrdinalIgnoreCase)
+            .Select(candidate => candidate!.Path)
+            .FirstOrDefault();
+    }
+
+    private static SdkCandidate? CreateCandidate(string sdkDirectory)
+    {
+        var directoryName = Path.GetFileName(sdkDirectory);
+        if (string.IsNullOrWhiteSpace(directoryName))
+        {
+            return null;
+        }
+
+        var versionParts = directoryName.Split('-', 2, StringSplitOptions.TrimEntries);
+        if (!Version.TryParse(versionParts[0], out var numericVersion))
+        {
+            return null;
+        }
+
+        return new SdkCandidate(
+            sdkDirectory,
+            directoryName,
+            numericVersion,
+            versionParts.Length > 1);
+    }
+
+    private sealed record SdkCandidate(
+        string Path,
+        string OriginalVersion,
+        Version NumericVersion,
+        bool IsPrerelease);
+}

--- a/src/RoslynMcp.Core/Workspace/MSBuildWorkspaceProvider.cs
+++ b/src/RoslynMcp.Core/Workspace/MSBuildWorkspaceProvider.cs
@@ -247,26 +247,7 @@ public sealed class MSBuildWorkspaceProvider : IWorkspaceProvider
     {
         var programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
         var sdkBase = Path.Combine(programFiles, "dotnet", "sdk");
-
-        if (!Directory.Exists(sdkBase))
-        {
-            return null;
-        }
-
-        // Find the latest SDK version
-        var sdkVersions = Directory.GetDirectories(sdkBase)
-            .Select(Path.GetFileName)
-            .Where(d => d != null && char.IsDigit(d[0]))
-            .OrderByDescending(v => v)
-            .ToList();
-
-        if (sdkVersions.Count == 0)
-        {
-            return null;
-        }
-
-        var latestSdk = Path.Combine(sdkBase, sdkVersions[0]!);
-        return Directory.Exists(latestSdk) ? latestSdk : null;
+        return DotNetSdkResolver.FindLatestSdkPath(sdkBase);
     }
 
     private static VisualStudioInstance SelectPreferredInstance(VisualStudioInstance[] instances)

--- a/tests/RoslynMcp.Core.Tests/ModuleInitializer.cs
+++ b/tests/RoslynMcp.Core.Tests/ModuleInitializer.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 using Microsoft.Build.Locator;
+using RoslynMcp.Core.Workspace;
 
 namespace RoslynMcp.Core.Tests;
 
@@ -59,28 +60,8 @@ internal static class ModuleInitializer
 
     private static string? FindDotNetSdk()
     {
-        // Check common SDK locations
         var programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
         var sdkBase = Path.Combine(programFiles, "dotnet", "sdk");
-
-        if (!Directory.Exists(sdkBase))
-        {
-            return null;
-        }
-
-        // Find the latest SDK version
-        var sdkVersions = Directory.GetDirectories(sdkBase)
-            .Select(Path.GetFileName)
-            .Where(d => d != null && char.IsDigit(d[0]))
-            .OrderByDescending(v => v)
-            .ToList();
-
-        if (sdkVersions.Count == 0)
-        {
-            return null;
-        }
-
-        var latestSdk = Path.Combine(sdkBase, sdkVersions[0]!);
-        return Directory.Exists(latestSdk) ? latestSdk : null;
+        return DotNetSdkResolver.FindLatestSdkPath(sdkBase);
     }
 }

--- a/tests/RoslynMcp.Core.Tests/Workspace/DotNetSdkResolverTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Workspace/DotNetSdkResolverTests.cs
@@ -1,0 +1,39 @@
+using RoslynMcp.Core.Workspace;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Workspace;
+
+public class DotNetSdkResolverTests
+{
+    [Fact]
+    public void TryFindLatestSdkPath_PrefersSemanticVersionOrdering()
+    {
+        var sdkBasePath = @"C:\dotnet\sdk";
+        var sdkDirectories = new[]
+        {
+            Path.Combine(sdkBasePath, "9.0.308"),
+            Path.Combine(sdkBasePath, "10.0.100"),
+            Path.Combine(sdkBasePath, "10.0.301")
+        };
+
+        var result = DotNetSdkResolver.TryFindLatestSdkPath(sdkDirectories);
+
+        Assert.Equal(Path.Combine(sdkBasePath, "10.0.301"), result);
+    }
+
+    [Fact]
+    public void TryFindLatestSdkPath_ParsesPreviewVersionFolders()
+    {
+        var sdkBasePath = @"C:\dotnet\sdk";
+        var sdkDirectories = new[]
+        {
+            Path.Combine(sdkBasePath, "9.0.308"),
+            Path.Combine(sdkBasePath, "10.0.200-preview.0.26103.119"),
+            Path.Combine(sdkBasePath, "10.0.100")
+        };
+
+        var result = DotNetSdkResolver.TryFindLatestSdkPath(sdkDirectories);
+
+        Assert.Equal(Path.Combine(sdkBasePath, "10.0.200-preview.0.26103.119"), result);
+    }
+}


### PR DESCRIPTION
## Summary
- replace raw string sorting of SDK directory names with a shared resolver that compares parsed version values
- route both the production workspace provider and the test MSBuild initializer through the same SDK selection logic
- add regression tests covering `10.x` SDK folders and preview-style SDK directory names
- potentially fixes #21 

## Why
The previous selection logic sorted SDK folder names lexically, which could prefer `9.x` over `10.x` and cause Roslyn MCP to register the wrong SDK path or fail to load projects that require the newer installed SDK.

## Test Plan
- [x] `dotnet test D:\RoslynMcpServer\tests\RoslynMcp.Core.Tests\RoslynMcp.Core.Tests.csproj --filter DotNetSdkResolverTests`
- [x] `dotnet build D:\RoslynMcpServer\RoslynMcp.sln -c Release`
- [x] `dotnet test D:\RoslynMcpServer\RoslynMcp.sln`