### PR TITLE
Fix SDK discovery and capability diagnostics

### DIFF
--- a/src/RoslynMcp.Cli/Program.cs
+++ b/src/RoslynMcp.Cli/Program.cs
@@ -80,7 +80,7 @@ try
     // Special handling for diagnose (needs IWorkspaceProvider, not WorkspaceContext)
     if (parsed.ToolName.Equals("diagnose", StringComparison.OrdinalIgnoreCase))
     {
-        var diagnoseResult = await ExecuteDiagnoseAsync(workspaceProvider, parsed, cts.Token);
+        var diagnoseResult = await ExecuteDiagnoseAsync(workspaceProvider, registry, parsed, cts.Token);
         OutputResult(diagnoseResult, parsed.Format);
         return diagnoseResult is DiagnoseResult dr && dr.Healthy ? ExitSuccess : ExitToolError;
     }
@@ -157,6 +157,7 @@ bool IsEnvironmentError(Exception ex)
 
 async Task<DiagnoseResult> ExecuteDiagnoseAsync(
     MSBuildWorkspaceProvider provider,
+    ToolRegistry toolRegistry,
     ParsedArgs args,
     CancellationToken ct)
 {
@@ -221,9 +222,7 @@ async Task<DiagnoseResult> ExecuteDiagnoseAsync(
             DotnetSdkVersion = envDiag.DotnetSdkVersion
         },
         Workspace = workspaceStatus,
-        Capabilities = envDiag.MsBuildFound
-            ? ["move_type_to_file", "move_type_to_namespace", "diagnose"]
-            : ["diagnose"],
+        Capabilities = toolRegistry.GetAllTools().Select(tool => tool.Name).ToArray(),
         Errors = errors,
         Warnings = []
     };

--- a/src/RoslynMcp.Core/RoslynMcp.Core.csproj
+++ b/src/RoslynMcp.Core/RoslynMcp.Core.csproj
@@ -38,4 +38,8 @@
     <ProjectReference Include="..\RoslynMcp.Contracts\RoslynMcp.Contracts.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="RoslynMcp.Core.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/RoslynMcp.Core/Workspace/DotNetSdkResolver.cs
+++ b/src/RoslynMcp.Core/Workspace/DotNetSdkResolver.cs
@@ -1,0 +1,152 @@
+using System.Diagnostics;
+
+namespace RoslynMcp.Core.Workspace;
+
+internal sealed record DotNetSdkInfo(string Version, string Path);
+
+internal static class DotNetSdkResolver
+{
+    private static readonly TimeSpan DotNetCommandTimeout = TimeSpan.FromSeconds(5);
+
+    public static DotNetSdkInfo? FindLatest()
+    {
+        var sdkPaths = FindFromKnownRoots()
+            .Concat(FindFromDotNetHost())
+            .Distinct(StringComparer.OrdinalIgnoreCase);
+
+        return SelectLatest(sdkPaths);
+    }
+
+    internal static DotNetSdkInfo? SelectLatest(IEnumerable<string> sdkPaths)
+    {
+        return sdkPaths
+            .Select(path => new
+            {
+                Path = path,
+                VersionText = Path.GetFileName(Path.TrimEndingDirectorySeparator(path))
+            })
+            .Where(candidate => TryParseSdkVersion(candidate.VersionText, out _))
+            .Select(candidate => new
+            {
+                candidate.Path,
+                candidate.VersionText,
+                Version = ParseSdkVersion(candidate.VersionText),
+                IsPrerelease = candidate.VersionText!.Contains('-')
+            })
+            .OrderByDescending(candidate => candidate.Version)
+            .ThenBy(candidate => candidate.IsPrerelease)
+            .ThenByDescending(candidate => candidate.VersionText, StringComparer.OrdinalIgnoreCase)
+            .Select(candidate => new DotNetSdkInfo(candidate.VersionText!, candidate.Path))
+            .FirstOrDefault();
+    }
+
+    private static IEnumerable<string> FindFromKnownRoots()
+    {
+        var roots = new[]
+        {
+            Environment.GetEnvironmentVariable("DOTNET_ROOT"),
+            Environment.GetEnvironmentVariable("DOTNET_ROOT(x86)"),
+            GetDotNetHostDirectory(),
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "dotnet"),
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "dotnet"),
+            "/usr/local/share/dotnet",
+            "/usr/share/dotnet"
+        };
+
+        foreach (var root in roots.Where(root => !string.IsNullOrWhiteSpace(root)))
+        {
+            var sdkRoot = Path.Combine(root!, "sdk");
+            if (!Directory.Exists(sdkRoot))
+            {
+                continue;
+            }
+
+            foreach (var sdkPath in Directory.EnumerateDirectories(sdkRoot))
+            {
+                yield return sdkPath;
+            }
+        }
+    }
+
+    private static IReadOnlyList<string> FindFromDotNetHost()
+    {
+        try
+        {
+            using var process = Process.Start(new ProcessStartInfo
+            {
+                FileName = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") ?? "dotnet",
+                Arguments = "--list-sdks",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            });
+
+            if (process == null)
+            {
+                return Array.Empty<string>();
+            }
+
+            var output = process.StandardOutput.ReadToEnd();
+            if (!process.WaitForExit((int)DotNetCommandTimeout.TotalMilliseconds))
+            {
+                process.Kill(entireProcessTree: true);
+                return Array.Empty<string>();
+            }
+
+            var sdkPaths = new List<string>();
+            foreach (var line in output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries))
+            {
+                var separatorIndex = line.IndexOf(" [", StringComparison.Ordinal);
+                if (separatorIndex <= 0 || !line.EndsWith(']'))
+                {
+                    continue;
+                }
+
+                var version = line[..separatorIndex].Trim();
+                var sdkRoot = line[(separatorIndex + 2)..^1];
+                var sdkPath = Path.Combine(sdkRoot, version);
+                if (Directory.Exists(sdkPath))
+                {
+                    sdkPaths.Add(sdkPath);
+                }
+            }
+
+            return sdkPaths;
+        }
+        catch (System.ComponentModel.Win32Exception)
+        {
+            return Array.Empty<string>();
+        }
+        catch (InvalidOperationException)
+        {
+            return Array.Empty<string>();
+        }
+        catch (IOException)
+        {
+            return Array.Empty<string>();
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return Array.Empty<string>();
+        }
+    }
+
+    private static string? GetDotNetHostDirectory()
+    {
+        var hostPath = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH");
+        return string.IsNullOrWhiteSpace(hostPath) ? null : Path.GetDirectoryName(hostPath);
+    }
+
+    private static Version ParseSdkVersion(string? version)
+    {
+        TryParseSdkVersion(version, out var parsed);
+        return parsed!;
+    }
+
+    private static bool TryParseSdkVersion(string? version, out Version? parsed)
+    {
+        var numericVersion = version?.Split('-', 2)[0];
+        return Version.TryParse(numericVersion, out parsed);
+    }
+}

--- a/src/RoslynMcp.Core/Workspace/DotNetSdkResolver.cs
+++ b/src/RoslynMcp.Core/Workspace/DotNetSdkResolver.cs
@@ -23,36 +23,46 @@ internal static class DotNetSdkResolver
             .Select(path => new
             {
                 Path = path,
-                VersionText = Path.GetFileName(Path.TrimEndingDirectorySeparator(path))
+                VersionText = Path.GetFileName(Path.TrimEndingDirectorySeparator(path)),
             })
-            .Where(candidate => TryParseSdkVersion(candidate.VersionText, out _))
             .Select(candidate => new
             {
                 candidate.Path,
                 candidate.VersionText,
-                Version = ParseSdkVersion(candidate.VersionText),
-                IsPrerelease = candidate.VersionText!.Contains('-')
+                Version = DotNetSdkVersion.TryParse(candidate.VersionText, out var version)
+                    ? version
+                    : null
             })
+            .Where(candidate => candidate.Version != null)
             .OrderByDescending(candidate => candidate.Version)
-            .ThenBy(candidate => candidate.IsPrerelease)
-            .ThenByDescending(candidate => candidate.VersionText, StringComparer.OrdinalIgnoreCase)
+            .Select(candidate => new
+            {
+                candidate.Path,
+                candidate.VersionText,
+                candidate.Version
+            })
             .Select(candidate => new DotNetSdkInfo(candidate.VersionText!, candidate.Path))
             .FirstOrDefault();
     }
 
-    private static IEnumerable<string> FindFromKnownRoots()
+    private static IReadOnlyList<string> FindFromKnownRoots()
     {
-        var roots = new[]
+        var roots = new List<string?>
         {
             Environment.GetEnvironmentVariable("DOTNET_ROOT"),
             Environment.GetEnvironmentVariable("DOTNET_ROOT(x86)"),
             GetDotNetHostDirectory(),
-            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "dotnet"),
-            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "dotnet"),
             "/usr/local/share/dotnet",
             "/usr/share/dotnet"
         };
 
+        if (OperatingSystem.IsWindows())
+        {
+            AddProgramFilesRoot(roots, Environment.SpecialFolder.ProgramFiles);
+            AddProgramFilesRoot(roots, Environment.SpecialFolder.ProgramFilesX86);
+        }
+
+        var sdkPaths = new List<string>();
         foreach (var root in roots.Where(root => !string.IsNullOrWhiteSpace(root)))
         {
             var sdkRoot = Path.Combine(root!, "sdk");
@@ -61,11 +71,25 @@ internal static class DotNetSdkResolver
                 continue;
             }
 
-            foreach (var sdkPath in Directory.EnumerateDirectories(sdkRoot))
+            try
             {
-                yield return sdkPath;
+                sdkPaths.AddRange(Directory.EnumerateDirectories(sdkRoot));
+            }
+            catch (IOException)
+            {
+                // Continue probing other configured SDK roots.
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // Continue probing other configured SDK roots.
+            }
+            catch (System.Security.SecurityException)
+            {
+                // Continue probing other configured SDK roots.
             }
         }
+
+        return sdkPaths;
     }
 
     private static IReadOnlyList<string> FindFromDotNetHost()
@@ -87,13 +111,29 @@ internal static class DotNetSdkResolver
                 return Array.Empty<string>();
             }
 
-            var output = process.StandardOutput.ReadToEnd();
-            if (!process.WaitForExit((int)DotNetCommandTimeout.TotalMilliseconds))
+            var outputTask = process.StandardOutput.ReadToEndAsync();
+            var errorTask = process.StandardError.ReadToEndAsync();
+            using var timeoutCts = new CancellationTokenSource(DotNetCommandTimeout);
+
+            try
             {
-                process.Kill(entireProcessTree: true);
+                process.WaitForExitAsync(timeoutCts.Token).GetAwaiter().GetResult();
+            }
+            catch (OperationCanceledException)
+            {
+                if (!process.HasExited)
+                {
+                    process.Kill(entireProcessTree: true);
+                }
+
+                process.WaitForExitAsync().GetAwaiter().GetResult();
+                _ = outputTask.GetAwaiter().GetResult();
+                _ = errorTask.GetAwaiter().GetResult();
                 return Array.Empty<string>();
             }
 
+            var output = outputTask.GetAwaiter().GetResult();
+            _ = errorTask.GetAwaiter().GetResult();
             var sdkPaths = new List<string>();
             foreach (var line in output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries))
             {
@@ -132,21 +172,113 @@ internal static class DotNetSdkResolver
         }
     }
 
+    private static void AddProgramFilesRoot(
+        ICollection<string?> roots,
+        Environment.SpecialFolder specialFolder)
+    {
+        var programFiles = Environment.GetFolderPath(specialFolder);
+        if (!string.IsNullOrWhiteSpace(programFiles))
+        {
+            roots.Add(Path.Combine(programFiles, "dotnet"));
+        }
+    }
+
     private static string? GetDotNetHostDirectory()
     {
         var hostPath = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH");
         return string.IsNullOrWhiteSpace(hostPath) ? null : Path.GetDirectoryName(hostPath);
     }
 
-    private static Version ParseSdkVersion(string? version)
+    private sealed class DotNetSdkVersion : IComparable<DotNetSdkVersion>
     {
-        TryParseSdkVersion(version, out var parsed);
-        return parsed!;
-    }
+        private readonly Version _numericVersion;
+        private readonly string[] _prereleaseIdentifiers;
 
-    private static bool TryParseSdkVersion(string? version, out Version? parsed)
-    {
-        var numericVersion = version?.Split('-', 2)[0];
-        return Version.TryParse(numericVersion, out parsed);
+        private DotNetSdkVersion(Version numericVersion, string[] prereleaseIdentifiers)
+        {
+            _numericVersion = numericVersion;
+            _prereleaseIdentifiers = prereleaseIdentifiers;
+        }
+
+        public static bool TryParse(string? value, out DotNetSdkVersion? version)
+        {
+            version = null;
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return false;
+            }
+
+            var versionParts = value.Split('-', 2);
+            if (!Version.TryParse(versionParts[0], out var numericVersion))
+            {
+                return false;
+            }
+
+            var prereleaseIdentifiers = versionParts.Length == 1
+                ? Array.Empty<string>()
+                : versionParts[1].Split('.', StringSplitOptions.RemoveEmptyEntries);
+            version = new DotNetSdkVersion(numericVersion, prereleaseIdentifiers);
+            return true;
+        }
+
+        public int CompareTo(DotNetSdkVersion? other)
+        {
+            if (other == null)
+            {
+                return 1;
+            }
+
+            var numericComparison = _numericVersion.CompareTo(other._numericVersion);
+            if (numericComparison != 0)
+            {
+                return numericComparison;
+            }
+
+            if (_prereleaseIdentifiers.Length == 0 || other._prereleaseIdentifiers.Length == 0)
+            {
+                return other._prereleaseIdentifiers.Length.CompareTo(_prereleaseIdentifiers.Length);
+            }
+
+            for (var index = 0;
+                 index < Math.Min(_prereleaseIdentifiers.Length, other._prereleaseIdentifiers.Length);
+                 index++)
+            {
+                var identifierComparison = CompareIdentifier(
+                    _prereleaseIdentifiers[index],
+                    other._prereleaseIdentifiers[index]);
+                if (identifierComparison != 0)
+                {
+                    return identifierComparison;
+                }
+            }
+
+            return _prereleaseIdentifiers.Length.CompareTo(other._prereleaseIdentifiers.Length);
+        }
+
+        private static int CompareIdentifier(string left, string right)
+        {
+            var leftIsNumeric = left.All(char.IsAsciiDigit);
+            var rightIsNumeric = right.All(char.IsAsciiDigit);
+
+            if (leftIsNumeric && rightIsNumeric)
+            {
+                var normalizedLeft = left.TrimStart('0');
+                var normalizedRight = right.TrimStart('0');
+                normalizedLeft = normalizedLeft.Length == 0 ? "0" : normalizedLeft;
+                normalizedRight = normalizedRight.Length == 0 ? "0" : normalizedRight;
+
+                var lengthComparison = normalizedLeft.Length.CompareTo(normalizedRight.Length);
+                return lengthComparison != 0
+                    ? lengthComparison
+                    : string.Compare(normalizedLeft, normalizedRight, StringComparison.Ordinal);
+            }
+
+            if (leftIsNumeric != rightIsNumeric)
+            {
+                return leftIsNumeric ? -1 : 1;
+            }
+
+            return string.Compare(left, right, StringComparison.OrdinalIgnoreCase);
+        }
     }
 }

--- a/src/RoslynMcp.Core/Workspace/MSBuildWorkspaceProvider.cs
+++ b/src/RoslynMcp.Core/Workspace/MSBuildWorkspaceProvider.cs
@@ -171,7 +171,6 @@ public sealed class MSBuildWorkspaceProvider : IWorkspaceProvider
                     return new EnvironmentDiagnostics
                     {
                         MsBuildFound = true,
-                        MsBuildVersion = fallbackSdk.Version,
                         MsBuildPath = fallbackSdk.Path,
                         DotnetSdkVersion = fallbackSdk.Version,
                         SearchPaths = new[] { fallbackSdk.Path }
@@ -193,7 +192,9 @@ public sealed class MSBuildWorkspaceProvider : IWorkspaceProvider
             return new EnvironmentDiagnostics
             {
                 MsBuildFound = true,
-                MsBuildVersion = preferred.Version.ToString(),
+                MsBuildVersion = preferred.DiscoveryType == DiscoveryType.DotNetSdk
+                    ? null
+                    : preferred.Version.ToString(),
                 MsBuildPath = preferred.MSBuildPath,
                 DotnetSdkVersion = detectedSdk?.Version,
                 SearchPaths = instances.Select(i => i.MSBuildPath).ToList()

--- a/src/RoslynMcp.Core/Workspace/MSBuildWorkspaceProvider.cs
+++ b/src/RoslynMcp.Core/Workspace/MSBuildWorkspaceProvider.cs
@@ -16,6 +16,7 @@ public sealed class MSBuildWorkspaceProvider : IWorkspaceProvider
     private static bool _msBuildRegistered;
     private static readonly object _registrationLock = new();
     private static VisualStudioInstance? _registeredInstance;
+    private static DotNetSdkInfo? _registeredSdk;
 
     /// <summary>
     /// Optional logging callback for diagnostics.
@@ -164,6 +165,19 @@ public sealed class MSBuildWorkspaceProvider : IWorkspaceProvider
 
             if (instances.Length == 0)
             {
+                var fallbackSdk = _registeredSdk ?? DotNetSdkResolver.FindLatest();
+                if (fallbackSdk != null)
+                {
+                    return new EnvironmentDiagnostics
+                    {
+                        MsBuildFound = true,
+                        MsBuildVersion = fallbackSdk.Version,
+                        MsBuildPath = fallbackSdk.Path,
+                        DotnetSdkVersion = fallbackSdk.Version,
+                        SearchPaths = new[] { fallbackSdk.Path }
+                    };
+                }
+
                 return new EnvironmentDiagnostics
                 {
                     MsBuildFound = false,
@@ -172,13 +186,16 @@ public sealed class MSBuildWorkspaceProvider : IWorkspaceProvider
             }
 
             var preferred = SelectPreferredInstance(instances);
+            var detectedSdk = preferred.DiscoveryType == DiscoveryType.DotNetSdk
+                ? new DotNetSdkInfo(preferred.Version.ToString(), preferred.MSBuildPath)
+                : DotNetSdkResolver.FindLatest();
 
             return new EnvironmentDiagnostics
             {
                 MsBuildFound = true,
                 MsBuildVersion = preferred.Version.ToString(),
                 MsBuildPath = preferred.MSBuildPath,
-                DotnetSdkVersion = Environment.Version.ToString(),
+                DotnetSdkVersion = detectedSdk?.Version,
                 SearchPaths = instances.Select(i => i.MSBuildPath).ToList()
             };
         }
@@ -216,14 +233,14 @@ public sealed class MSBuildWorkspaceProvider : IWorkspaceProvider
 
             if (instances.Length == 0)
             {
-                // Try to find .NET SDK manually
                 LogCallback?.Invoke("No instances found, searching for .NET SDK manually...");
-                var sdkPath = FindDotNetSdk();
-                if (sdkPath != null)
+                var sdk = DotNetSdkResolver.FindLatest();
+                if (sdk != null)
                 {
-                    LogCallback?.Invoke($"Found .NET SDK at: {sdkPath}");
-                    MSBuildLocator.RegisterMSBuildPath(sdkPath);
+                    LogCallback?.Invoke($"Found .NET SDK {sdk.Version} at: {sdk.Path}");
+                    MSBuildLocator.RegisterMSBuildPath(sdk.Path);
                     LogCallback?.Invoke("MSBuild registered via .NET SDK path.");
+                    _registeredSdk = sdk;
                     _msBuildRegistered = true;
                     return;
                 }
@@ -241,32 +258,6 @@ public sealed class MSBuildWorkspaceProvider : IWorkspaceProvider
             LogCallback?.Invoke("MSBuild registered successfully.");
             _msBuildRegistered = true;
         }
-    }
-
-    private static string? FindDotNetSdk()
-    {
-        var programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
-        var sdkBase = Path.Combine(programFiles, "dotnet", "sdk");
-
-        if (!Directory.Exists(sdkBase))
-        {
-            return null;
-        }
-
-        // Find the latest SDK version
-        var sdkVersions = Directory.GetDirectories(sdkBase)
-            .Select(Path.GetFileName)
-            .Where(d => d != null && char.IsDigit(d[0]))
-            .OrderByDescending(v => v)
-            .ToList();
-
-        if (sdkVersions.Count == 0)
-        {
-            return null;
-        }
-
-        var latestSdk = Path.Combine(sdkBase, sdkVersions[0]!);
-        return Directory.Exists(latestSdk) ? latestSdk : null;
     }
 
     private static VisualStudioInstance SelectPreferredInstance(VisualStudioInstance[] instances)

--- a/src/RoslynMcp.Server/McpServerHost.cs
+++ b/src/RoslynMcp.Server/McpServerHost.cs
@@ -27,7 +27,7 @@ public sealed class McpServerHost : IAsyncDisposable
         // Register tools
         _toolRegistry.Register(new MoveTypeToFileTool(workspaceProvider));
         _toolRegistry.Register(new MoveTypeToNamespaceTool(workspaceProvider));
-        _toolRegistry.Register(new DiagnoseTool(workspaceProvider));
+        _toolRegistry.Register(new DiagnoseTool(workspaceProvider, _toolRegistry.GetToolNames));
 
         // Phase 1 - Tier 1 Operations
         _toolRegistry.Register(new RenameSymbolTool(workspaceProvider));

--- a/src/RoslynMcp.Server/Tools/DiagnoseTool.cs
+++ b/src/RoslynMcp.Server/Tools/DiagnoseTool.cs
@@ -12,14 +12,18 @@ namespace RoslynMcp.Server.Tools;
 public sealed class DiagnoseTool : IToolHandler
 {
     private readonly IWorkspaceProvider _workspaceProvider;
+    private readonly Func<IReadOnlyList<string>> _capabilityProvider;
     private readonly JsonSerializerOptions _jsonOptions;
 
     /// <summary>
     /// Creates a new diagnose tool.
     /// </summary>
-    public DiagnoseTool(IWorkspaceProvider workspaceProvider)
+    public DiagnoseTool(
+        IWorkspaceProvider workspaceProvider,
+        Func<IReadOnlyList<string>>? capabilityProvider = null)
     {
         _workspaceProvider = workspaceProvider;
+        _capabilityProvider = capabilityProvider ?? (() => new[] { Name });
         _jsonOptions = new JsonSerializerOptions
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -121,10 +125,6 @@ public sealed class DiagnoseTool : IToolHandler
                 };
             }
 
-            var capabilities = envDiag.MsBuildFound
-                ? new[] { "move_type_to_file", "move_type_to_namespace", "diagnose" }
-                : new[] { "diagnose" };
-
             var result = new DiagnoseResult
             {
                 Healthy = envDiag.MsBuildFound && errors.Count == 0,
@@ -138,7 +138,7 @@ public sealed class DiagnoseTool : IToolHandler
                     DotnetSdkVersion = envDiag.DotnetSdkVersion
                 },
                 Workspace = workspaceStatus,
-                Capabilities = capabilities,
+                Capabilities = _capabilityProvider(),
                 Errors = errors,
                 Warnings = warnings
             };

--- a/tests/RoslynMcp.Core.Tests/Workspace/DotNetSdkResolverTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Workspace/DotNetSdkResolverTests.cs
@@ -46,6 +46,19 @@ public class DotNetSdkResolverTests
     }
 
     [Fact]
+    public void SelectLatest_OrdersPrereleaseIdentifiersNumerically()
+    {
+        var result = DotNetSdkResolver.SelectLatest(new[]
+        {
+            Path.Combine("dotnet", "sdk", "10.0.100-preview.9"),
+            Path.Combine("dotnet", "sdk", "10.0.100-preview.10")
+        });
+
+        Assert.NotNull(result);
+        Assert.Equal("10.0.100-preview.10", result.Version);
+    }
+
+    [Fact]
     public void SelectLatest_IgnoresNonSdkDirectories()
     {
         var result = DotNetSdkResolver.SelectLatest(new[]

--- a/tests/RoslynMcp.Core.Tests/Workspace/DotNetSdkResolverTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Workspace/DotNetSdkResolverTests.cs
@@ -1,0 +1,60 @@
+using RoslynMcp.Core.Workspace;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Workspace;
+
+public class DotNetSdkResolverTests
+{
+    [Fact]
+    public void SelectLatest_PrefersDotNet10OverDotNet9()
+    {
+        var result = DotNetSdkResolver.SelectLatest(new[]
+        {
+            Path.Combine("dotnet", "sdk", "9.0.311"),
+            Path.Combine("dotnet", "sdk", "10.0.100"),
+            Path.Combine("dotnet", "sdk", "8.0.408")
+        });
+
+        Assert.NotNull(result);
+        Assert.Equal("10.0.100", result.Version);
+    }
+
+    [Fact]
+    public void SelectLatest_SupportsPrereleaseSdkVersions()
+    {
+        var result = DotNetSdkResolver.SelectLatest(new[]
+        {
+            Path.Combine("dotnet", "sdk", "10.0.100"),
+            Path.Combine("dotnet", "sdk", "10.0.200-preview.0.26103.119")
+        });
+
+        Assert.NotNull(result);
+        Assert.Equal("10.0.200-preview.0.26103.119", result.Version);
+    }
+
+    [Fact]
+    public void SelectLatest_PrefersStableSdkForSameNumericVersion()
+    {
+        var result = DotNetSdkResolver.SelectLatest(new[]
+        {
+            Path.Combine("dotnet", "sdk", "10.0.200-preview.0.26103.119"),
+            Path.Combine("dotnet", "sdk", "10.0.200")
+        });
+
+        Assert.NotNull(result);
+        Assert.Equal("10.0.200", result.Version);
+    }
+
+    [Fact]
+    public void SelectLatest_IgnoresNonSdkDirectories()
+    {
+        var result = DotNetSdkResolver.SelectLatest(new[]
+        {
+            Path.Combine("dotnet", "sdk", "metadata"),
+            Path.Combine("dotnet", "sdk", "9.0.311")
+        });
+
+        Assert.NotNull(result);
+        Assert.Equal("9.0.311", result.Version);
+    }
+}

--- a/tests/RoslynMcp.Server.Tests/Tools/DiagnoseToolTests.cs
+++ b/tests/RoslynMcp.Server.Tests/Tools/DiagnoseToolTests.cs
@@ -1,0 +1,51 @@
+using System.Text.Json;
+using RoslynMcp.Core.Workspace;
+using RoslynMcp.Server.Tools;
+using Xunit;
+
+namespace RoslynMcp.Server.Tests.Tools;
+
+public class DiagnoseToolTests
+{
+    [Fact]
+    public async Task ExecuteAsync_ReturnsCapabilitiesFromRegistry()
+    {
+        var capabilities = new[] { "diagnose", "rename_symbol", "search_symbols" };
+        var tool = new DiagnoseTool(
+            new HealthyWorkspaceProvider(),
+            () => capabilities);
+
+        var result = await tool.ExecuteAsync(null);
+        var json = result.Content.Single().Text;
+        Assert.NotNull(json);
+        using var document = JsonDocument.Parse(json);
+        var reportedCapabilities = document.RootElement
+            .GetProperty("capabilities")
+            .EnumerateArray()
+            .Select(item => item.GetString())
+            .ToArray();
+
+        Assert.False(result.IsError);
+        Assert.Equal(capabilities, reportedCapabilities);
+    }
+
+    private sealed class HealthyWorkspaceProvider : IWorkspaceProvider
+    {
+        public Task<WorkspaceContext> CreateContextAsync(
+            string projectOrSolutionPath,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public EnvironmentDiagnostics CheckEnvironment()
+        {
+            return new EnvironmentDiagnostics
+            {
+                MsBuildFound = true,
+                MsBuildVersion = "17.0",
+                DotnetSdkVersion = "10.0.100"
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- report `diagnose.capabilities` from the live MCP and CLI registries
- use the same SDK fallback for environment diagnostics and workspace loading
- discover SDKs through `DOTNET_ROOT`, `DOTNET_HOST_PATH`, standard install roots, and `dotnet --list-sdks`
- compare SDK versions numerically so .NET 10 is selected over .NET 9, including preview SDK support
- add regression coverage for SDK ordering and dynamic capability reporting

Fixes #18
Fixes #20
Fixes #21