### PR TITLE
Add inline_method (extract_method inverse)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Let AI assistants like Claude safely refactor your C# codebase using the same Roslyn compiler platform that powers Visual Studio.
 
-Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that exposes **41 Roslyn-powered tools** to AI assistants and other MCP clients. It combines 19 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 7 code conversion tools -- giving your AI deep code intelligence, comprehensive refactoring, and modern C# syntax transformations with full solution-wide reference tracking and preview support.
+Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that exposes **42 Roslyn-powered tools** to AI assistants and other MCP clients. It combines 20 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 7 code conversion tools -- giving your AI deep code intelligence, comprehensive refactoring, and modern C# syntax transformations with full solution-wide reference tracking and preview support.
 
 ---
 
@@ -30,7 +30,7 @@ Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotoc
 
 ## Why RoslynMcpServer?
 
-- **41 tools** -- refactoring, navigation, analysis, generation, and conversion tools, the most comprehensive Roslyn MCP server available
+- **42 tools** -- refactoring, navigation, analysis, generation, and conversion tools, the most comprehensive Roslyn MCP server available
 - **Preview mode on every operation** -- see exactly what will change before applying
 - **Atomic file writes with rollback** -- if any file write fails, all changes are reverted
 - **Solution-wide reference updates** -- renames and moves propagate across your entire solution
@@ -102,7 +102,7 @@ Claude will use the `rename_symbol` tool to rename the class and update every re
 
 ## Standalone CLI
 
-All 41 tools are also available as a standalone CLI for use in scripts, CI/CD pipelines, and terminals without an AI assistant.
+All 42 tools are also available as a standalone CLI for use in scripts, CI/CD pipelines, and terminals without an AI assistant.
 
 ### Install
 
@@ -206,6 +206,7 @@ All tools accept a `solutionPath` parameter (absolute path to a `.sln`, `.slnx`,
 
 | Tool | Description | Key Parameters |
 |------|-------------|----------------|
+| `inline_method` | Inline a method by replacing call sites with the method body. Optionally remove the method. | `sourceFile`, `methodName`, `line`, `column`, `callSiteLocation`, `removeMethod` |
 | `inline_variable` | Inline a local variable by replacing all usages with its initializer value. | `sourceFile`, `variableName`, `line` |
 
 ### Signature and Encapsulation

--- a/src/RoslynMcp.Cli/RoslynMcp.Cli.csproj
+++ b/src/RoslynMcp.Cli/RoslynMcp.Cli.csproj
@@ -17,7 +17,7 @@
     <Version>0.4.0</Version>
     <Authors>Joshua Ramirez</Authors>
     <Company>RedJay</Company>
-    <Description>Standalone CLI for 41 Roslyn-powered C# refactoring, analysis, and navigation tools.</Description>
+    <Description>Standalone CLI for 42 Roslyn-powered C# refactoring, analysis, and navigation tools.</Description>
     <PackageTags>roslyn;cli;refactoring;csharp;code-analysis</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/JoshuaRamirez/RoslynMcpServer</RepositoryUrl>

--- a/src/RoslynMcp.Cli/ToolRegistry.cs
+++ b/src/RoslynMcp.Cli/ToolRegistry.cs
@@ -46,7 +46,7 @@ public sealed class ToolEntry
 }
 
 /// <summary>
-/// Maps tool names to execution delegates for all 41 Roslyn tools.
+/// Maps tool names to execution delegates for all 42 Roslyn tools.
 /// </summary>
 public sealed class ToolRegistry
 {
@@ -138,7 +138,7 @@ public sealed class ToolRegistry
         _tools.Values.OrderBy(t => t.Category).ThenBy(t => t.Name).ToList();
 
     /// <summary>
-    /// Build the default registry with all 41 tools registered.
+    /// Build the default registry with all 42 tools registered.
     /// </summary>
     public static ToolRegistry BuildDefault()
     {
@@ -162,9 +162,11 @@ public sealed class ToolRegistry
         r.RegisterRefactoring<RenameSymbolOperation, RenameSymbolParams>(
             "rename-symbol", "Rename any C# symbol with automatic reference updates");
 
-        // ── Refactoring: Inline (1) ───────────────────────────────────
+        // ── Refactoring: Inline (2) ───────────────────────────────────
         r.RegisterRefactoring<InlineVariableOperation, InlineVariableParams>(
             "inline-variable", "Inline a variable, replacing all references with its value");
+        r.RegisterRefactoring<InlineMethodOperation, InlineMethodParams>(
+            "inline-method", "Inline a method by replacing call sites with the method body");
 
         // ── Refactoring: Signature (1) ────────────────────────────────
         r.RegisterRefactoring<ChangeSignatureOperation, ChangeSignatureParams>(

--- a/src/RoslynMcp.Contracts/Enums/RefactoringKind.cs
+++ b/src/RoslynMcp.Contracts/Enums/RefactoringKind.cs
@@ -38,6 +38,10 @@ public enum RefactoringKind
     /// <summary>Extract expression to constant.</summary>
     ExtractConstant,
 
+    // Inline Operations
+    /// <summary>Inline a method by replacing call sites with the method body.</summary>
+    InlineMethod,
+
     // Generate Operations
     /// <summary>Generate constructor from fields/properties.</summary>
     GenerateConstructor,

--- a/src/RoslynMcp.Contracts/Errors/ErrorCodes.cs
+++ b/src/RoslynMcp.Contracts/Errors/ErrorCodes.cs
@@ -292,6 +292,18 @@ public static class ErrorCodes
     /// <summary>Cannot inline expression with side effects.</summary>
     public const string CannotInlineSideEffects = "3093";
 
+    /// <summary>Recursive methods cannot be inlined.</summary>
+    public const string MethodIsRecursive = "3094";
+
+    /// <summary>Virtual, override, or abstract methods cannot be inlined.</summary>
+    public const string MethodIsVirtual = "3095";
+
+    /// <summary>Method has no body (abstract, extern, partial declaration, or interface member).</summary>
+    public const string MethodHasNoBody = "3096";
+
+    /// <summary>No call sites found for the method.</summary>
+    public const string NoCallSitesFound = "3097";
+
     // --------------------------------------------
     // Region/Range Errors (3100-3109)
     // --------------------------------------------

--- a/src/RoslynMcp.Contracts/Models/InlineMethodParams.cs
+++ b/src/RoslynMcp.Contracts/Models/InlineMethodParams.cs
@@ -1,0 +1,64 @@
+namespace RoslynMcp.Contracts.Models;
+
+/// <summary>
+/// Parameters for the inline_method tool.
+/// </summary>
+public sealed class InlineMethodParams
+{
+    /// <summary>
+    /// Absolute path to the source file containing the method.
+    /// </summary>
+    public required string SourceFile { get; init; }
+
+    /// <summary>
+    /// Name of the method to inline.
+    /// </summary>
+    public required string MethodName { get; init; }
+
+    /// <summary>
+    /// Line number of the method declaration (1-based). Optional for disambiguation.
+    /// </summary>
+    public int? Line { get; init; }
+
+    /// <summary>
+    /// Column number of the method declaration (1-based). Optional for disambiguation.
+    /// </summary>
+    public int? Column { get; init; }
+
+    /// <summary>
+    /// When set, inline only this call site and leave the method in place.
+    /// </summary>
+    public CallSiteLocation? CallSiteLocation { get; init; }
+
+    /// <summary>
+    /// Remove the method after inlining all call sites. Default: true.
+    /// Ignored when <see cref="CallSiteLocation"/> is set.
+    /// </summary>
+    public bool RemoveMethod { get; init; } = true;
+
+    /// <summary>
+    /// Return computed changes without applying. Default: false.
+    /// </summary>
+    public bool Preview { get; init; }
+}
+
+/// <summary>
+/// Identifies a single call site for partial inlining.
+/// </summary>
+public sealed class CallSiteLocation
+{
+    /// <summary>
+    /// Absolute path to the file containing the call site.
+    /// </summary>
+    public required string File { get; init; }
+
+    /// <summary>
+    /// 1-based line of the call site.
+    /// </summary>
+    public required int Line { get; init; }
+
+    /// <summary>
+    /// 1-based column of the call site.
+    /// </summary>
+    public required int Column { get; init; }
+}

--- a/src/RoslynMcp.Core/Refactoring/Inline/InlineMethodOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Inline/InlineMethodOperation.cs
@@ -1,0 +1,733 @@
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Text;
+using RoslynMcp.Contracts.Enums;
+using RoslynMcp.Contracts.Errors;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.FileSystem;
+using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Workspace;
+
+namespace RoslynMcp.Core.Refactoring.Inline;
+
+/// <summary>
+/// Inlines a method by replacing call sites with the method body and optionally removing the method.
+/// </summary>
+public sealed class InlineMethodOperation : RefactoringOperationBase<InlineMethodParams>
+{
+    private static readonly Regex IdentifierPattern = new(
+        @"^[A-Za-z_][A-Za-z0-9_]*$",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// Creates a new inline method operation.
+    /// </summary>
+    public InlineMethodOperation(WorkspaceContext context) : base(context)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override void ValidateParams(InlineMethodParams @params)
+    {
+        if (string.IsNullOrWhiteSpace(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "sourceFile is required.");
+
+        if (string.IsNullOrWhiteSpace(@params.MethodName))
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "methodName is required.");
+
+        if (!PathResolver.IsAbsolutePath(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.InvalidSourcePath, "sourceFile must be an absolute path.");
+
+        if (!PathResolver.IsValidCSharpFilePath(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.InvalidSourcePath, "sourceFile must be a .cs file.");
+
+        if (!File.Exists(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.SourceFileNotFound, $"Source file not found: {@params.SourceFile}");
+
+        if (!IdentifierPattern.IsMatch(@params.MethodName))
+            throw new RefactoringException(ErrorCodes.InvalidSymbolName, $"'{@params.MethodName}' is not a valid method name.");
+
+        if (@params.Line.HasValue && @params.Line < 1)
+            throw new RefactoringException(ErrorCodes.InvalidLineNumber, "line must be >= 1.");
+
+        if (@params.Column.HasValue && @params.Column < 1)
+            throw new RefactoringException(ErrorCodes.InvalidColumnNumber, "column must be >= 1.");
+
+        if (@params.CallSiteLocation != null)
+        {
+            if (string.IsNullOrWhiteSpace(@params.CallSiteLocation.File))
+                throw new RefactoringException(ErrorCodes.MissingRequiredParam, "callSiteLocation.file is required.");
+
+            if (!PathResolver.IsAbsolutePath(@params.CallSiteLocation.File))
+                throw new RefactoringException(ErrorCodes.InvalidSourcePath, "callSiteLocation.file must be an absolute path.");
+
+            if (!PathResolver.IsValidCSharpFilePath(@params.CallSiteLocation.File))
+                throw new RefactoringException(ErrorCodes.InvalidSourcePath, "callSiteLocation.file must be a .cs file.");
+
+            if (@params.CallSiteLocation.Line < 1)
+                throw new RefactoringException(ErrorCodes.InvalidLineNumber, "callSiteLocation.line must be >= 1.");
+
+            if (@params.CallSiteLocation.Column < 1)
+                throw new RefactoringException(ErrorCodes.InvalidColumnNumber, "callSiteLocation.column must be >= 1.");
+        }
+    }
+
+    /// <inheritdoc />
+    protected override async Task<RefactoringResult> ExecuteCoreAsync(
+        Guid operationId,
+        InlineMethodParams @params,
+        CancellationToken cancellationToken)
+    {
+        var document = GetDocumentOrThrow(@params.SourceFile);
+        var root = await document.GetSyntaxRootAsync(cancellationToken);
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken);
+
+        if (root == null || semanticModel == null)
+        {
+            throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse file.");
+        }
+
+        var methodSyntax = FindMethodDeclaration(root, @params);
+        var methodSymbol = semanticModel.GetDeclaredSymbol(methodSyntax, cancellationToken) as IMethodSymbol
+            ?? throw new RefactoringException(ErrorCodes.RoslynError, "Could not resolve method symbol.");
+
+        ValidateInlineable(methodSyntax, methodSymbol, semanticModel, cancellationToken);
+
+        var callSites = await FindCallSitesAsync(methodSymbol, methodSyntax, document, @params, cancellationToken);
+        if (callSites.Count == 0)
+        {
+            throw new RefactoringException(
+                ErrorCodes.NoCallSitesFound,
+                $"No call sites found for method '{@params.MethodName}'.");
+        }
+
+        var removeMethod = @params.RemoveMethod && @params.CallSiteLocation == null;
+        var newSolution = await ApplyInliningAsync(
+            document,
+            methodSyntax,
+            methodSymbol,
+            callSites,
+            removeMethod,
+            cancellationToken);
+
+        if (@params.Preview)
+        {
+            return await CreatePreviewResultAsync(
+                operationId,
+                @params,
+                document,
+                newSolution,
+                callSites.Count,
+                removeMethod,
+                cancellationToken);
+        }
+
+        var commitResult = await CommitChangesAsync(newSolution, cancellationToken);
+
+        return RefactoringResult.Succeeded(
+            operationId,
+            new FileChanges
+            {
+                FilesModified = commitResult.FilesModified,
+                FilesCreated = commitResult.FilesCreated,
+                FilesDeleted = commitResult.FilesDeleted
+            },
+            new Contracts.Models.SymbolInfo
+            {
+                Name = @params.MethodName,
+                FullyQualifiedName = methodSymbol.ToDisplayString(),
+                Kind = Contracts.Enums.SymbolKind.Method
+            },
+            callSites.Count,
+            0);
+    }
+
+    private static MethodDeclarationSyntax FindMethodDeclaration(SyntaxNode root, InlineMethodParams @params)
+    {
+        var candidates = root.DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .Where(m => m.Identifier.Text == @params.MethodName)
+            .ToList();
+
+        if (candidates.Count == 0)
+        {
+            throw new RefactoringException(
+                ErrorCodes.MethodNotFound,
+                $"Method '{@params.MethodName}' not found.");
+        }
+
+        if (candidates.Count == 1 && !@params.Line.HasValue)
+        {
+            return candidates[0];
+        }
+
+        if (@params.Line.HasValue)
+        {
+            var match = candidates.FirstOrDefault(m =>
+            {
+                var span = m.Identifier.GetLocation().GetLineSpan();
+                var line = span.StartLinePosition.Line + 1;
+                if (line != @params.Line.Value)
+                    return false;
+
+                if (@params.Column.HasValue)
+                {
+                    var column = span.StartLinePosition.Character + 1;
+                    return column == @params.Column.Value;
+                }
+
+                return true;
+            });
+
+            if (match == null)
+            {
+                throw new RefactoringException(
+                    ErrorCodes.MethodNotFound,
+                    $"Method '{@params.MethodName}' not found at line {@params.Line}.");
+            }
+
+            return match;
+        }
+
+        var lines = candidates
+            .Select(m => m.Identifier.GetLocation().GetLineSpan().StartLinePosition.Line + 1)
+            .ToList();
+        throw new RefactoringException(
+            ErrorCodes.SymbolAmbiguous,
+            $"Multiple methods named '{@params.MethodName}' found. Provide line number. Options: {string.Join(", ", lines)}");
+    }
+
+    private static void ValidateInlineable(
+        MethodDeclarationSyntax methodSyntax,
+        IMethodSymbol methodSymbol,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        if (methodSymbol.IsAbstract || methodSymbol.IsExtern ||
+            (methodSyntax.Body == null && methodSyntax.ExpressionBody == null))
+        {
+            throw new RefactoringException(
+                ErrorCodes.MethodHasNoBody,
+                $"Method '{methodSymbol.Name}' has no body and cannot be inlined.");
+        }
+
+        if (methodSymbol.IsVirtual || methodSymbol.IsOverride || methodSymbol.IsAbstract)
+        {
+            throw new RefactoringException(
+                ErrorCodes.MethodIsVirtual,
+                $"Virtual, override, or abstract method '{methodSymbol.Name}' cannot be inlined.");
+        }
+
+        if (IsInterfaceImplementation(methodSymbol))
+        {
+            throw new RefactoringException(
+                ErrorCodes.MethodIsVirtual,
+                $"Method '{methodSymbol.Name}' implements an interface and cannot be inlined.");
+        }
+
+        if (IsRecursive(methodSyntax, methodSymbol, semanticModel, cancellationToken))
+        {
+            throw new RefactoringException(
+                ErrorCodes.MethodIsRecursive,
+                $"Recursive method '{methodSymbol.Name}' cannot be inlined.");
+        }
+    }
+
+    private static bool IsInterfaceImplementation(IMethodSymbol method)
+    {
+        if (method.ExplicitInterfaceImplementations.Length > 0)
+            return true;
+
+        var containingType = method.ContainingType;
+        if (containingType == null)
+            return false;
+
+        foreach (var iface in containingType.AllInterfaces)
+        {
+            foreach (var member in iface.GetMembers().OfType<IMethodSymbol>())
+            {
+                var implementation = containingType.FindImplementationForInterfaceMember(member);
+                if (SymbolEqualityComparer.Default.Equals(implementation, method))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsRecursive(
+        MethodDeclarationSyntax methodSyntax,
+        IMethodSymbol methodSymbol,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        foreach (var invocation in methodSyntax.DescendantNodes().OfType<InvocationExpressionSyntax>())
+        {
+            var invoked = semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol as IMethodSymbol;
+            if (invoked == null)
+                continue;
+
+            if (SymbolEqualityComparer.Default.Equals(invoked.OriginalDefinition, methodSymbol.OriginalDefinition))
+                return true;
+        }
+
+        return false;
+    }
+
+    private async Task<List<CallSite>> FindCallSitesAsync(
+        IMethodSymbol methodSymbol,
+        MethodDeclarationSyntax methodSyntax,
+        Document declaringDocument,
+        InlineMethodParams @params,
+        CancellationToken cancellationToken)
+    {
+        var references = await SymbolFinder.FindReferencesAsync(
+            methodSymbol,
+            Context.Solution,
+            cancellationToken);
+
+        var callSites = new List<CallSite>();
+
+        foreach (var referencedSymbol in references)
+        {
+            foreach (var location in referencedSymbol.Locations)
+            {
+                if (location.Location.Kind != LocationKind.SourceFile)
+                    continue;
+
+                var document = location.Document;
+                var root = await document.GetSyntaxRootAsync(cancellationToken);
+                if (root == null)
+                    continue;
+
+                var node = root.FindNode(location.Location.SourceSpan);
+                var invocation = node.AncestorsAndSelf().OfType<InvocationExpressionSyntax>().FirstOrDefault();
+                if (invocation == null)
+                    continue;
+
+                if (document.Id == declaringDocument.Id && methodSyntax.Span.Contains(invocation.Span))
+                    continue;
+
+                callSites.Add(new CallSite(document, invocation));
+            }
+        }
+
+        if (@params.CallSiteLocation != null)
+        {
+            var targetPath = PathResolver.NormalizePath(@params.CallSiteLocation.File);
+            callSites = callSites
+                .Where(site =>
+                {
+                    if (PathResolver.NormalizePath(site.Document.FilePath ?? "") != targetPath)
+                        return false;
+
+                    var span = site.Invocation.GetLocation().GetLineSpan();
+                    var startLine = span.StartLinePosition.Line + 1;
+                    var startColumn = span.StartLinePosition.Character + 1;
+                    var endLine = span.EndLinePosition.Line + 1;
+                    var endColumn = span.EndLinePosition.Character + 1;
+                    if (@params.CallSiteLocation.Line < startLine || @params.CallSiteLocation.Line > endLine)
+                        return false;
+
+                    if (startLine == endLine)
+                    {
+                        return @params.CallSiteLocation.Column >= startColumn &&
+                               @params.CallSiteLocation.Column <= endColumn;
+                    }
+
+                    if (@params.CallSiteLocation.Line == startLine)
+                        return @params.CallSiteLocation.Column >= startColumn;
+                    if (@params.CallSiteLocation.Line == endLine)
+                        return @params.CallSiteLocation.Column <= endColumn;
+                    return true;
+                })
+                .ToList();
+        }
+
+        return callSites;
+    }
+
+    private static async Task<Solution> ApplyInliningAsync(
+        Document declaringDocument,
+        MethodDeclarationSyntax methodSyntax,
+        IMethodSymbol methodSymbol,
+        IReadOnlyList<CallSite> callSites,
+        bool removeMethod,
+        CancellationToken cancellationToken)
+    {
+        var solution = declaringDocument.Project.Solution;
+        var sitesByDocument = callSites.GroupBy(s => s.Document.Id);
+
+        foreach (var group in sitesByDocument)
+        {
+            var document = solution.GetDocument(group.Key)
+                ?? throw new RefactoringException(ErrorCodes.RoslynError, "Document disappeared from solution.");
+            var root = await document.GetSyntaxRootAsync(cancellationToken)
+                ?? throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse file.");
+
+            var invocations = group.Select(s => s.Invocation).ToList();
+            var rewriter = new InlineCallSiteRewriter(invocations, methodSyntax, methodSymbol);
+            var newRoot = rewriter.Visit(root)
+                ?? throw new RefactoringException(ErrorCodes.RoslynError, "Failed to rewrite call sites.");
+
+            if (removeMethod && document.Id == declaringDocument.Id)
+            {
+                newRoot = RemoveMethodDeclaration(newRoot, methodSyntax.Identifier.Text, methodSyntax.Span);
+            }
+
+            solution = document.WithSyntaxRoot(newRoot).Project.Solution;
+        }
+
+        if (removeMethod && callSites.All(s => s.Document.Id != declaringDocument.Id))
+        {
+            var document = solution.GetDocument(declaringDocument.Id)
+                ?? throw new RefactoringException(ErrorCodes.RoslynError, "Declaring document disappeared from solution.");
+            var root = await document.GetSyntaxRootAsync(cancellationToken)
+                ?? throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse file.");
+            var newRoot = RemoveMethodDeclaration(root, methodSyntax.Identifier.Text, methodSyntax.Span);
+            solution = document.WithSyntaxRoot(newRoot).Project.Solution;
+        }
+
+        return solution;
+    }
+
+    private static SyntaxNode RemoveMethodDeclaration(SyntaxNode root, string methodName, TextSpan originalSpan)
+    {
+        var method = root.DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .FirstOrDefault(m => m.Identifier.Text == methodName && m.Span.Start == originalSpan.Start);
+
+        if (method == null)
+        {
+            method = root.DescendantNodes()
+                .OfType<MethodDeclarationSyntax>()
+                .FirstOrDefault(m => m.Identifier.Text == methodName);
+        }
+
+        if (method == null)
+            return root;
+
+        return root.RemoveNode(method, SyntaxRemoveOptions.KeepDirectives)
+            ?? root;
+    }
+
+    private static async Task<RefactoringResult> CreatePreviewResultAsync(
+        Guid operationId,
+        InlineMethodParams @params,
+        Document originalDocument,
+        Solution newSolution,
+        int callSiteCount,
+        bool removeMethod,
+        CancellationToken cancellationToken)
+    {
+        var pendingChanges = new List<PendingChange>();
+        var originalSolution = originalDocument.Project.Solution;
+
+        foreach (var projectChanges in newSolution.GetChanges(originalSolution).GetProjectChanges())
+        {
+            foreach (var docId in projectChanges.GetChangedDocuments())
+            {
+                var oldDoc = originalSolution.GetDocument(docId);
+                var newDoc = newSolution.GetDocument(docId);
+                if (oldDoc?.FilePath == null || newDoc == null)
+                    continue;
+
+                var before = await oldDoc.GetTextAsync(cancellationToken);
+                var after = await newDoc.GetTextAsync(cancellationToken);
+                pendingChanges.Add(new PendingChange
+                {
+                    File = oldDoc.FilePath,
+                    ChangeType = ChangeKind.Modify,
+                    Description = $"Inline method '{@params.MethodName}' ({callSiteCount} call site(s)" +
+                                  (removeMethod ? ", method removed" : "") + ")",
+                    BeforeSnippet = before.ToString(),
+                    AfterSnippet = after.ToString()
+                });
+            }
+        }
+
+        if (pendingChanges.Count == 0)
+        {
+            pendingChanges.Add(new PendingChange
+            {
+                File = @params.SourceFile,
+                ChangeType = ChangeKind.Modify,
+                Description = $"Inline method '{@params.MethodName}' ({callSiteCount} call site(s))",
+                BeforeSnippet = null,
+                AfterSnippet = null
+            });
+        }
+
+        return RefactoringResult.PreviewResult(operationId, pendingChanges);
+    }
+
+    private sealed record CallSite(Document Document, InvocationExpressionSyntax Invocation);
+
+    private sealed class InlineCallSiteRewriter : CSharpSyntaxRewriter
+    {
+        private readonly HashSet<InvocationExpressionSyntax> _targets;
+        private readonly MethodDeclarationSyntax _methodSyntax;
+        private readonly IMethodSymbol _methodSymbol;
+
+        public InlineCallSiteRewriter(
+            IReadOnlyList<InvocationExpressionSyntax> targets,
+            MethodDeclarationSyntax methodSyntax,
+            IMethodSymbol methodSymbol)
+        {
+            _targets = new HashSet<InvocationExpressionSyntax>(targets);
+            _methodSyntax = methodSyntax;
+            _methodSymbol = methodSymbol;
+        }
+
+        public override SyntaxNode? VisitBlock(BlockSyntax node)
+        {
+            var rewritten = new List<StatementSyntax>();
+            var changed = false;
+
+            foreach (var statement in node.Statements)
+            {
+                if (statement is ExpressionStatementSyntax expressionStatement &&
+                    TryGetTargetInvocation(expressionStatement.Expression, out var invocation))
+                {
+                    var inlined = CreateInlinedStatements(invocation, expressionStatement);
+                    rewritten.AddRange(inlined);
+                    changed = true;
+                    continue;
+                }
+
+                var visited = (StatementSyntax?)base.Visit(statement);
+                if (visited != null)
+                    rewritten.Add(visited);
+                if (!ReferenceEquals(visited, statement))
+                    changed = true;
+            }
+
+            return changed ? node.WithStatements(SyntaxFactory.List(rewritten)) : node;
+        }
+
+        public override SyntaxNode? VisitInvocationExpression(InvocationExpressionSyntax node)
+        {
+            if (!_targets.Contains(node))
+                return base.VisitInvocationExpression(node);
+
+            // Statement-level void calls are handled in VisitBlock.
+            if (node.Parent is ExpressionStatementSyntax)
+                return node;
+
+            var expression = CreateInlinedExpression(node);
+            return ParenthesizeIfNeeded(expression, node.Parent).WithTriviaFrom(node);
+        }
+
+        private bool TryGetTargetInvocation(ExpressionSyntax expression, out InvocationExpressionSyntax invocation)
+        {
+            if (expression is InvocationExpressionSyntax direct && _targets.Contains(direct))
+            {
+                invocation = direct;
+                return true;
+            }
+
+            invocation = null!;
+            return false;
+        }
+
+        private IReadOnlyList<StatementSyntax> CreateInlinedStatements(
+            InvocationExpressionSyntax invocation,
+            ExpressionStatementSyntax originalStatement)
+        {
+            var parameterMap = BuildParameterMap(invocation);
+            var statements = TransformToStatements(parameterMap);
+
+            if (statements.Count == 0)
+                return Array.Empty<StatementSyntax>();
+
+            var result = new List<StatementSyntax>(statements.Count);
+            for (var i = 0; i < statements.Count; i++)
+            {
+                var statement = statements[i].NormalizeWhitespace();
+                if (i == 0)
+                {
+                    statement = statement
+                        .WithLeadingTrivia(originalStatement.GetLeadingTrivia())
+                        .WithTrailingTrivia(originalStatement.GetTrailingTrivia());
+                }
+                else
+                {
+                    statement = statement.WithLeadingTrivia(originalStatement.GetLeadingTrivia());
+                }
+
+                result.Add(statement);
+            }
+
+            return result;
+        }
+
+        private ExpressionSyntax CreateInlinedExpression(InvocationExpressionSyntax invocation)
+        {
+            var parameterMap = BuildParameterMap(invocation);
+            return TransformToExpression(parameterMap);
+        }
+
+        private Dictionary<string, ExpressionSyntax> BuildParameterMap(InvocationExpressionSyntax invocation)
+        {
+            var map = new Dictionary<string, ExpressionSyntax>(StringComparer.Ordinal);
+            var arguments = invocation.ArgumentList.Arguments;
+
+            for (var i = 0; i < _methodSymbol.Parameters.Length; i++)
+            {
+                var parameter = _methodSymbol.Parameters[i];
+                ArgumentSyntax? argument = null;
+
+                foreach (var candidate in arguments)
+                {
+                    if (candidate.NameColon != null &&
+                        candidate.NameColon.Name.Identifier.Text == parameter.Name)
+                    {
+                        argument = candidate;
+                        break;
+                    }
+                }
+
+                if (argument == null && i < arguments.Count && arguments[i].NameColon == null)
+                    argument = arguments[i];
+
+                if (argument != null)
+                {
+                    map[parameter.Name] = argument.Expression;
+                    continue;
+                }
+
+                var defaultSyntax = _methodSyntax.ParameterList.Parameters
+                    .FirstOrDefault(p => p.Identifier.Text == parameter.Name)?
+                    .Default?.Value;
+
+                if (defaultSyntax != null)
+                    map[parameter.Name] = defaultSyntax;
+            }
+
+            return map;
+        }
+
+        private IReadOnlyList<StatementSyntax> TransformToStatements(
+            IReadOnlyDictionary<string, ExpressionSyntax> parameterMap)
+        {
+            if (_methodSyntax.ExpressionBody != null)
+            {
+                var expression = Substitute(_methodSyntax.ExpressionBody.Expression, parameterMap);
+                if (_methodSymbol.ReturnsVoid)
+                    return new[] { SyntaxFactory.ExpressionStatement(expression) };
+
+                return new[] { SyntaxFactory.ExpressionStatement(expression) };
+            }
+
+            var body = _methodSyntax.Body
+                ?? throw new RefactoringException(ErrorCodes.MethodHasNoBody, "Method has no body.");
+
+            var statements = new List<StatementSyntax>();
+            foreach (var statement in body.Statements)
+            {
+                if (statement is ReturnStatementSyntax returnStatement && returnStatement.Expression == null)
+                    continue;
+
+                var substituted = Substitute(statement, parameterMap);
+                if (substituted is ReturnStatementSyntax substitutedReturn && substitutedReturn.Expression != null)
+                {
+                    statements.Add(SyntaxFactory.ExpressionStatement(substitutedReturn.Expression)
+                        .WithTriviaFrom(substitutedReturn));
+                }
+                else
+                {
+                    statements.Add(substituted);
+                }
+            }
+
+            return statements;
+        }
+
+        private ExpressionSyntax TransformToExpression(
+            IReadOnlyDictionary<string, ExpressionSyntax> parameterMap)
+        {
+            if (_methodSyntax.ExpressionBody != null)
+                return Substitute(_methodSyntax.ExpressionBody.Expression, parameterMap);
+
+            var body = _methodSyntax.Body
+                ?? throw new RefactoringException(ErrorCodes.MethodHasNoBody, "Method has no body.");
+
+            var returns = body.Statements.OfType<ReturnStatementSyntax>()
+                .Where(r => r.Expression != null)
+                .ToList();
+
+            if (body.Statements.Count == 1 &&
+                body.Statements[0] is ReturnStatementSyntax singleReturn &&
+                singleReturn.Expression != null)
+            {
+                return Substitute(singleReturn.Expression, parameterMap);
+            }
+
+            if (returns.Count == 1 && body.Statements[^1] == returns[0])
+            {
+                return Substitute(returns[0].Expression!, parameterMap);
+            }
+
+            throw new RefactoringException(
+                ErrorCodes.InvalidSelection,
+                $"Cannot inline method '{_methodSymbol.Name}' as an expression; it does not have a single return.");
+        }
+
+        private static T Substitute<T>(T node, IReadOnlyDictionary<string, ExpressionSyntax> parameterMap)
+            where T : SyntaxNode
+        {
+            var rewriter = new ParameterSubstituter(parameterMap);
+            return (T)rewriter.Visit(node)!;
+        }
+
+        private static ExpressionSyntax ParenthesizeIfNeeded(ExpressionSyntax expression, SyntaxNode? parent)
+        {
+            if (expression is IdentifierNameSyntax or LiteralExpressionSyntax or ParenthesizedExpressionSyntax
+                or InvocationExpressionSyntax or MemberAccessExpressionSyntax)
+            {
+                return expression;
+            }
+
+            if (parent is BinaryExpressionSyntax or MemberAccessExpressionSyntax or ConditionalExpressionSyntax
+                or PrefixUnaryExpressionSyntax or PostfixUnaryExpressionSyntax or ElementAccessExpressionSyntax
+                or AssignmentExpressionSyntax or CastExpressionSyntax)
+            {
+                return SyntaxFactory.ParenthesizedExpression(expression);
+            }
+
+            return expression;
+        }
+    }
+
+    private sealed class ParameterSubstituter : CSharpSyntaxRewriter
+    {
+        private readonly IReadOnlyDictionary<string, ExpressionSyntax> _parameterMap;
+
+        public ParameterSubstituter(IReadOnlyDictionary<string, ExpressionSyntax> parameterMap)
+        {
+            _parameterMap = parameterMap;
+        }
+
+        public override SyntaxNode? VisitIdentifierName(IdentifierNameSyntax node)
+        {
+            if (!_parameterMap.TryGetValue(node.Identifier.Text, out var replacement))
+                return base.VisitIdentifierName(node);
+
+            var needsParens = node.Parent is BinaryExpressionSyntax or MemberAccessExpressionSyntax
+                or ConditionalExpressionSyntax or PrefixUnaryExpressionSyntax
+                or ElementAccessExpressionSyntax or AssignmentExpressionSyntax;
+
+            if (needsParens && replacement is BinaryExpressionSyntax or ConditionalExpressionSyntax
+                or AssignmentExpressionSyntax or PrefixUnaryExpressionSyntax)
+            {
+                return SyntaxFactory.ParenthesizedExpression(replacement.WithoutTrivia())
+                    .WithTriviaFrom(node);
+            }
+
+            return replacement.WithoutTrivia().WithTriviaFrom(node);
+        }
+    }
+}

--- a/src/RoslynMcp.Core/Refactoring/Inline/InlineMethodOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Inline/InlineMethodOperation.cs
@@ -9,6 +9,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 
 namespace RoslynMcp.Core.Refactoring.Inline;
@@ -21,6 +22,8 @@ public sealed class InlineMethodOperation : RefactoringOperationBase<InlineMetho
     private static readonly Regex IdentifierPattern = new(
         @"^[A-Za-z_][A-Za-z0-9_]*$",
         RegexOptions.Compiled);
+
+    private static readonly SyntaxAnnotation TargetMethodAnnotation = new("RoslynMcp.InlineMethod.Target");
 
     /// <summary>
     /// Creates a new inline method operation.
@@ -103,6 +106,8 @@ public sealed class InlineMethodOperation : RefactoringOperationBase<InlineMetho
                 ErrorCodes.NoCallSitesFound,
                 $"No call sites found for method '{@params.MethodName}'.");
         }
+
+        await ValidateCallSitesAsync(methodSyntax, methodSymbol, callSites, cancellationToken);
 
         var removeMethod = @params.RemoveMethod && @params.CallSiteLocation == null;
         var newSolution = await ApplyInliningAsync(
@@ -234,6 +239,38 @@ public sealed class InlineMethodOperation : RefactoringOperationBase<InlineMetho
                 ErrorCodes.MethodIsRecursive,
                 $"Recursive method '{methodSymbol.Name}' cannot be inlined.");
         }
+
+        if (HasUnsupportedControlFlow(methodSyntax))
+        {
+            throw new RefactoringException(
+                ErrorCodes.UnresolvableControlFlow,
+                $"Method '{methodSymbol.Name}' contains nested return, break, continue, goto, or yield and cannot be inlined.");
+        }
+    }
+
+    private static bool HasUnsupportedControlFlow(MethodDeclarationSyntax methodSyntax)
+    {
+        SyntaxNode? body = methodSyntax.Body ?? (SyntaxNode?)methodSyntax.ExpressionBody;
+        if (body == null)
+            return false;
+
+        foreach (var node in body.DescendantNodes())
+        {
+            if (node is YieldStatementSyntax or GotoStatementSyntax
+                or BreakStatementSyntax or ContinueStatementSyntax)
+            {
+                return true;
+            }
+
+            if (node is ReturnStatementSyntax returnStatement &&
+                methodSyntax.Body != null &&
+                returnStatement.Parent != methodSyntax.Body)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static bool IsInterfaceImplementation(IMethodSymbol method)
@@ -304,50 +341,238 @@ public sealed class InlineMethodOperation : RefactoringOperationBase<InlineMetho
                     continue;
 
                 var node = root.FindNode(location.Location.SourceSpan);
-                var invocation = node.AncestorsAndSelf().OfType<InvocationExpressionSyntax>().FirstOrDefault();
-                if (invocation == null)
+                if (IsMethodDeclarationReference(node, methodSyntax, declaringDocument, document, location.Location))
                     continue;
+
+                var invocation = FindInvokedCall(node, location.Location.SourceSpan);
+                if (invocation == null)
+                {
+                    throw new RefactoringException(
+                        ErrorCodes.InvalidSelection,
+                        $"Method '{methodSymbol.Name}' is used as a method group or non-invocation reference and cannot be inlined.");
+                }
+
+                var model = await document.GetSemanticModelAsync(cancellationToken)
+                    ?? throw new RefactoringException(ErrorCodes.RoslynError, "Could not get semantic model.");
+                var invoked = model.GetSymbolInfo(invocation, cancellationToken).Symbol as IMethodSymbol;
+                if (invoked == null ||
+                    !SymbolEqualityComparer.Default.Equals(invoked.OriginalDefinition, methodSymbol.OriginalDefinition))
+                {
+                    throw new RefactoringException(
+                        ErrorCodes.InvalidSelection,
+                        $"Method '{methodSymbol.Name}' is used as a method group or non-invocation reference and cannot be inlined.");
+                }
 
                 if (document.Id == declaringDocument.Id && methodSyntax.Span.Contains(invocation.Span))
                     continue;
 
-                callSites.Add(new CallSite(document, invocation));
+                if (@params.CallSiteLocation != null &&
+                    !MatchesCallSiteLocation(document, invocation, @params.CallSiteLocation))
+                {
+                    continue;
+                }
+
+                callSites.Add(new CallSite(document, invocation.Span));
             }
         }
 
-        if (@params.CallSiteLocation != null)
+        return callSites;
+    }
+
+    private static bool IsMethodDeclarationReference(
+        SyntaxNode node,
+        MethodDeclarationSyntax methodSyntax,
+        Document declaringDocument,
+        Document document,
+        Location location)
+    {
+        if (document.Id != declaringDocument.Id)
+            return false;
+
+        if (methodSyntax.Identifier.Span.Contains(location.SourceSpan) ||
+            location.SourceSpan.Contains(methodSyntax.Identifier.Span))
         {
-            var targetPath = PathResolver.NormalizePath(@params.CallSiteLocation.File);
-            callSites = callSites
-                .Where(site =>
-                {
-                    if (PathResolver.NormalizePath(site.Document.FilePath ?? "") != targetPath)
-                        return false;
-
-                    var span = site.Invocation.GetLocation().GetLineSpan();
-                    var startLine = span.StartLinePosition.Line + 1;
-                    var startColumn = span.StartLinePosition.Character + 1;
-                    var endLine = span.EndLinePosition.Line + 1;
-                    var endColumn = span.EndLinePosition.Character + 1;
-                    if (@params.CallSiteLocation.Line < startLine || @params.CallSiteLocation.Line > endLine)
-                        return false;
-
-                    if (startLine == endLine)
-                    {
-                        return @params.CallSiteLocation.Column >= startColumn &&
-                               @params.CallSiteLocation.Column <= endColumn;
-                    }
-
-                    if (@params.CallSiteLocation.Line == startLine)
-                        return @params.CallSiteLocation.Column >= startColumn;
-                    if (@params.CallSiteLocation.Line == endLine)
-                        return @params.CallSiteLocation.Column <= endColumn;
-                    return true;
-                })
-                .ToList();
+            return true;
         }
 
-        return callSites;
+        return node.AncestorsAndSelf().OfType<MethodDeclarationSyntax>()
+            .Any(m => m.Identifier.Span == methodSyntax.Identifier.Span);
+    }
+
+    private static InvocationExpressionSyntax? FindInvokedCall(SyntaxNode node, TextSpan referenceSpan)
+    {
+        var invocation = node.AncestorsAndSelf().OfType<InvocationExpressionSyntax>().FirstOrDefault();
+        if (invocation == null)
+            return null;
+
+        var invokedName = invocation.Expression switch
+        {
+            IdentifierNameSyntax identifier => (SyntaxNode)identifier,
+            GenericNameSyntax generic => generic,
+            MemberAccessExpressionSyntax memberAccess => memberAccess.Name,
+            MemberBindingExpressionSyntax memberBinding => memberBinding.Name,
+            _ => invocation.Expression
+        };
+
+        if (invokedName.Span.Contains(referenceSpan) || referenceSpan.Contains(invokedName.Span))
+            return invocation;
+
+        return null;
+    }
+
+    private static bool MatchesCallSiteLocation(
+        Document document,
+        InvocationExpressionSyntax invocation,
+        CallSiteLocation location)
+    {
+        if (PathResolver.NormalizePath(document.FilePath ?? "") != PathResolver.NormalizePath(location.File))
+            return false;
+
+        var span = invocation.GetLocation().GetLineSpan();
+        var startLine = span.StartLinePosition.Line + 1;
+        var startColumn = span.StartLinePosition.Character + 1;
+        var endLine = span.EndLinePosition.Line + 1;
+        var endColumn = span.EndLinePosition.Character + 1;
+        if (location.Line < startLine || location.Line > endLine)
+            return false;
+
+        if (startLine == endLine)
+        {
+            return location.Column >= startColumn && location.Column <= endColumn;
+        }
+
+        if (location.Line == startLine)
+            return location.Column >= startColumn;
+        if (location.Line == endLine)
+            return location.Column <= endColumn;
+        return true;
+    }
+
+    private static async Task ValidateCallSitesAsync(
+        MethodDeclarationSyntax methodSyntax,
+        IMethodSymbol methodSymbol,
+        IReadOnlyList<CallSite> callSites,
+        CancellationToken cancellationToken)
+    {
+        var usageCounts = CountParameterUsages(methodSyntax, methodSymbol);
+
+        foreach (var site in callSites)
+        {
+            var root = await site.Document.GetSyntaxRootAsync(cancellationToken)
+                ?? throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse file.");
+            var invocation = RematchInvocation(root, site.Span)
+                ?? throw new RefactoringException(ErrorCodes.RoslynError, "Call site disappeared from document.");
+            var model = await site.Document.GetSemanticModelAsync(cancellationToken)
+                ?? throw new RefactoringException(ErrorCodes.RoslynError, "Could not get semantic model.");
+
+            ValidateReceiver(methodSymbol, invocation);
+            ValidateArgumentEvaluation(methodSyntax, methodSymbol, invocation, model, usageCounts);
+        }
+    }
+
+    private static void ValidateReceiver(IMethodSymbol methodSymbol, InvocationExpressionSyntax invocation)
+    {
+        if (methodSymbol.IsStatic)
+            return;
+
+        var receiver = invocation.Expression switch
+        {
+            MemberAccessExpressionSyntax memberAccess => memberAccess.Expression,
+            MemberBindingExpressionSyntax => invocation.Parent,
+            _ => null
+        };
+
+        if (receiver == null || receiver is ThisExpressionSyntax)
+            return;
+
+        throw new RefactoringException(
+            ErrorCodes.InvalidSelection,
+            $"Cannot inline instance method '{methodSymbol.Name}' at a call site with a different receiver.");
+    }
+
+    private static void ValidateArgumentEvaluation(
+        MethodDeclarationSyntax methodSyntax,
+        IMethodSymbol methodSymbol,
+        InvocationExpressionSyntax invocation,
+        SemanticModel model,
+        IReadOnlyDictionary<string, int> usageCounts)
+    {
+        var arguments = MapArguments(methodSyntax, methodSymbol, invocation);
+        foreach (var (parameterName, expression) in arguments)
+        {
+            usageCounts.TryGetValue(parameterName, out var uses);
+            var safe = MemberAnalyzer.IsSafeToInline(expression, model);
+            if (safe)
+                continue;
+
+            if (uses != 1)
+            {
+                throw new RefactoringException(
+                    ErrorCodes.CannotInlineSideEffects,
+                    $"Cannot inline method '{methodSymbol.Name}': argument for '{parameterName}' has side effects and is not used exactly once.");
+            }
+        }
+    }
+
+    private static Dictionary<string, ExpressionSyntax> MapArguments(
+        MethodDeclarationSyntax methodSyntax,
+        IMethodSymbol methodSymbol,
+        InvocationExpressionSyntax invocation)
+    {
+        var map = new Dictionary<string, ExpressionSyntax>(StringComparer.Ordinal);
+        var arguments = invocation.ArgumentList.Arguments;
+
+        for (var i = 0; i < methodSymbol.Parameters.Length; i++)
+        {
+            var parameter = methodSymbol.Parameters[i];
+            ArgumentSyntax? argument = null;
+
+            foreach (var candidate in arguments)
+            {
+                if (candidate.NameColon != null &&
+                    candidate.NameColon.Name.Identifier.Text == parameter.Name)
+                {
+                    argument = candidate;
+                    break;
+                }
+            }
+
+            if (argument == null && i < arguments.Count && arguments[i].NameColon == null)
+                argument = arguments[i];
+
+            if (argument != null)
+            {
+                map[parameter.Name] = argument.Expression;
+                continue;
+            }
+
+            var defaultSyntax = methodSyntax.ParameterList.Parameters
+                .FirstOrDefault(p => p.Identifier.Text == parameter.Name)?
+                .Default?.Value;
+
+            if (defaultSyntax != null)
+                map[parameter.Name] = defaultSyntax;
+        }
+
+        return map;
+    }
+
+    private static Dictionary<string, int> CountParameterUsages(
+        MethodDeclarationSyntax methodSyntax,
+        IMethodSymbol methodSymbol)
+    {
+        var counts = methodSymbol.Parameters.ToDictionary(p => p.Name, _ => 0, StringComparer.Ordinal);
+        SyntaxNode? body = methodSyntax.Body ?? (SyntaxNode?)methodSyntax.ExpressionBody;
+        if (body == null)
+            return counts;
+
+        foreach (var identifier in body.DescendantNodes().OfType<IdentifierNameSyntax>())
+        {
+            if (counts.ContainsKey(identifier.Identifier.Text))
+                counts[identifier.Identifier.Text]++;
+        }
+
+        return counts;
     }
 
     private static async Task<Solution> ApplyInliningAsync(
@@ -359,8 +584,17 @@ public sealed class InlineMethodOperation : RefactoringOperationBase<InlineMetho
         CancellationToken cancellationToken)
     {
         var solution = declaringDocument.Project.Solution;
-        var sitesByDocument = callSites.GroupBy(s => s.Document.Id);
 
+        var declaringRoot = await declaringDocument.GetSyntaxRootAsync(cancellationToken)
+            ?? throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse file.");
+        var currentMethod = RematchMethod(declaringRoot, methodSyntax)
+            ?? throw new RefactoringException(ErrorCodes.RoslynError, "Method declaration disappeared.");
+        declaringRoot = declaringRoot.ReplaceNode(
+            currentMethod,
+            currentMethod.WithAdditionalAnnotations(TargetMethodAnnotation));
+        solution = declaringDocument.WithSyntaxRoot(declaringRoot).Project.Solution;
+
+        var sitesByDocument = callSites.GroupBy(s => s.Document.Id);
         foreach (var group in sitesByDocument)
         {
             var document = solution.GetDocument(group.Key)
@@ -368,14 +602,14 @@ public sealed class InlineMethodOperation : RefactoringOperationBase<InlineMetho
             var root = await document.GetSyntaxRootAsync(cancellationToken)
                 ?? throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse file.");
 
-            var invocations = group.Select(s => s.Invocation).ToList();
+            var invocations = RematchInvocations(root, group.Select(s => s.Span));
             var rewriter = new InlineCallSiteRewriter(invocations, methodSyntax, methodSymbol);
             var newRoot = rewriter.Visit(root)
                 ?? throw new RefactoringException(ErrorCodes.RoslynError, "Failed to rewrite call sites.");
 
             if (removeMethod && document.Id == declaringDocument.Id)
             {
-                newRoot = RemoveMethodDeclaration(newRoot, methodSyntax.Identifier.Text, methodSyntax.Span);
+                newRoot = RemoveAnnotatedMethod(newRoot, methodSyntax.Identifier.Text);
             }
 
             solution = document.WithSyntaxRoot(newRoot).Project.Solution;
@@ -387,31 +621,60 @@ public sealed class InlineMethodOperation : RefactoringOperationBase<InlineMetho
                 ?? throw new RefactoringException(ErrorCodes.RoslynError, "Declaring document disappeared from solution.");
             var root = await document.GetSyntaxRootAsync(cancellationToken)
                 ?? throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse file.");
-            var newRoot = RemoveMethodDeclaration(root, methodSyntax.Identifier.Text, methodSyntax.Span);
+            var newRoot = RemoveAnnotatedMethod(root, methodSyntax.Identifier.Text);
             solution = document.WithSyntaxRoot(newRoot).Project.Solution;
         }
 
         return solution;
     }
 
-    private static SyntaxNode RemoveMethodDeclaration(SyntaxNode root, string methodName, TextSpan originalSpan)
+    private static MethodDeclarationSyntax? RematchMethod(SyntaxNode root, MethodDeclarationSyntax original)
     {
-        var method = root.DescendantNodes()
+        return root.DescendantNodes()
             .OfType<MethodDeclarationSyntax>()
-            .FirstOrDefault(m => m.Identifier.Text == methodName && m.Span.Start == originalSpan.Start);
+            .FirstOrDefault(m => m.Span == original.Span && m.Identifier.Text == original.Identifier.Text);
+    }
 
-        if (method == null)
+    private static List<InvocationExpressionSyntax> RematchInvocations(SyntaxNode root, IEnumerable<TextSpan> spans)
+    {
+        var spanSet = spans.ToHashSet();
+        return root.DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .Where(invocation => spanSet.Contains(invocation.Span))
+            .ToList();
+    }
+
+    private static InvocationExpressionSyntax? RematchInvocation(SyntaxNode root, TextSpan span)
+    {
+        return root.DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .FirstOrDefault(invocation => invocation.Span == span);
+    }
+
+    private static SyntaxNode RemoveAnnotatedMethod(SyntaxNode root, string methodName)
+    {
+        var annotated = root.GetAnnotatedNodes(TargetMethodAnnotation)
+            .OfType<MethodDeclarationSyntax>()
+            .ToList();
+
+        if (annotated.Count == 1)
         {
-            method = root.DescendantNodes()
-                .OfType<MethodDeclarationSyntax>()
-                .FirstOrDefault(m => m.Identifier.Text == methodName);
+            return root.RemoveNode(annotated[0], SyntaxRemoveOptions.KeepDirectives) ?? root;
         }
 
-        if (method == null)
-            return root;
+        var sameName = root.DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .Where(m => m.Identifier.Text == methodName)
+            .ToList();
 
-        return root.RemoveNode(method, SyntaxRemoveOptions.KeepDirectives)
-            ?? root;
+        if (sameName.Count != 1)
+        {
+            throw new RefactoringException(
+                ErrorCodes.SymbolAmbiguous,
+                $"Could not uniquely identify method '{methodName}' to remove after inlining. Provide a line number to select the overload.");
+        }
+
+        return root.RemoveNode(sameName[0], SyntaxRemoveOptions.KeepDirectives) ?? root;
     }
 
     private static async Task<RefactoringResult> CreatePreviewResultAsync(
@@ -464,7 +727,7 @@ public sealed class InlineMethodOperation : RefactoringOperationBase<InlineMetho
         return RefactoringResult.PreviewResult(operationId, pendingChanges);
     }
 
-    private sealed record CallSite(Document Document, InvocationExpressionSyntax Invocation);
+    private sealed record CallSite(Document Document, TextSpan Span);
 
     private sealed class InlineCallSiteRewriter : CSharpSyntaxRewriter
     {
@@ -508,12 +771,30 @@ public sealed class InlineMethodOperation : RefactoringOperationBase<InlineMetho
             return changed ? node.WithStatements(SyntaxFactory.List(rewritten)) : node;
         }
 
+        public override SyntaxNode? VisitExpressionStatement(ExpressionStatementSyntax node)
+        {
+            if (!TryGetTargetInvocation(node.Expression, out var invocation))
+                return base.VisitExpressionStatement(node);
+
+            // In-block calls are spliced by VisitBlock so multiple statements stay in the caller block.
+            if (node.Parent is BlockSyntax)
+                return node;
+
+            var inlined = CreateInlinedStatements(invocation, node);
+            if (inlined.Count == 0)
+                return SyntaxFactory.Block().WithTriviaFrom(node);
+            if (inlined.Count == 1)
+                return inlined[0];
+
+            return SyntaxFactory.Block(inlined);
+        }
+
         public override SyntaxNode? VisitInvocationExpression(InvocationExpressionSyntax node)
         {
             if (!_targets.Contains(node))
                 return base.VisitInvocationExpression(node);
 
-            // Statement-level void calls are handled in VisitBlock.
+            // Statement-level calls are handled in VisitBlock / VisitExpressionStatement.
             if (node.Parent is ExpressionStatementSyntax)
                 return node;
 
@@ -537,7 +818,7 @@ public sealed class InlineMethodOperation : RefactoringOperationBase<InlineMetho
             InvocationExpressionSyntax invocation,
             ExpressionStatementSyntax originalStatement)
         {
-            var parameterMap = BuildParameterMap(invocation);
+            var parameterMap = MapArguments(_methodSyntax, _methodSymbol, invocation);
             var statements = TransformToStatements(parameterMap);
 
             if (statements.Count == 0)
@@ -566,48 +847,8 @@ public sealed class InlineMethodOperation : RefactoringOperationBase<InlineMetho
 
         private ExpressionSyntax CreateInlinedExpression(InvocationExpressionSyntax invocation)
         {
-            var parameterMap = BuildParameterMap(invocation);
+            var parameterMap = MapArguments(_methodSyntax, _methodSymbol, invocation);
             return TransformToExpression(parameterMap);
-        }
-
-        private Dictionary<string, ExpressionSyntax> BuildParameterMap(InvocationExpressionSyntax invocation)
-        {
-            var map = new Dictionary<string, ExpressionSyntax>(StringComparer.Ordinal);
-            var arguments = invocation.ArgumentList.Arguments;
-
-            for (var i = 0; i < _methodSymbol.Parameters.Length; i++)
-            {
-                var parameter = _methodSymbol.Parameters[i];
-                ArgumentSyntax? argument = null;
-
-                foreach (var candidate in arguments)
-                {
-                    if (candidate.NameColon != null &&
-                        candidate.NameColon.Name.Identifier.Text == parameter.Name)
-                    {
-                        argument = candidate;
-                        break;
-                    }
-                }
-
-                if (argument == null && i < arguments.Count && arguments[i].NameColon == null)
-                    argument = arguments[i];
-
-                if (argument != null)
-                {
-                    map[parameter.Name] = argument.Expression;
-                    continue;
-                }
-
-                var defaultSyntax = _methodSyntax.ParameterList.Parameters
-                    .FirstOrDefault(p => p.Identifier.Text == parameter.Name)?
-                    .Default?.Value;
-
-                if (defaultSyntax != null)
-                    map[parameter.Name] = defaultSyntax;
-            }
-
-            return map;
         }
 
         private IReadOnlyList<StatementSyntax> TransformToStatements(
@@ -616,9 +857,6 @@ public sealed class InlineMethodOperation : RefactoringOperationBase<InlineMetho
             if (_methodSyntax.ExpressionBody != null)
             {
                 var expression = Substitute(_methodSyntax.ExpressionBody.Expression, parameterMap);
-                if (_methodSymbol.ReturnsVoid)
-                    return new[] { SyntaxFactory.ExpressionStatement(expression) };
-
                 return new[] { SyntaxFactory.ExpressionStatement(expression) };
             }
 
@@ -655,10 +893,6 @@ public sealed class InlineMethodOperation : RefactoringOperationBase<InlineMetho
             var body = _methodSyntax.Body
                 ?? throw new RefactoringException(ErrorCodes.MethodHasNoBody, "Method has no body.");
 
-            var returns = body.Statements.OfType<ReturnStatementSyntax>()
-                .Where(r => r.Expression != null)
-                .ToList();
-
             if (body.Statements.Count == 1 &&
                 body.Statements[0] is ReturnStatementSyntax singleReturn &&
                 singleReturn.Expression != null)
@@ -666,14 +900,9 @@ public sealed class InlineMethodOperation : RefactoringOperationBase<InlineMetho
                 return Substitute(singleReturn.Expression, parameterMap);
             }
 
-            if (returns.Count == 1 && body.Statements[^1] == returns[0])
-            {
-                return Substitute(returns[0].Expression!, parameterMap);
-            }
-
             throw new RefactoringException(
                 ErrorCodes.InvalidSelection,
-                $"Cannot inline method '{_methodSymbol.Name}' as an expression; it does not have a single return.");
+                $"Cannot inline method '{_methodSymbol.Name}' as an expression; only a return-only or expression-bodied method is supported.");
         }
 
         private static T Substitute<T>(T node, IReadOnlyDictionary<string, ExpressionSyntax> parameterMap)
@@ -693,7 +922,7 @@ public sealed class InlineMethodOperation : RefactoringOperationBase<InlineMetho
 
             if (parent is BinaryExpressionSyntax or MemberAccessExpressionSyntax or ConditionalExpressionSyntax
                 or PrefixUnaryExpressionSyntax or PostfixUnaryExpressionSyntax or ElementAccessExpressionSyntax
-                or AssignmentExpressionSyntax or CastExpressionSyntax)
+                or AssignmentExpressionSyntax or CastExpressionSyntax or AwaitExpressionSyntax)
             {
                 return SyntaxFactory.ParenthesizedExpression(expression);
             }
@@ -718,7 +947,7 @@ public sealed class InlineMethodOperation : RefactoringOperationBase<InlineMetho
 
             var needsParens = node.Parent is BinaryExpressionSyntax or MemberAccessExpressionSyntax
                 or ConditionalExpressionSyntax or PrefixUnaryExpressionSyntax
-                or ElementAccessExpressionSyntax or AssignmentExpressionSyntax;
+                or ElementAccessExpressionSyntax or AssignmentExpressionSyntax or AwaitExpressionSyntax;
 
             if (needsParens && replacement is BinaryExpressionSyntax or ConditionalExpressionSyntax
                 or AssignmentExpressionSyntax or PrefixUnaryExpressionSyntax)

--- a/src/RoslynMcp.Server/McpServerHost.cs
+++ b/src/RoslynMcp.Server/McpServerHost.cs
@@ -43,6 +43,7 @@ public sealed class McpServerHost : IAsyncDisposable
         _toolRegistry.Register(new GenerateOverridesTool(workspaceProvider));
         _toolRegistry.Register(new ExtractVariableTool(workspaceProvider));
         _toolRegistry.Register(new InlineVariableTool(workspaceProvider));
+        _toolRegistry.Register(new InlineMethodTool(workspaceProvider));
         _toolRegistry.Register(new ExtractConstantTool(workspaceProvider));
         _toolRegistry.Register(new ChangeSignatureTool(workspaceProvider));
         _toolRegistry.Register(new EncapsulateFieldTool(workspaceProvider));

--- a/src/RoslynMcp.Server/RoslynMcp.Server.csproj
+++ b/src/RoslynMcp.Server/RoslynMcp.Server.csproj
@@ -18,7 +18,7 @@
     <Version>0.4.0</Version>
     <Authors>Joshua Ramirez</Authors>
     <Company>RedJay</Company>
-    <Description>MCP Server for Roslyn-powered C# refactoring operations. Install as a global tool to use with Claude Code, Claude Desktop, or other MCP clients. Provides 41 tools: 19 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 7 code conversion tools.</Description>
+    <Description>MCP Server for Roslyn-powered C# refactoring operations. Install as a global tool to use with Claude Code, Claude Desktop, or other MCP clients. Provides 42 tools: 20 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 7 code conversion tools.</Description>
     <PackageTags>roslyn;mcp;refactoring;csharp;model-context-protocol;code-analysis;dotnet;ai-tools;claude</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/JoshuaRamirez/RoslynMcpServer</RepositoryUrl>

--- a/src/RoslynMcp.Server/Tools/InlineMethodTool.cs
+++ b/src/RoslynMcp.Server/Tools/InlineMethodTool.cs
@@ -1,0 +1,174 @@
+using System.Text.Json;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.Refactoring;
+using RoslynMcp.Core.Refactoring.Inline;
+using RoslynMcp.Core.Workspace;
+using RoslynMcp.Server.Transport;
+
+namespace RoslynMcp.Server.Tools;
+
+/// <summary>
+/// MCP tool handler for inline_method operation.
+/// </summary>
+public sealed class InlineMethodTool : IToolHandler
+{
+    private readonly IWorkspaceProvider _workspaceProvider;
+    private readonly JsonSerializerOptions _jsonOptions;
+
+    /// <summary>
+    /// Creates a new inline method tool.
+    /// </summary>
+    public InlineMethodTool(IWorkspaceProvider workspaceProvider)
+    {
+        _workspaceProvider = workspaceProvider;
+        _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = false
+        };
+    }
+
+    /// <inheritdoc />
+    public string Name => "inline_method";
+
+    /// <inheritdoc />
+    public string Description => "Inline a method by replacing call sites with the method body. Optionally remove the method.";
+
+    /// <inheritdoc />
+    public object InputSchema => new
+    {
+        type = "object",
+        required = new[] { "solutionPath", "sourceFile", "methodName" },
+        properties = new
+        {
+            solutionPath = new
+            {
+                type = "string",
+                description = "Absolute path to the .sln or .csproj file"
+            },
+            sourceFile = new
+            {
+                type = "string",
+                description = "Absolute path to the source file containing the method"
+            },
+            methodName = new
+            {
+                type = "string",
+                description = "Name of the method to inline"
+            },
+            line = new
+            {
+                type = "integer",
+                description = "Line number of the method declaration (1-based). Optional for disambiguation."
+            },
+            column = new
+            {
+                type = "integer",
+                description = "Column number of the method declaration (1-based). Optional for disambiguation."
+            },
+            callSiteLocation = new
+            {
+                type = "object",
+                description = "When set, inline only this call site and leave the method in place.",
+                properties = new
+                {
+                    file = new
+                    {
+                        type = "string",
+                        description = "Absolute path to the file containing the call site"
+                    },
+                    line = new
+                    {
+                        type = "integer",
+                        description = "1-based line of the call site"
+                    },
+                    column = new
+                    {
+                        type = "integer",
+                        description = "1-based column of the call site"
+                    }
+                },
+                required = new[] { "file", "line", "column" }
+            },
+            removeMethod = new
+            {
+                type = "boolean",
+                description = "Remove the method after inlining all call sites",
+                @default = true
+            },
+            preview = new
+            {
+                type = "boolean",
+                description = "Return computed changes without applying",
+                @default = false
+            }
+        },
+        additionalProperties = false
+    };
+
+    /// <inheritdoc />
+    public async Task<ToolResult> ExecuteAsync(JsonElement? arguments, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (arguments == null)
+            {
+                return ToolResult.Error("Arguments required");
+            }
+
+            var args = JsonSerializer.Deserialize<InlineMethodArgs>(arguments.Value.GetRawText(), _jsonOptions);
+            if (args == null)
+            {
+                return ToolResult.Error("Failed to parse arguments");
+            }
+
+            using var context = await _workspaceProvider.CreateContextAsync(
+                args.SolutionPath,
+                cancellationToken);
+
+            var operation = new InlineMethodOperation(context);
+            var @params = new InlineMethodParams
+            {
+                SourceFile = args.SourceFile,
+                MethodName = args.MethodName,
+                Line = args.Line,
+                Column = args.Column,
+                CallSiteLocation = args.CallSiteLocation,
+                RemoveMethod = args.RemoveMethod ?? true,
+                Preview = args.Preview ?? false
+            };
+
+            var result = await operation.ExecuteAsync(@params, cancellationToken);
+
+            var json = JsonSerializer.Serialize(result, _jsonOptions);
+            return result.Success ? ToolResult.Success(json) : ToolResult.Error(json);
+        }
+        catch (RefactoringException ex)
+        {
+            var error = ex.ToError();
+            var json = JsonSerializer.Serialize(new { success = false, error }, _jsonOptions);
+            return ToolResult.Error(json);
+        }
+        catch (Exception ex)
+        {
+            var json = JsonSerializer.Serialize(new
+            {
+                success = false,
+                error = new { code = "INTERNAL_ERROR", message = ex.Message }
+            }, _jsonOptions);
+            return ToolResult.Error(json);
+        }
+    }
+
+    private sealed class InlineMethodArgs
+    {
+        public string SolutionPath { get; init; } = "";
+        public string SourceFile { get; init; } = "";
+        public string MethodName { get; init; } = "";
+        public int? Line { get; init; }
+        public int? Column { get; init; }
+        public CallSiteLocation? CallSiteLocation { get; init; }
+        public bool? RemoveMethod { get; init; }
+        public bool? Preview { get; init; }
+    }
+}

--- a/tests/RoslynMcp.Cli.Tests/HelpGeneratorTests.cs
+++ b/tests/RoslynMcp.Cli.Tests/HelpGeneratorTests.cs
@@ -15,11 +15,12 @@ public class HelpGeneratorTests
     }
 
     [Fact]
-    public void GenerateGlobalHelp_Lists41Tools()
+    public void GenerateGlobalHelp_Lists42Tools()
     {
         var registry = ToolRegistry.BuildDefault();
         var help = HelpGenerator.GenerateGlobalHelp(registry);
-        Assert.Contains("Total: 41 tools", help);
+        Assert.Contains("Total: 42 tools", help);
+        Assert.Contains("inline-method", help);
     }
 
     [Fact]

--- a/tests/RoslynMcp.Cli.Tests/ToolRegistryTests.cs
+++ b/tests/RoslynMcp.Cli.Tests/ToolRegistryTests.cs
@@ -6,11 +6,11 @@ namespace RoslynMcp.Cli.Tests;
 public class ToolRegistryTests
 {
     [Fact]
-    public void BuildDefault_Registers41Tools()
+    public void BuildDefault_Registers42Tools()
     {
         var registry = ToolRegistry.BuildDefault();
         var tools = registry.GetAllTools();
-        Assert.Equal(41, tools.Count);
+        Assert.Equal(42, tools.Count);
     }
 
     [Fact]
@@ -83,6 +83,7 @@ public class ToolRegistryTests
 
     [Theory]
     [InlineData("extract-method", "Refactoring")]
+    [InlineData("inline-method", "Refactoring")]
     [InlineData("find-references", "Query")]
     [InlineData("get-diagnostics", "Query")]
     [InlineData("diagnose", "Diagnostic")]
@@ -101,11 +102,11 @@ public class ToolRegistryTests
     }
 
     [Fact]
-    public void RefactoringToolCount_Is28()
+    public void RefactoringToolCount_Is29()
     {
         var registry = ToolRegistry.BuildDefault();
         var count = registry.GetAllTools().Count(t => t.Category == "Refactoring");
-        Assert.Equal(28, count);
+        Assert.Equal(29, count);
     }
 
     [Fact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Inline/InlineMethodOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Inline/InlineMethodOperationTests.cs
@@ -415,9 +415,314 @@ public class InlineMethodOperationTests
         Assert.Equal(ErrorCodes.NoCallSitesFound, ex.ErrorCode);
     }
 
+    [SkippableFact]
+    public async Task InlineMethod_UnbracedIfCall_ReplacesStatementAndRemovesMethod()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                private void Log(string message)
+                {
+                    System.Console.WriteLine(message);
+                }
+
+                public void Run(bool flag)
+                {
+                    if (flag)
+                        Log("one");
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new InlineMethodOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new InlineMethodParams
+        {
+            SourceFile = workspace.SourcePath,
+            MethodName = "Log"
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.DoesNotContain("void Log", text);
+        Assert.Contains(@"System.Console.WriteLine(""one"")", text);
+        Assert.DoesNotContain(@"Log(""one"")", text);
+    }
+
+    [SkippableFact]
+    public async Task InlineMethod_SideEffectArgumentUsedTwice_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                private int Next() => 1;
+
+                private int Twice(int value) => value + value;
+
+                public int Run()
+                {
+                    return Twice(Next());
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new InlineMethodOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new InlineMethodParams
+            {
+                SourceFile = workspace.SourcePath,
+                MethodName = "Twice"
+            }));
+
+        Assert.Equal(ErrorCodes.CannotInlineSideEffects, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task InlineMethod_ForeignReceiver_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                private int _value = 1;
+
+                private int GetValue() => _value;
+
+                public int Run()
+                {
+                    var other = new Calculator();
+                    return other.GetValue();
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new InlineMethodOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new InlineMethodParams
+            {
+                SourceFile = workspace.SourcePath,
+                MethodName = "GetValue"
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidSelection, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task InlineMethod_StatementsBeforeReturnUsedAsExpression_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                private int Get()
+                {
+                    System.Console.WriteLine("x");
+                    return 1;
+                }
+
+                public int Run()
+                {
+                    return Get();
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new InlineMethodOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new InlineMethodParams
+            {
+                SourceFile = workspace.SourcePath,
+                MethodName = "Get"
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidSelection, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task InlineMethod_MethodGroupReference_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                private int Convert(int value) => value * 2;
+
+                public int Run()
+                {
+                    var items = new[] { 1 };
+                    var projected = System.Linq.Enumerable.Select(items, Convert);
+                    return Convert(3);
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new InlineMethodOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new InlineMethodParams
+            {
+                SourceFile = workspace.SourcePath,
+                MethodName = "Convert"
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidSelection, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task InlineMethod_NestedReturn_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                private void Log(string message)
+                {
+                    if (message == null)
+                        return;
+                    System.Console.WriteLine(message);
+                }
+
+                public void Run()
+                {
+                    Log("one");
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new InlineMethodOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new InlineMethodParams
+            {
+                SourceFile = workspace.SourcePath,
+                MethodName = "Log"
+            }));
+
+        Assert.Equal(ErrorCodes.UnresolvableControlFlow, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task InlineMethod_Overload_RemovesOnlySelectedMethod()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                private void Log(string message)
+                {
+                    System.Console.WriteLine(message);
+                }
+
+                private void Log(int value)
+                {
+                    System.Console.WriteLine(value);
+                }
+
+                public void Run()
+                {
+                    Log("one");
+                }
+            }
+            """;
+
+        var methodLine = FindMethodIdentifierLine(source, "Log");
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new InlineMethodOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new InlineMethodParams
+        {
+            SourceFile = workspace.SourcePath,
+            MethodName = "Log",
+            Line = methodLine
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Contains("void Log(int value)", text);
+        Assert.DoesNotContain("void Log(string message)", text);
+        Assert.Contains(@"System.Console.WriteLine(""one"")", text);
+        Assert.DoesNotContain(@"Log(""one"")", text);
+    }
+
+    [SkippableFact]
+    public async Task InlineMethod_AwaitParent_ParenthesizesBinaryExpression()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                private AwaitableInt _left = new AwaitableInt(1);
+                private AwaitableInt _right = new AwaitableInt(2);
+
+                private AwaitableInt Sum() => _left + _right;
+
+                public async System.Threading.Tasks.Task<int> Run()
+                {
+                    return await Sum();
+                }
+            }
+
+            public readonly struct AwaitableInt
+            {
+                public AwaitableInt(int value) => Value = value;
+                public int Value { get; }
+                public System.Runtime.CompilerServices.TaskAwaiter<int> GetAwaiter() =>
+                    System.Threading.Tasks.Task.FromResult(Value).GetAwaiter();
+                public static AwaitableInt operator +(AwaitableInt left, AwaitableInt right) =>
+                    new AwaitableInt(left.Value + right.Value);
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new InlineMethodOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new InlineMethodParams
+        {
+            SourceFile = workspace.SourcePath,
+            MethodName = "Sum"
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Contains("await (_left + _right)", text);
+        Assert.DoesNotContain("await _left + _right", text);
+    }
+
     #endregion
 
     #region Helpers
+
+    private static int FindMethodIdentifierLine(string source, string methodName)
+    {
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var method = tree.GetRoot()
+            .DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .First(node => node.Identifier.Text == methodName);
+        return method.Identifier.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+    }
 
     private static (int Line, int Column) FindInvocationLocation(string source, string invocationText)
     {

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Inline/InlineMethodOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Inline/InlineMethodOperationTests.cs
@@ -1,0 +1,512 @@
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using RoslynMcp.Contracts.Errors;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.Refactoring;
+using RoslynMcp.Core.Refactoring.Inline;
+using RoslynMcp.Core.Workspace;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Refactoring.Inline;
+
+/// <summary>
+/// Operation-level tests for <see cref="InlineMethodOperation"/>.
+/// These execute the real refactoring against a loaded workspace.
+/// </summary>
+public class InlineMethodOperationTests
+{
+    #region P0 Happy Path
+
+    [SkippableFact]
+    public async Task InlineMethod_SimpleVoidMethod_ReplacesAllCallSitesAndRemovesMethod()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                private void Log(string message)
+                {
+                    System.Console.WriteLine(message);
+                }
+
+                public void Run()
+                {
+                    Log("one");
+                    Log("two");
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new InlineMethodOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new InlineMethodParams
+        {
+            SourceFile = workspace.SourcePath,
+            MethodName = "Log"
+        });
+
+        Assert.True(result.Success);
+        Assert.False(result.Preview);
+        Assert.Equal(2, result.ReferencesUpdated);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.DoesNotContain("void Log", text);
+        Assert.Contains(@"System.Console.WriteLine(""one"")", text);
+        Assert.Contains(@"System.Console.WriteLine(""two"")", text);
+        Assert.DoesNotContain(@"Log(""one"")", text);
+        Assert.DoesNotContain(@"Log(""two"")", text);
+    }
+
+    [SkippableFact]
+    public async Task InlineMethod_ReturnValueMethod_SubstitutesExpression()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                private int Add(int a, int b)
+                {
+                    return a + b;
+                }
+
+                public int Run()
+                {
+                    return Add(1, 2);
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new InlineMethodOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new InlineMethodParams
+        {
+            SourceFile = workspace.SourcePath,
+            MethodName = "Add"
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.DoesNotContain("int Add", text);
+        Assert.Contains("return 1 + 2;", text);
+        Assert.DoesNotContain("Add(1, 2)", text);
+    }
+
+    [SkippableFact]
+    public async Task InlineMethod_ExpressionBodiedMethod_SubstitutesExpression()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                private int Double(int value) => value * 2;
+
+                public int Run()
+                {
+                    return Double(4);
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new InlineMethodOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new InlineMethodParams
+        {
+            SourceFile = workspace.SourcePath,
+            MethodName = "Double"
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.DoesNotContain("int Double", text);
+        Assert.Contains("return 4 * 2;", text);
+    }
+
+    [SkippableFact]
+    public async Task InlineMethod_Preview_ReturnsChangesAndWritesNothing()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                private void Log(string message)
+                {
+                    System.Console.WriteLine(message);
+                }
+
+                public void Run()
+                {
+                    Log("one");
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var original = await File.ReadAllTextAsync(workspace.SourcePath);
+        var operation = new InlineMethodOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new InlineMethodParams
+        {
+            SourceFile = workspace.SourcePath,
+            MethodName = "Log",
+            Preview = true
+        });
+
+        Assert.True(result.Success);
+        Assert.True(result.Preview);
+        Assert.NotNull(result.PendingChanges);
+        Assert.NotEmpty(result.PendingChanges);
+        Assert.Contains(result.PendingChanges, c => c.AfterSnippet != null && c.AfterSnippet.Contains("WriteLine"));
+
+        var after = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Equal(original, after);
+    }
+
+    [SkippableFact]
+    public async Task InlineMethod_RemoveMethodFalse_LeavesMethodInPlace()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                private void Log(string message)
+                {
+                    System.Console.WriteLine(message);
+                }
+
+                public void Run()
+                {
+                    Log("one");
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new InlineMethodOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new InlineMethodParams
+        {
+            SourceFile = workspace.SourcePath,
+            MethodName = "Log",
+            RemoveMethod = false
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Contains("void Log", text);
+        Assert.Contains(@"System.Console.WriteLine(""one"")", text);
+        Assert.DoesNotContain(@"Log(""one"")", text);
+    }
+
+    [SkippableFact]
+    public async Task InlineMethod_SingleCallSite_LeavesMethodAndOtherCalls()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                private void Log(string message)
+                {
+                    System.Console.WriteLine(message);
+                }
+
+                public void Run()
+                {
+                    Log("one");
+                    Log("two");
+                }
+            }
+            """;
+
+        var callSite = FindInvocationLocation(source, @"Log(""one"")");
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new InlineMethodOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new InlineMethodParams
+        {
+            SourceFile = workspace.SourcePath,
+            MethodName = "Log",
+            CallSiteLocation = new CallSiteLocation
+            {
+                File = workspace.SourcePath,
+                Line = callSite.Line,
+                Column = callSite.Column
+            }
+        });
+
+        Assert.True(result.Success);
+        Assert.Equal(1, result.ReferencesUpdated);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Contains("void Log", text);
+        Assert.Contains(@"System.Console.WriteLine(""one"")", text);
+        Assert.Contains(@"Log(""two"")", text);
+        Assert.DoesNotContain(@"Log(""one"")", text);
+    }
+
+    #endregion
+
+    #region P0 Reject
+
+    [SkippableFact]
+    public async Task InlineMethod_MethodNotFound_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public void Run()
+                {
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new InlineMethodOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new InlineMethodParams
+            {
+                SourceFile = workspace.SourcePath,
+                MethodName = "Missing"
+            }));
+
+        Assert.Equal(ErrorCodes.MethodNotFound, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task InlineMethod_Recursive_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                private int Fact(int n)
+                {
+                    if (n <= 1) return 1;
+                    return n * Fact(n - 1);
+                }
+
+                public int Run()
+                {
+                    return Fact(3);
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new InlineMethodOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new InlineMethodParams
+            {
+                SourceFile = workspace.SourcePath,
+                MethodName = "Fact"
+            }));
+
+        Assert.Equal(ErrorCodes.MethodIsRecursive, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task InlineMethod_Virtual_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public virtual void Log(string message)
+                {
+                    System.Console.WriteLine(message);
+                }
+
+                public void Run()
+                {
+                    Log("one");
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new InlineMethodOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new InlineMethodParams
+            {
+                SourceFile = workspace.SourcePath,
+                MethodName = "Log"
+            }));
+
+        Assert.Equal(ErrorCodes.MethodIsVirtual, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task InlineMethod_NoBody_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public abstract class Calculator
+            {
+                public abstract void Log(string message);
+
+                public void Run()
+                {
+                    Log("one");
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new InlineMethodOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new InlineMethodParams
+            {
+                SourceFile = workspace.SourcePath,
+                MethodName = "Log"
+            }));
+
+        Assert.Equal(ErrorCodes.MethodHasNoBody, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task InlineMethod_NoCallSites_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                private void Log(string message)
+                {
+                    System.Console.WriteLine(message);
+                }
+
+                public void Run()
+                {
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new InlineMethodOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new InlineMethodParams
+            {
+                SourceFile = workspace.SourcePath,
+                MethodName = "Log"
+            }));
+
+        Assert.Equal(ErrorCodes.NoCallSitesFound, ex.ErrorCode);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static (int Line, int Column) FindInvocationLocation(string source, string invocationText)
+    {
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var invocation = tree.GetRoot()
+            .DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .First(node => node.ToString() == invocationText);
+        var span = invocation.GetLocation().GetLineSpan();
+        return (span.StartLinePosition.Line + 1, span.StartLinePosition.Character + 1);
+    }
+
+    private sealed class TempWorkspace : IAsyncDisposable
+    {
+        public required string DirectoryPath { get; init; }
+        public required string ProjectPath { get; init; }
+        public required string SourcePath { get; init; }
+        public required WorkspaceContext Context { get; init; }
+
+        public static async Task<TempWorkspace> CreateAsync(string source, string fileName = "Calculator.cs")
+        {
+            Skip.IfNot(ModuleInitializer.MsBuildAvailable, ModuleInitializer.MsBuildError ?? "MSBuild not available");
+
+            var directory = Path.Combine(Path.GetTempPath(), "RoslynMcpInlineMethod_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(directory);
+
+            var projectPath = Path.Combine(directory, "TestApp.csproj");
+            var sourcePath = Path.Combine(directory, fileName);
+
+            await File.WriteAllTextAsync(projectPath, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net9.0</TargetFramework>
+                    <Nullable>enable</Nullable>
+                  </PropertyGroup>
+                </Project>
+                """);
+            await File.WriteAllTextAsync(sourcePath, source);
+
+            try
+            {
+                var provider = new MSBuildWorkspaceProvider();
+                var context = await provider.CreateContextAsync(projectPath);
+                if (context.GetDocumentByPath(sourcePath) == null)
+                {
+                    context.Dispose();
+                    throw new InvalidOperationException($"Workspace loaded but did not include {sourcePath}.");
+                }
+
+                return new TempWorkspace
+                {
+                    DirectoryPath = directory,
+                    ProjectPath = projectPath,
+                    SourcePath = sourcePath,
+                    Context = context
+                };
+            }
+            catch (Exception ex) when (ex is not SkipException)
+            {
+                try
+                {
+                    Directory.Delete(directory, recursive: true);
+                }
+                catch
+                {
+                    // ignore cleanup failures
+                }
+
+                Skip.If(true, $"Workspace load failed: {ex.Message}");
+                throw;
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            Context.Dispose();
+            await Task.Run(() =>
+            {
+                try
+                {
+                    Directory.Delete(DirectoryPath, recursive: true);
+                }
+                catch
+                {
+                    // ignore locked temp files
+                }
+            });
+        }
+    }
+
+    #endregion
+}

--- a/tests/RoslynMcp.Server.Tests/Tools/InlineMethodToolTests.cs
+++ b/tests/RoslynMcp.Server.Tests/Tools/InlineMethodToolTests.cs
@@ -1,0 +1,134 @@
+using System.Text.Json;
+using RoslynMcp.Server.Tests.TestHelpers;
+using RoslynMcp.Server.Tools;
+using RoslynMcp.Server.Transport;
+using Xunit;
+
+namespace RoslynMcp.Server.Tests.Tools;
+
+/// <summary>
+/// Unit tests for InlineMethodTool.
+/// Tests tool definition and argument validation.
+/// </summary>
+public class InlineMethodToolTests
+{
+    private readonly InlineMethodTool _tool;
+
+    public InlineMethodToolTests()
+    {
+        // Fails loudly if workspace creation is attempted; argument validation is exercised via ExecuteAsync error paths.
+        _tool = new InlineMethodTool(new ThrowingWorkspaceProvider());
+    }
+
+    #region GetDefinition Tests
+
+    [Fact]
+    public void GetDefinition_ReturnsCorrectName()
+    {
+        Assert.Equal("inline_method", _tool.Name);
+    }
+
+    [Fact]
+    public void GetDefinition_ReturnsNonEmptyDescription()
+    {
+        Assert.NotNull(_tool.Description);
+        Assert.NotEmpty(_tool.Description);
+    }
+
+    [Fact]
+    public void GetDefinition_ReturnsCorrectSchema()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.Equal("object", root.GetProperty("type").GetString());
+        Assert.True(root.TryGetProperty("properties", out _));
+        Assert.True(root.TryGetProperty("required", out _));
+    }
+
+    [Fact]
+    public void GetDefinition_HasRequiredFields()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var required = doc.RootElement.GetProperty("required");
+
+        var requiredFields = new List<string>();
+        foreach (var item in required.EnumerateArray())
+        {
+            requiredFields.Add(item.GetString()!);
+        }
+
+        Assert.Contains("solutionPath", requiredFields);
+        Assert.Contains("sourceFile", requiredFields);
+        Assert.Contains("methodName", requiredFields);
+    }
+
+    [Fact]
+    public void GetDefinition_HasProperties_ForAllParameters()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var properties = doc.RootElement.GetProperty("properties");
+
+        Assert.True(properties.TryGetProperty("solutionPath", out _));
+        Assert.True(properties.TryGetProperty("sourceFile", out _));
+        Assert.True(properties.TryGetProperty("methodName", out _));
+        Assert.True(properties.TryGetProperty("line", out _));
+        Assert.True(properties.TryGetProperty("column", out _));
+        Assert.True(properties.TryGetProperty("callSiteLocation", out _));
+        Assert.True(properties.TryGetProperty("removeMethod", out _));
+        Assert.True(properties.TryGetProperty("preview", out _));
+    }
+
+    #endregion
+
+    #region ExecuteAsync Argument Validation Tests
+
+    [Fact]
+    public async Task ExecuteAsync_NullArguments_ReturnsError()
+    {
+        var result = await _tool.ExecuteAsync(null);
+
+        Assert.True(result.IsError);
+        Assert.Contains("Arguments required", GetResultText(result));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EmptyArguments_ReturnsError()
+    {
+        var args = JsonDocument.Parse("{}").RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MissingRequiredField_ReturnsError()
+    {
+        var args = JsonDocument.Parse(@"{
+            ""solutionPath"": ""C:/test/test.sln"",
+            ""sourceFile"": ""C:/test/Test.cs""
+        }").RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static string GetResultText(ToolResult result)
+    {
+        return result.Content.FirstOrDefault()?.Text ?? string.Empty;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the leftover `inline_method` operation as the inverse of the already-shipped `extract_method`.

- **Contracts:** `InlineMethodParams` (+ optional `CallSiteLocation`), `RefactoringKind.InlineMethod`, and inline-method error codes **3094–3097** (the Phase 2 3050–3059 draft collides with generate codes 3055/3056; 3090–3093 were already taken by inline-variable).
- **Core:** `InlineMethodOperation` next to `InlineVariableOperation`, using `RefactoringOperationBase`, preview mode, and the existing atomic commit path.
- **Server:** `InlineMethodTool` registered in `McpServerHost`.
- **CLI:** `inline-method` registered under Inline in `ToolRegistry.BuildDefault`.
- **Docs:** README tool count 41 → 42 and a new Inline table row.

P0 behavior:
- Inline a simple void method at all call sites (parameter substitution; `removeMethod` default true)
- Inline a method that returns a value (single return / expression-bodied)
- `preview: true` returns computed changes and writes nothing
- Optional `callSiteLocation` inlines one site and leaves the method in place
- Reject: method not found, recursive, virtual/override/abstract, no body, no call sites

Review follow-up (leftover-scope correctness, no extra features):
- Handle unbraced `if`/`else`/`while` call statements
- Rematch call sites by span; annotate the selected method for removal
- Parenthesize inlined expressions under `await`
- Reject: method groups, foreign receivers, unsafe side-effect args, dropped pre-return statements, nested return/break/continue/goto/yield

## Testing

Local `dotnet test` is green after the review fixes:

- CLI: 91 passed
- Server: 334 passed
- Core: 294 passed (includes operation-level `InlineMethodOperationTests` against a loaded workspace)

Closes #30
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6c04a5f-99d2-4599-9119-9ad5ef307d72?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6c04a5f-99d2-4599-9119-9ad5ef307d72&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

