### PR TITLE
Add pull_members_up hierarchy refactoring

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "roslyn-mcp",
   "version": "0.4.1",
-  "description": "Roslyn-powered C# refactoring MCP server — 41 tools for code navigation, analysis, generation, and refactoring across entire .NET solutions",
+  "description": "Roslyn-powered C# refactoring MCP server — 43 tools for code navigation, analysis, generation, and refactoring across entire .NET solutions",
   "author": {
     "name": "Joshua Ramirez"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- `pull_members_up` — move selected members from a derived type onto an existing base class or interface, with preview mode and rejects for missing bases, interface-incompatible members, and name/signature conflicts
+
 ## [0.4.0] - 2026-02-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Let AI assistants like Claude safely refactor your C# codebase using the same Roslyn compiler platform that powers Visual Studio.
 
-Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that exposes **42 Roslyn-powered tools** to AI assistants and other MCP clients. It combines 20 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 7 code conversion tools -- giving your AI deep code intelligence, comprehensive refactoring, and modern C# syntax transformations with full solution-wide reference tracking and preview support.
+Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that exposes **43 Roslyn-powered tools** to AI assistants and other MCP clients. It combines 21 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 7 code conversion tools -- giving your AI deep code intelligence, comprehensive refactoring, and modern C# syntax transformations with full solution-wide reference tracking and preview support.
 
 ---
 
@@ -30,7 +30,7 @@ Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotoc
 
 ## Why RoslynMcpServer?
 
-- **42 tools** -- refactoring, navigation, analysis, generation, and conversion tools, the most comprehensive Roslyn MCP server available
+- **43 tools** -- refactoring, navigation, analysis, generation, and conversion tools, the most comprehensive Roslyn MCP server available
 - **Preview mode on every operation** -- see exactly what will change before applying
 - **Atomic file writes with rollback** -- if any file write fails, all changes are reverted
 - **Solution-wide reference updates** -- renames and moves propagate across your entire solution
@@ -102,7 +102,7 @@ Claude will use the `rename_symbol` tool to rename the class and update every re
 
 ## Standalone CLI
 
-All 42 tools are also available as a standalone CLI for use in scripts, CI/CD pipelines, and terminals without an AI assistant.
+All 43 tools are also available as a standalone CLI for use in scripts, CI/CD pipelines, and terminals without an AI assistant.
 
 ### Install
 
@@ -201,6 +201,7 @@ All tools accept a `solutionPath` parameter (absolute path to a `.sln`, `.slnx`,
 | `extract_constant` | Extract a literal value to a named constant. | `sourceFile`, `startLine`, `startColumn`, `endLine`, `endColumn`, `constantName`, `visibility`, `replaceAll` |
 | `extract_interface` | Extract an interface from a class's public members. | `sourceFile`, `typeName`, `interfaceName`, `members`, `targetFile` |
 | `extract_base_class` | Extract members to a new base class. | `sourceFile`, `typeName`, `baseClassName`, `members`, `targetFile`, `makeAbstract` |
+| `pull_members_up` | Move selected members from a derived type onto an existing base class or interface. | `sourceFile`, `typeName`, `members`, `targetBaseType`, `makeAbstract` |
 
 ### Inline
 

--- a/src/RoslynMcp.Cli/ToolRegistry.cs
+++ b/src/RoslynMcp.Cli/ToolRegistry.cs
@@ -10,6 +10,7 @@ using RoslynMcp.Core.Refactoring.Encapsulate;
 using RoslynMcp.Core.Refactoring.Extract;
 using RoslynMcp.Core.Refactoring.Format;
 using RoslynMcp.Core.Refactoring.Generate;
+using RoslynMcp.Core.Refactoring.Hierarchy;
 using RoslynMcp.Core.Refactoring.Inline;
 using RoslynMcp.Core.Refactoring.Organize;
 using RoslynMcp.Core.Refactoring.Rename;
@@ -138,7 +139,7 @@ public sealed class ToolRegistry
         _tools.Values.OrderBy(t => t.Category).ThenBy(t => t.Name).ToList();
 
     /// <summary>
-    /// Build the default registry with all 42 tools registered.
+    /// Build the default registry with all 43 tools registered.
     /// </summary>
     public static ToolRegistry BuildDefault()
     {
@@ -157,6 +158,8 @@ public sealed class ToolRegistry
             "extract-base-class", "Extract a base class from common members");
         r.RegisterRefactoring<IntroduceParameterOperation, IntroduceParameterParams>(
             "introduce-parameter", "Introduce a method parameter from an expression");
+        r.RegisterRefactoring<PullMembersUpOperation, PullMembersUpParams>(
+            "pull-members-up", "Move selected members from a derived type onto an existing base class or interface");
 
         // ── Refactoring: Rename (1) ───────────────────────────────────
         r.RegisterRefactoring<RenameSymbolOperation, RenameSymbolParams>(

--- a/src/RoslynMcp.Contracts/Enums/RefactoringKind.cs
+++ b/src/RoslynMcp.Contracts/Enums/RefactoringKind.cs
@@ -32,6 +32,9 @@ public enum RefactoringKind
     /// <summary>Extract base class from type.</summary>
     ExtractBaseClass,
 
+    /// <summary>Move selected members from a derived type onto an existing base class or interface.</summary>
+    PullMembersUp,
+
     /// <summary>Extract expression to variable.</summary>
     ExtractVariable,
 

--- a/src/RoslynMcp.Contracts/Errors/ErrorCodes.cs
+++ b/src/RoslynMcp.Contracts/Errors/ErrorCodes.cs
@@ -311,6 +311,28 @@ public static class ErrorCodes
     /// <summary>Start/end line range is invalid for data or control flow analysis.</summary>
     public const string InvalidRegion = "3100";
 
+    // --------------------------------------------
+    // Hierarchy Errors (3105-3110)
+    // --------------------------------------------
+
+    /// <summary>Member depends on derived-only members that are not being pulled.</summary>
+    public const string MemberDependsOnDerived = "3105";
+
+    /// <summary>Target base class is sealed.</summary>
+    public const string BaseClassIsSealed = "3106";
+
+    /// <summary>Type has no base class or interface to pull members to.</summary>
+    public const string NoCommonBase = "3107";
+
+    /// <summary>Member name or signature already exists on the target type.</summary>
+    public const string ConflictsWithExistingMember = "3108";
+
+    /// <summary>Base class or interface is not editable (external assembly).</summary>
+    public const string BaseClassNotEditable = "3109";
+
+    /// <summary>Member cannot be declared on an interface (field, constructor, static, or non-public).</summary>
+    public const string MemberNotInterfaceCompatible = "3110";
+
     // ============================================
     // System Errors (4xxx)
     // ============================================

--- a/src/RoslynMcp.Contracts/Models/PullMembersUpParams.cs
+++ b/src/RoslynMcp.Contracts/Models/PullMembersUpParams.cs
@@ -1,0 +1,40 @@
+namespace RoslynMcp.Contracts.Models;
+
+/// <summary>
+/// Parameters for the pull_members_up tool.
+/// </summary>
+public sealed class PullMembersUpParams
+{
+    /// <summary>
+    /// Absolute path to the source file containing the derived type.
+    /// </summary>
+    public required string SourceFile { get; init; }
+
+    /// <summary>
+    /// Name of the derived class or struct that currently declares the members.
+    /// </summary>
+    public required string TypeName { get; init; }
+
+    /// <summary>
+    /// Names of members to pull up. At least one is required.
+    /// </summary>
+    public required IReadOnlyList<string> Members { get; init; }
+
+    /// <summary>
+    /// Target base class or interface name. If omitted, uses the nearest base
+    /// class, or the single implemented interface when there is no class base.
+    /// </summary>
+    public string? TargetBaseType { get; init; }
+
+    /// <summary>
+    /// When pulling to a class, declare the members as abstract on the base
+    /// and keep the original implementations as overrides on the derived type.
+    /// Ignored when the target is an interface. Default: false.
+    /// </summary>
+    public bool MakeAbstract { get; init; }
+
+    /// <summary>
+    /// Return computed changes without applying. Default: false.
+    /// </summary>
+    public bool Preview { get; init; }
+}

--- a/src/RoslynMcp.Core/Refactoring/Hierarchy/PullMembersUpOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Hierarchy/PullMembersUpOperation.cs
@@ -1,0 +1,824 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using RoslynMcp.Contracts.Enums;
+using RoslynMcp.Contracts.Errors;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.FileSystem;
+using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Workspace;
+
+namespace RoslynMcp.Core.Refactoring.Hierarchy;
+
+/// <summary>
+/// Moves selected members from a derived type onto an existing base class or interface.
+/// </summary>
+public sealed class PullMembersUpOperation : RefactoringOperationBase<PullMembersUpParams>
+{
+    /// <summary>
+    /// Creates a new pull-members-up operation.
+    /// </summary>
+    public PullMembersUpOperation(WorkspaceContext context) : base(context)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override void ValidateParams(PullMembersUpParams @params) => Validate(@params);
+
+    /// <summary>
+    /// Validates pull-members-up parameters. Internal so tests can exercise
+    /// input rules without loading a workspace.
+    /// </summary>
+    internal static void Validate(PullMembersUpParams @params)
+    {
+        if (string.IsNullOrWhiteSpace(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "sourceFile is required.");
+
+        if (string.IsNullOrWhiteSpace(@params.TypeName))
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "typeName is required.");
+
+        if (@params.Members == null || @params.Members.Count == 0 || @params.Members.All(string.IsNullOrWhiteSpace))
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "members is required.");
+
+        if (!PathResolver.IsAbsolutePath(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.InvalidSourcePath, "sourceFile must be an absolute path.");
+
+        if (!PathResolver.IsValidCSharpFilePath(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.InvalidSourcePath, "sourceFile must be a .cs file.");
+
+        if (!File.Exists(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.SourceFileNotFound, $"Source file not found: {@params.SourceFile}");
+    }
+
+    /// <inheritdoc />
+    protected override async Task<RefactoringResult> ExecuteCoreAsync(
+        Guid operationId,
+        PullMembersUpParams @params,
+        CancellationToken cancellationToken)
+    {
+        var document = GetDocumentOrThrow(@params.SourceFile);
+        var root = await document.GetSyntaxRootAsync(cancellationToken);
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken);
+
+        if (root == null || semanticModel == null)
+            throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse file.");
+
+        var derivedDecl = FindTypeDeclaration(root, @params.TypeName);
+        if (derivedDecl == null)
+        {
+            throw new RefactoringException(
+                ErrorCodes.TypeNotFound,
+                $"Type '{@params.TypeName}' not found in file.");
+        }
+
+        var derivedSymbol = semanticModel.GetDeclaredSymbol(derivedDecl, cancellationToken) as INamedTypeSymbol;
+        if (derivedSymbol == null)
+            throw new RefactoringException(ErrorCodes.RoslynError, "Could not resolve type symbol.");
+
+        var target = GetTargetBaseType(derivedSymbol, @params.TargetBaseType);
+        ValidateTarget(target);
+
+        var members = FindMembersToPull(derivedDecl, @params.Members, semanticModel, cancellationToken);
+        ValidateMembersForPull(members, derivedSymbol, target, semanticModel);
+
+        var pulledNames = members.Select(m => m.Name).ToList();
+        var targetMembers = members
+            .Select(m => ConvertForTarget(m.Syntax, target, @params.MakeAbstract))
+            .ToList();
+        var derivedReplacement = BuildDerivedReplacement(
+            derivedDecl,
+            members,
+            target,
+            @params.MakeAbstract);
+
+        if (@params.Preview)
+        {
+            return CreatePreviewResult(
+                operationId,
+                @params,
+                target,
+                pulledNames,
+                targetMembers,
+                derivedDecl,
+                derivedReplacement);
+        }
+
+        var solution = await ApplyChangesAsync(
+            document,
+            derivedDecl,
+            derivedReplacement,
+            target,
+            targetMembers,
+            @params.MakeAbstract,
+            cancellationToken);
+
+        var commitResult = await CommitChangesAsync(solution, cancellationToken);
+
+        return RefactoringResult.Succeeded(
+            operationId,
+            new FileChanges
+            {
+                FilesModified = commitResult.FilesModified,
+                FilesCreated = commitResult.FilesCreated,
+                FilesDeleted = commitResult.FilesDeleted
+            },
+            new Contracts.Models.SymbolInfo
+            {
+                Name = target.Name,
+                FullyQualifiedName = target.ToDisplayString(),
+                Kind = target.TypeKind == TypeKind.Interface
+                    ? Contracts.Enums.SymbolKind.Interface
+                    : Contracts.Enums.SymbolKind.Class
+            },
+            0,
+            0);
+    }
+
+    private static TypeDeclarationSyntax? FindTypeDeclaration(SyntaxNode root, string typeName)
+    {
+        var simpleName = typeName.Contains('.')
+            ? typeName[(typeName.LastIndexOf('.') + 1)..]
+            : typeName;
+
+        return root.DescendantNodes()
+            .OfType<TypeDeclarationSyntax>()
+            .FirstOrDefault(t => t.Identifier.Text == simpleName);
+    }
+
+    internal static INamedTypeSymbol GetTargetBaseType(INamedTypeSymbol derived, string? targetTypeName)
+    {
+        var classBases = new List<INamedTypeSymbol>();
+        for (var baseType = derived.BaseType; baseType != null; baseType = baseType.BaseType)
+        {
+            if (baseType.SpecialType == SpecialType.System_Object)
+                break;
+            classBases.Add(baseType);
+        }
+
+        var interfaces = derived.AllInterfaces.ToList();
+
+        if (string.IsNullOrWhiteSpace(targetTypeName))
+        {
+            if (classBases.Count > 0)
+                return classBases[0];
+
+            if (derived.Interfaces.Length == 1)
+                return derived.Interfaces[0];
+
+            if (derived.Interfaces.Length > 1)
+            {
+                throw new RefactoringException(
+                    ErrorCodes.NoCommonBase,
+                    $"Type '{derived.Name}' implements multiple interfaces; specify targetBaseType.");
+            }
+
+            throw new RefactoringException(
+                ErrorCodes.NoCommonBase,
+                $"Type '{derived.Name}' has no base class or interface to pull members to.");
+        }
+
+        var candidates = classBases.Concat(interfaces);
+        var match = candidates.FirstOrDefault(candidate =>
+            candidate.Name.Equals(targetTypeName, StringComparison.Ordinal) ||
+            candidate.ToDisplayString().Equals(targetTypeName, StringComparison.Ordinal));
+
+        if (match == null)
+        {
+            throw new RefactoringException(
+                ErrorCodes.BaseClassNotFound,
+                $"Type '{targetTypeName}' is not a base class or interface of '{derived.Name}'.");
+        }
+
+        return match;
+    }
+
+    internal static void ValidateTarget(INamedTypeSymbol target)
+    {
+        if (target.TypeKind == TypeKind.Class && target.IsSealed)
+        {
+            throw new RefactoringException(
+                ErrorCodes.BaseClassIsSealed,
+                $"Base class '{target.Name}' is sealed.");
+        }
+
+        if (!target.Locations.Any(location => location.IsInSource))
+        {
+            throw new RefactoringException(
+                ErrorCodes.BaseClassNotEditable,
+                $"Base type '{target.Name}' is not editable (defined in an external assembly).");
+        }
+    }
+
+    private static List<PullableMember> FindMembersToPull(
+        TypeDeclarationSyntax typeDeclaration,
+        IReadOnlyList<string> memberNames,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        var requested = new HashSet<string>(memberNames.Where(n => !string.IsNullOrWhiteSpace(n)));
+        var found = new List<PullableMember>();
+
+        foreach (var (name, symbol, syntax) in EnumerateDeclaredMembers(typeDeclaration, semanticModel, cancellationToken))
+        {
+            if (!requested.Contains(name))
+                continue;
+
+            if (symbol == null)
+            {
+                throw new RefactoringException(
+                    ErrorCodes.RoslynError,
+                    $"Could not resolve symbol for member '{name}'.");
+            }
+
+            if (!IsSupportedMember(symbol))
+            {
+                throw new RefactoringException(
+                    ErrorCodes.MemberNotMoveable,
+                    $"Member '{name}' cannot be pulled up.");
+            }
+
+            found.Add(new PullableMember(name, symbol, syntax));
+            requested.Remove(name);
+        }
+
+        if (requested.Count > 0)
+        {
+            throw new RefactoringException(
+                ErrorCodes.MemberNotFound,
+                $"Members not found: {string.Join(", ", requested)}");
+        }
+
+        return found;
+    }
+
+    private static IEnumerable<(string Name, ISymbol? Symbol, MemberDeclarationSyntax Syntax)> EnumerateDeclaredMembers(
+        TypeDeclarationSyntax typeDeclaration,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        foreach (var member in typeDeclaration.Members)
+        {
+            switch (member)
+            {
+                case MethodDeclarationSyntax method:
+                    yield return (method.Identifier.Text, semanticModel.GetDeclaredSymbol(method, cancellationToken), method);
+                    break;
+                case PropertyDeclarationSyntax property:
+                    yield return (property.Identifier.Text, semanticModel.GetDeclaredSymbol(property, cancellationToken), property);
+                    break;
+                case FieldDeclarationSyntax field:
+                    foreach (var variable in field.Declaration.Variables)
+                    {
+                        yield return (variable.Identifier.Text, semanticModel.GetDeclaredSymbol(variable, cancellationToken), field);
+                    }
+                    break;
+                case EventFieldDeclarationSyntax eventField:
+                    foreach (var variable in eventField.Declaration.Variables)
+                    {
+                        yield return (variable.Identifier.Text, semanticModel.GetDeclaredSymbol(variable, cancellationToken), eventField);
+                    }
+                    break;
+                case EventDeclarationSyntax eventDecl:
+                    yield return (eventDecl.Identifier.Text, semanticModel.GetDeclaredSymbol(eventDecl, cancellationToken), eventDecl);
+                    break;
+            }
+        }
+    }
+
+    private static bool IsSupportedMember(ISymbol symbol) => symbol switch
+    {
+        IMethodSymbol method => method.MethodKind == MethodKind.Ordinary,
+        IPropertySymbol => true,
+        IFieldSymbol => true,
+        IEventSymbol => true,
+        _ => false
+    };
+
+    private static void ValidateMembersForPull(
+        IReadOnlyList<PullableMember> members,
+        INamedTypeSymbol derived,
+        INamedTypeSymbol target,
+        SemanticModel semanticModel)
+    {
+        var pulledNames = members.Select(m => m.Name).ToHashSet();
+
+        foreach (var member in members)
+        {
+            if (HasConflict(target, member.Symbol))
+            {
+                throw new RefactoringException(
+                    ErrorCodes.ConflictsWithExistingMember,
+                    $"Member '{member.Name}' already exists in '{target.Name}'.");
+            }
+
+            if (target.TypeKind == TypeKind.Interface && !IsInterfaceCompatible(member.Symbol))
+            {
+                throw new RefactoringException(
+                    ErrorCodes.MemberNotInterfaceCompatible,
+                    $"Member '{member.Name}' cannot be pulled to interface '{target.Name}'.");
+            }
+
+            var dependency = FindDerivedOnlyDependency(member, derived, pulledNames, semanticModel);
+            if (dependency != null)
+            {
+                throw new RefactoringException(
+                    ErrorCodes.MemberDependsOnDerived,
+                    $"Member '{member.Name}' depends on '{dependency}' which is not accessible from '{target.Name}'.");
+            }
+        }
+    }
+
+    private static bool HasConflict(INamedTypeSymbol target, ISymbol member)
+    {
+        foreach (var existing in target.GetMembers(member.Name))
+        {
+            if (existing.IsImplicitlyDeclared)
+                continue;
+
+            if (member is IMethodSymbol method && existing is IMethodSymbol existingMethod)
+            {
+                if (SignaturesMatch(method, existingMethod))
+                    return true;
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool SignaturesMatch(IMethodSymbol left, IMethodSymbol right)
+    {
+        if (left.Parameters.Length != right.Parameters.Length)
+            return false;
+
+        if (left.TypeParameters.Length != right.TypeParameters.Length)
+            return false;
+
+        for (var i = 0; i < left.Parameters.Length; i++)
+        {
+            if (!SymbolEqualityComparer.Default.Equals(left.Parameters[i].Type, right.Parameters[i].Type))
+                return false;
+            if (left.Parameters[i].RefKind != right.Parameters[i].RefKind)
+                return false;
+        }
+
+        return true;
+    }
+
+    private static bool IsInterfaceCompatible(ISymbol member)
+    {
+        if (member.IsStatic)
+            return false;
+
+        if (member.DeclaredAccessibility != Accessibility.Public)
+            return false;
+
+        return member switch
+        {
+            IMethodSymbol method => method.MethodKind == MethodKind.Ordinary,
+            IPropertySymbol => true,
+            IEventSymbol => true,
+            _ => false
+        };
+    }
+
+    private static string? FindDerivedOnlyDependency(
+        PullableMember member,
+        INamedTypeSymbol derived,
+        HashSet<string> pulledNames,
+        SemanticModel semanticModel)
+    {
+        foreach (var identifier in member.Syntax.DescendantNodes().OfType<IdentifierNameSyntax>())
+        {
+            var referenced = semanticModel.GetSymbolInfo(identifier).Symbol;
+            if (referenced == null)
+                continue;
+
+            if (referenced is IParameterSymbol or ILocalSymbol or ITypeParameterSymbol)
+                continue;
+
+            if (referenced.ContainingType == null)
+                continue;
+
+            if (!SymbolEqualityComparer.Default.Equals(referenced.ContainingType, derived))
+                continue;
+
+            if (referenced.Kind is not (Microsoft.CodeAnalysis.SymbolKind.Field
+                or Microsoft.CodeAnalysis.SymbolKind.Method
+                or Microsoft.CodeAnalysis.SymbolKind.Property
+                or Microsoft.CodeAnalysis.SymbolKind.Event))
+                continue;
+
+            if (SymbolEqualityComparer.Default.Equals(referenced, member.Symbol))
+                continue;
+
+            if (referenced is IMethodSymbol referencedMethod &&
+                member.Symbol is IMethodSymbol memberMethod &&
+                SignaturesMatch(referencedMethod, memberMethod) &&
+                referenced.Name == member.Name)
+            {
+                continue;
+            }
+
+            if (pulledNames.Contains(referenced.Name))
+                continue;
+
+            return referenced.Name;
+        }
+
+        return null;
+    }
+
+    private static MemberDeclarationSyntax ConvertForTarget(
+        MemberDeclarationSyntax member,
+        INamedTypeSymbol target,
+        bool makeAbstract)
+    {
+        if (target.TypeKind == TypeKind.Interface)
+            return ConvertToInterfaceMember(member);
+
+        return makeAbstract
+            ? ConvertToAbstract(member)
+            : ConvertToVirtualOnBase(member);
+    }
+
+    private static MemberDeclarationSyntax ConvertToInterfaceMember(MemberDeclarationSyntax member)
+    {
+        return member switch
+        {
+            MethodDeclarationSyntax method => method
+                .WithModifiers(SyntaxFactory.TokenList())
+                .WithBody(null)
+                .WithExpressionBody(null)
+                .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken))
+                .NormalizeWhitespace(),
+            PropertyDeclarationSyntax property => ToInterfaceProperty(property),
+            EventDeclarationSyntax eventDecl => eventDecl
+                .WithModifiers(SyntaxFactory.TokenList())
+                .WithAccessorList(null)
+                .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken))
+                .NormalizeWhitespace(),
+            EventFieldDeclarationSyntax eventField => SyntaxFactory.EventFieldDeclaration(eventField.Declaration)
+                .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken))
+                .NormalizeWhitespace(),
+            _ => throw new RefactoringException(
+                ErrorCodes.MemberNotInterfaceCompatible,
+                "Member cannot be declared on an interface.")
+        };
+    }
+
+    private static PropertyDeclarationSyntax ToInterfaceProperty(PropertyDeclarationSyntax property)
+    {
+        var accessors = new List<AccessorDeclarationSyntax>();
+        if (property.AccessorList != null)
+        {
+            foreach (var accessor in property.AccessorList.Accessors)
+            {
+                accessors.Add(accessor
+                    .WithModifiers(SyntaxFactory.TokenList())
+                    .WithBody(null)
+                    .WithExpressionBody(null)
+                    .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken)));
+            }
+        }
+        else
+        {
+            accessors.Add(SyntaxFactory.AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
+                .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken)));
+        }
+
+        return property
+            .WithModifiers(SyntaxFactory.TokenList())
+            .WithExpressionBody(null)
+            .WithSemicolonToken(default)
+            .WithAccessorList(SyntaxFactory.AccessorList(SyntaxFactory.List(accessors)))
+            .NormalizeWhitespace();
+    }
+
+    private static MemberDeclarationSyntax ConvertToAbstract(MemberDeclarationSyntax member)
+    {
+        return member switch
+        {
+            MethodDeclarationSyntax method => method
+                .WithModifiers(ToAbstractModifiers(method.Modifiers))
+                .WithBody(null)
+                .WithExpressionBody(null)
+                .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken))
+                .NormalizeWhitespace(),
+            PropertyDeclarationSyntax property => ToAbstractProperty(property),
+            _ => throw new RefactoringException(
+                ErrorCodes.MemberNotMoveable,
+                "Only methods and properties can be pulled up as abstract members.")
+        };
+    }
+
+    private static PropertyDeclarationSyntax ToAbstractProperty(PropertyDeclarationSyntax property)
+    {
+        var accessors = new List<AccessorDeclarationSyntax>();
+        if (property.AccessorList != null)
+        {
+            foreach (var accessor in property.AccessorList.Accessors)
+            {
+                accessors.Add(accessor
+                    .WithBody(null)
+                    .WithExpressionBody(null)
+                    .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken)));
+            }
+        }
+        else
+        {
+            accessors.Add(SyntaxFactory.AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
+                .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken)));
+        }
+
+        return property
+            .WithModifiers(ToAbstractModifiers(property.Modifiers))
+            .WithExpressionBody(null)
+            .WithSemicolonToken(default)
+            .WithAccessorList(SyntaxFactory.AccessorList(SyntaxFactory.List(accessors)))
+            .NormalizeWhitespace();
+    }
+
+    private static MemberDeclarationSyntax ConvertToVirtualOnBase(MemberDeclarationSyntax member)
+    {
+        return member switch
+        {
+            MethodDeclarationSyntax method => method
+                .WithModifiers(AdjustBaseClassModifiers(method.Modifiers, addVirtual: !method.Modifiers.Any(SyntaxKind.StaticKeyword)))
+                .NormalizeWhitespace(),
+            PropertyDeclarationSyntax property => property
+                .WithModifiers(AdjustBaseClassModifiers(property.Modifiers, addVirtual: !property.Modifiers.Any(SyntaxKind.StaticKeyword)))
+                .NormalizeWhitespace(),
+            FieldDeclarationSyntax field => field
+                .WithModifiers(AdjustBaseClassModifiers(field.Modifiers, addVirtual: false))
+                .NormalizeWhitespace(),
+            EventFieldDeclarationSyntax eventField => eventField
+                .WithModifiers(AdjustBaseClassModifiers(eventField.Modifiers, addVirtual: false))
+                .NormalizeWhitespace(),
+            EventDeclarationSyntax eventDecl => eventDecl
+                .WithModifiers(AdjustBaseClassModifiers(eventDecl.Modifiers, addVirtual: !eventDecl.Modifiers.Any(SyntaxKind.StaticKeyword)))
+                .NormalizeWhitespace(),
+            _ => member.NormalizeWhitespace()
+        };
+    }
+
+    private static SyntaxTokenList ToAbstractModifiers(SyntaxTokenList modifiers)
+    {
+        var tokens = StripModifiers(
+                modifiers,
+                SyntaxKind.PrivateKeyword,
+                SyntaxKind.VirtualKeyword,
+                SyntaxKind.OverrideKeyword,
+                SyntaxKind.SealedKeyword,
+                SyntaxKind.AbstractKeyword,
+                SyntaxKind.NewKeyword)
+            .ToList();
+
+        if (!HasAccessibility(tokens))
+            tokens.Insert(0, SyntaxFactory.Token(SyntaxKind.ProtectedKeyword));
+
+        tokens.Add(SyntaxFactory.Token(SyntaxKind.AbstractKeyword));
+        return SyntaxFactory.TokenList(tokens);
+    }
+
+    private static SyntaxTokenList AdjustBaseClassModifiers(SyntaxTokenList modifiers, bool addVirtual)
+    {
+        var tokens = StripModifiers(
+                modifiers,
+                SyntaxKind.PrivateKeyword,
+                SyntaxKind.NewKeyword)
+            .ToList();
+
+        if (modifiers.Any(SyntaxKind.PrivateKeyword) || !HasAccessibility(tokens))
+            tokens.Insert(0, SyntaxFactory.Token(SyntaxKind.ProtectedKeyword));
+
+        var alreadyOverridable = tokens.Any(t =>
+            t.IsKind(SyntaxKind.VirtualKeyword) ||
+            t.IsKind(SyntaxKind.OverrideKeyword) ||
+            t.IsKind(SyntaxKind.AbstractKeyword));
+
+        if (addVirtual && !alreadyOverridable)
+            tokens.Add(SyntaxFactory.Token(SyntaxKind.VirtualKeyword));
+
+        return SyntaxFactory.TokenList(tokens);
+    }
+
+    private static IEnumerable<SyntaxToken> StripModifiers(SyntaxTokenList modifiers, params SyntaxKind[] kinds)
+    {
+        var kindSet = kinds.ToHashSet();
+        return modifiers.Where(token => !kindSet.Contains(token.Kind()));
+    }
+
+    private static bool HasAccessibility(IEnumerable<SyntaxToken> modifiers) =>
+        modifiers.Any(token =>
+            token.IsKind(SyntaxKind.PublicKeyword) ||
+            token.IsKind(SyntaxKind.ProtectedKeyword) ||
+            token.IsKind(SyntaxKind.InternalKeyword) ||
+            token.IsKind(SyntaxKind.PrivateKeyword));
+
+    private static TypeDeclarationSyntax BuildDerivedReplacement(
+        TypeDeclarationSyntax derivedDecl,
+        IReadOnlyList<PullableMember> members,
+        INamedTypeSymbol target,
+        bool makeAbstract)
+    {
+        var pulledSyntax = members.Select(m => m.Syntax).ToHashSet();
+        var keepAsOverride = makeAbstract && target.TypeKind != TypeKind.Interface;
+        var newMembers = new List<MemberDeclarationSyntax>();
+
+        foreach (var member in derivedDecl.Members)
+        {
+            if (!pulledSyntax.Contains(member))
+            {
+                newMembers.Add(member);
+                continue;
+            }
+
+            if (target.TypeKind == TypeKind.Interface)
+            {
+                newMembers.Add(member);
+                continue;
+            }
+
+            if (keepAsOverride)
+            {
+                newMembers.Add(AddOverrideModifier(member));
+            }
+        }
+
+        return derivedDecl.WithMembers(SyntaxFactory.List(newMembers));
+    }
+
+    private static MemberDeclarationSyntax AddOverrideModifier(MemberDeclarationSyntax member)
+    {
+        return member switch
+        {
+            MethodDeclarationSyntax method => method.WithModifiers(ToOverrideModifiers(method.Modifiers)),
+            PropertyDeclarationSyntax property => property.WithModifiers(ToOverrideModifiers(property.Modifiers)),
+            _ => member
+        };
+    }
+
+    private static SyntaxTokenList ToOverrideModifiers(SyntaxTokenList modifiers)
+    {
+        var tokens = StripModifiers(
+                modifiers,
+                SyntaxKind.PrivateKeyword,
+                SyntaxKind.VirtualKeyword,
+                SyntaxKind.AbstractKeyword,
+                SyntaxKind.OverrideKeyword,
+                SyntaxKind.NewKeyword)
+            .ToList();
+
+        if (modifiers.Any(SyntaxKind.PrivateKeyword) || !HasAccessibility(tokens))
+            tokens.Insert(0, SyntaxFactory.Token(SyntaxKind.ProtectedKeyword));
+
+        tokens.Add(SyntaxFactory.Token(SyntaxKind.OverrideKeyword));
+        return SyntaxFactory.TokenList(tokens);
+    }
+
+    private async Task<Solution> ApplyChangesAsync(
+        Document derivedDocument,
+        TypeDeclarationSyntax derivedDecl,
+        TypeDeclarationSyntax newDerived,
+        INamedTypeSymbol target,
+        IReadOnlyList<MemberDeclarationSyntax> targetMembers,
+        bool makeAbstract,
+        CancellationToken cancellationToken)
+    {
+        var syntaxRef = target.DeclaringSyntaxReferences.FirstOrDefault();
+        if (syntaxRef == null)
+        {
+            throw new RefactoringException(
+                ErrorCodes.BaseClassNotEditable,
+                $"Base type '{target.Name}' is not editable (defined in an external assembly).");
+        }
+
+        var targetSyntax = await syntaxRef.GetSyntaxAsync(cancellationToken) as TypeDeclarationSyntax;
+        if (targetSyntax == null)
+        {
+            throw new RefactoringException(
+                ErrorCodes.RoslynError,
+                $"Could not locate declaration for '{target.Name}'.");
+        }
+
+        var newTarget = AddMembersToTarget(targetSyntax, targetMembers, makeAbstract && target.TypeKind != TypeKind.Interface);
+
+        var solution = derivedDocument.Project.Solution;
+        var targetDocument = solution.GetDocument(syntaxRef.SyntaxTree);
+        if (targetDocument == null)
+        {
+            throw new RefactoringException(
+                ErrorCodes.BaseClassNotEditable,
+                $"Base type '{target.Name}' is not part of the workspace.");
+        }
+
+        if (targetDocument.Id == derivedDocument.Id)
+        {
+            var root = await derivedDocument.GetSyntaxRootAsync(cancellationToken);
+            if (root == null)
+                throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse file.");
+
+            var targetInRoot = FindTypeInRoot(root, target.Name, targetSyntax.Span);
+            var updatedTarget = AddMembersToTarget(targetInRoot, targetMembers, makeAbstract && target.TypeKind != TypeKind.Interface);
+            var newRoot = root.ReplaceNodes(
+                new SyntaxNode[] { derivedDecl, targetInRoot },
+                (original, _) => original == derivedDecl ? newDerived : updatedTarget);
+
+            return derivedDocument.WithSyntaxRoot(newRoot).Project.Solution;
+        }
+
+        var derivedRoot = await derivedDocument.GetSyntaxRootAsync(cancellationToken);
+        var targetRoot = await targetDocument.GetSyntaxRootAsync(cancellationToken);
+        if (derivedRoot == null || targetRoot == null)
+            throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse file.");
+
+        solution = derivedDocument.WithSyntaxRoot(derivedRoot.ReplaceNode(derivedDecl, newDerived)).Project.Solution;
+        targetDocument = solution.GetDocument(targetDocument.Id)!;
+        targetRoot = await targetDocument.GetSyntaxRootAsync(cancellationToken);
+        if (targetRoot == null)
+            throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse target file.");
+
+        var currentTarget = FindTypeInRoot(targetRoot, target.Name, targetSyntax.Span);
+        return targetDocument.WithSyntaxRoot(targetRoot.ReplaceNode(currentTarget, newTarget)).Project.Solution;
+    }
+
+    private static TypeDeclarationSyntax FindTypeInRoot(SyntaxNode root, string typeName, Microsoft.CodeAnalysis.Text.TextSpan preferredSpan)
+    {
+        var matches = root.DescendantNodes()
+            .OfType<TypeDeclarationSyntax>()
+            .Where(t => t.Identifier.Text == typeName)
+            .ToList();
+
+        return matches.FirstOrDefault(t => t.Span == preferredSpan) ?? matches[0];
+    }
+
+    private static TypeDeclarationSyntax AddMembersToTarget(
+        TypeDeclarationSyntax target,
+        IReadOnlyList<MemberDeclarationSyntax> members,
+        bool makeClassAbstract)
+    {
+        var formatted = members.Select(member => member
+            .WithLeadingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed)
+            .WithTrailingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed));
+
+        var updated = target.WithMembers(target.Members.AddRange(formatted));
+
+        if (makeClassAbstract &&
+            target is ClassDeclarationSyntax &&
+            !target.Modifiers.Any(SyntaxKind.AbstractKeyword))
+        {
+            updated = updated.AddModifiers(SyntaxFactory.Token(SyntaxKind.AbstractKeyword));
+        }
+
+        return updated;
+    }
+
+    private static RefactoringResult CreatePreviewResult(
+        Guid operationId,
+        PullMembersUpParams @params,
+        INamedTypeSymbol target,
+        IReadOnlyList<string> pulledNames,
+        IReadOnlyList<MemberDeclarationSyntax> targetMembers,
+        TypeDeclarationSyntax originalDerived,
+        TypeDeclarationSyntax updatedDerived)
+    {
+        var memberList = string.Join(", ", pulledNames);
+        var afterSnippet = string.Join(
+            Environment.NewLine + Environment.NewLine,
+            targetMembers.Select(m => m.NormalizeWhitespace().ToFullString()));
+
+        var targetLocation = target.Locations.FirstOrDefault(l => l.IsInSource);
+        var targetFile = targetLocation?.SourceTree?.FilePath ?? @params.SourceFile;
+
+        var pendingChanges = new List<PendingChange>
+        {
+            new()
+            {
+                File = targetFile,
+                ChangeType = ChangeKind.Modify,
+                Description = $"Add {memberList} to {@params.TargetBaseType ?? target.Name}",
+                BeforeSnippet = $"{target.TypeKind.ToString().ToLowerInvariant()} {target.Name}",
+                AfterSnippet = afterSnippet
+            },
+            new()
+            {
+                File = @params.SourceFile,
+                ChangeType = ChangeKind.Modify,
+                Description = target.TypeKind == TypeKind.Interface
+                    ? $"Keep {memberList} on {@params.TypeName} to implement {target.Name}"
+                    : @params.MakeAbstract
+                        ? $"Keep {memberList} on {@params.TypeName} as override"
+                        : $"Remove {memberList} from {@params.TypeName}",
+                BeforeSnippet = originalDerived.Identifier.Text,
+                AfterSnippet = updatedDerived.NormalizeWhitespace().ToFullString()
+            }
+        };
+
+        return RefactoringResult.PreviewResult(operationId, pendingChanges);
+    }
+
+    private sealed record PullableMember(string Name, ISymbol Symbol, MemberDeclarationSyntax Syntax);
+}

--- a/src/RoslynMcp.Server/McpServerHost.cs
+++ b/src/RoslynMcp.Server/McpServerHost.cs
@@ -49,6 +49,7 @@ public sealed class McpServerHost : IAsyncDisposable
         _toolRegistry.Register(new EncapsulateFieldTool(workspaceProvider));
         _toolRegistry.Register(new ConvertToAsyncTool(workspaceProvider));
         _toolRegistry.Register(new ExtractBaseClassTool(workspaceProvider));
+        _toolRegistry.Register(new PullMembersUpTool(workspaceProvider));
 
         // Code Navigation / Query Tools
         _toolRegistry.Register(new FindReferencesTool(workspaceProvider));

--- a/src/RoslynMcp.Server/RoslynMcp.Server.csproj
+++ b/src/RoslynMcp.Server/RoslynMcp.Server.csproj
@@ -18,7 +18,7 @@
     <Version>0.4.0</Version>
     <Authors>Joshua Ramirez</Authors>
     <Company>RedJay</Company>
-    <Description>MCP Server for Roslyn-powered C# refactoring operations. Install as a global tool to use with Claude Code, Claude Desktop, or other MCP clients. Provides 42 tools: 20 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 7 code conversion tools.</Description>
+    <Description>MCP Server for Roslyn-powered C# refactoring operations. Install as a global tool to use with Claude Code, Claude Desktop, or other MCP clients. Provides 43 tools: 21 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 7 code conversion tools.</Description>
     <PackageTags>roslyn;mcp;refactoring;csharp;model-context-protocol;code-analysis;dotnet;ai-tools;claude</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/JoshuaRamirez/RoslynMcpServer</RepositoryUrl>

--- a/src/RoslynMcp.Server/Tools/PullMembersUpTool.cs
+++ b/src/RoslynMcp.Server/Tools/PullMembersUpTool.cs
@@ -1,0 +1,149 @@
+using System.Text.Json;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.Refactoring;
+using RoslynMcp.Core.Refactoring.Hierarchy;
+using RoslynMcp.Core.Workspace;
+using RoslynMcp.Server.Transport;
+
+namespace RoslynMcp.Server.Tools;
+
+/// <summary>
+/// MCP tool handler for pull_members_up operation.
+/// </summary>
+public sealed class PullMembersUpTool : IToolHandler
+{
+    private readonly IWorkspaceProvider _workspaceProvider;
+    private readonly JsonSerializerOptions _jsonOptions;
+
+    /// <summary>
+    /// Creates a new pull members up tool.
+    /// </summary>
+    public PullMembersUpTool(IWorkspaceProvider workspaceProvider)
+    {
+        _workspaceProvider = workspaceProvider;
+        _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = false
+        };
+    }
+
+    /// <inheritdoc />
+    public string Name => "pull_members_up";
+
+    /// <inheritdoc />
+    public string Description => "Move selected members from a derived type onto an existing base class or interface.";
+
+    /// <inheritdoc />
+    public object InputSchema => new
+    {
+        type = "object",
+        required = new[] { "solutionPath", "sourceFile", "typeName", "members" },
+        properties = new
+        {
+            solutionPath = new
+            {
+                type = "string",
+                description = "Absolute path to the .sln or .csproj file"
+            },
+            sourceFile = new
+            {
+                type = "string",
+                description = "Absolute path to the source file containing the derived type"
+            },
+            typeName = new
+            {
+                type = "string",
+                description = "Name of the derived class or struct"
+            },
+            members = new
+            {
+                type = "array",
+                items = new { type = "string" },
+                description = "Names of members to move to the base class or interface"
+            },
+            targetBaseType = new
+            {
+                type = "string",
+                description = "Target base class or interface name. Uses the nearest base if omitted."
+            },
+            makeAbstract = new
+            {
+                type = "boolean",
+                description = "Declare abstract members on the base class and keep overrides on the derived type",
+                @default = false
+            },
+            preview = new
+            {
+                type = "boolean",
+                description = "Return computed changes without applying",
+                @default = false
+            }
+        },
+        additionalProperties = false
+    };
+
+    /// <inheritdoc />
+    public async Task<ToolResult> ExecuteAsync(JsonElement? arguments, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (arguments == null)
+            {
+                return ToolResult.Error("Arguments required");
+            }
+
+            var args = JsonSerializer.Deserialize<PullMembersUpArgs>(arguments.Value.GetRawText(), _jsonOptions);
+            if (args == null)
+            {
+                return ToolResult.Error("Failed to parse arguments");
+            }
+
+            using var context = await _workspaceProvider.CreateContextAsync(
+                args.SolutionPath,
+                cancellationToken);
+
+            var operation = new PullMembersUpOperation(context);
+            var @params = new PullMembersUpParams
+            {
+                SourceFile = args.SourceFile,
+                TypeName = args.TypeName,
+                Members = args.Members ?? new List<string>(),
+                TargetBaseType = args.TargetBaseType,
+                MakeAbstract = args.MakeAbstract ?? false,
+                Preview = args.Preview ?? false
+            };
+
+            var result = await operation.ExecuteAsync(@params, cancellationToken);
+
+            var json = JsonSerializer.Serialize(result, _jsonOptions);
+            return result.Success ? ToolResult.Success(json) : ToolResult.Error(json);
+        }
+        catch (RefactoringException ex)
+        {
+            var error = ex.ToError();
+            var json = JsonSerializer.Serialize(new { success = false, error }, _jsonOptions);
+            return ToolResult.Error(json);
+        }
+        catch (Exception ex)
+        {
+            var json = JsonSerializer.Serialize(new
+            {
+                success = false,
+                error = new { code = "INTERNAL_ERROR", message = ex.Message }
+            }, _jsonOptions);
+            return ToolResult.Error(json);
+        }
+    }
+
+    private sealed class PullMembersUpArgs
+    {
+        public string SolutionPath { get; init; } = "";
+        public string SourceFile { get; init; } = "";
+        public string TypeName { get; init; } = "";
+        public List<string>? Members { get; init; }
+        public string? TargetBaseType { get; init; }
+        public bool? MakeAbstract { get; init; }
+        public bool? Preview { get; init; }
+    }
+}

--- a/tests/RoslynMcp.Cli.Tests/HelpGeneratorTests.cs
+++ b/tests/RoslynMcp.Cli.Tests/HelpGeneratorTests.cs
@@ -15,12 +15,12 @@ public class HelpGeneratorTests
     }
 
     [Fact]
-    public void GenerateGlobalHelp_Lists42Tools()
+    public void GenerateGlobalHelp_Lists43Tools()
     {
         var registry = ToolRegistry.BuildDefault();
         var help = HelpGenerator.GenerateGlobalHelp(registry);
-        Assert.Contains("Total: 42 tools", help);
-        Assert.Contains("inline-method", help);
+        Assert.Contains("Total: 43 tools", help);
+        Assert.Contains("pull-members-up", help);
     }
 
     [Fact]

--- a/tests/RoslynMcp.Cli.Tests/ToolRegistryTests.cs
+++ b/tests/RoslynMcp.Cli.Tests/ToolRegistryTests.cs
@@ -6,11 +6,11 @@ namespace RoslynMcp.Cli.Tests;
 public class ToolRegistryTests
 {
     [Fact]
-    public void BuildDefault_Registers42Tools()
+    public void BuildDefault_Registers43Tools()
     {
         var registry = ToolRegistry.BuildDefault();
         var tools = registry.GetAllTools();
-        Assert.Equal(42, tools.Count);
+        Assert.Equal(43, tools.Count);
     }
 
     [Fact]
@@ -84,6 +84,7 @@ public class ToolRegistryTests
     [Theory]
     [InlineData("extract-method", "Refactoring")]
     [InlineData("inline-method", "Refactoring")]
+    [InlineData("pull-members-up", "Refactoring")]
     [InlineData("find-references", "Query")]
     [InlineData("get-diagnostics", "Query")]
     [InlineData("diagnose", "Diagnostic")]
@@ -102,11 +103,11 @@ public class ToolRegistryTests
     }
 
     [Fact]
-    public void RefactoringToolCount_Is29()
+    public void RefactoringToolCount_Is30()
     {
         var registry = ToolRegistry.BuildDefault();
         var count = registry.GetAllTools().Count(t => t.Category == "Refactoring");
-        Assert.Equal(29, count);
+        Assert.Equal(30, count);
     }
 
     [Fact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Hierarchy/PullMembersUpOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Hierarchy/PullMembersUpOperationTests.cs
@@ -1,0 +1,825 @@
+using RoslynMcp.Contracts.Errors;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.Refactoring;
+using RoslynMcp.Core.Refactoring.Hierarchy;
+using RoslynMcp.Core.Workspace;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Refactoring.Hierarchy;
+
+/// <summary>
+/// Operation-level tests for <see cref="PullMembersUpOperation"/>.
+/// </summary>
+public class PullMembersUpOperationTests
+{
+    #region Input Validation
+
+    [Fact]
+    public void Validate_MissingSourceFile_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            PullMembersUpOperation.Validate(new PullMembersUpParams
+            {
+                SourceFile = "",
+                TypeName = "Derived",
+                Members = ["Foo"]
+            }));
+
+        Assert.Equal(ErrorCodes.MissingRequiredParam, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_MissingTypeName_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            PullMembersUpOperation.Validate(new PullMembersUpParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                TypeName = "",
+                Members = ["Foo"]
+            }));
+
+        Assert.Equal(ErrorCodes.MissingRequiredParam, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_MissingMembers_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            PullMembersUpOperation.Validate(new PullMembersUpParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                TypeName = "Derived",
+                Members = []
+            }));
+
+        Assert.Equal(ErrorCodes.MissingRequiredParam, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_RelativePath_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            PullMembersUpOperation.Validate(new PullMembersUpParams
+            {
+                SourceFile = "Derived.cs",
+                TypeName = "Derived",
+                Members = ["Foo"]
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidSourcePath, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_MissingFile_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            PullMembersUpOperation.Validate(new PullMembersUpParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                TypeName = "Derived",
+                Members = ["Foo"]
+            }));
+
+        Assert.Equal(ErrorCodes.SourceFileNotFound, ex.ErrorCode);
+    }
+
+    #endregion
+
+    #region P0 Happy Path
+
+    [SkippableFact]
+    public async Task PullMembersUp_MethodToBaseClass_MovesMemberAndMakesVirtual()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+            }
+
+            public class Dog : Animal
+            {
+                public int Speak()
+                {
+                    return 1;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new PullMembersUpOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new PullMembersUpParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Dog",
+            Members = ["Speak"]
+        });
+
+        Assert.True(result.Success);
+        Assert.False(result.Preview);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        var animal = ExtractTypeBody(text, "Animal");
+        var dog = ExtractTypeBody(text, "Dog");
+        Assert.Contains("Speak", animal);
+        Assert.Contains("virtual", animal);
+        Assert.DoesNotContain("Speak", dog);
+    }
+
+    [SkippableFact]
+    public async Task PullMembersUp_PropertyToBaseClass_MovesProperty()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+            }
+
+            public class Dog : Animal
+            {
+                public string Name { get; set; } = "";
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new PullMembersUpOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new PullMembersUpParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Dog",
+            Members = ["Name"]
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Contains("Name", ExtractTypeBody(text, "Animal"));
+        Assert.DoesNotContain("Name", ExtractTypeBody(text, "Dog"));
+    }
+
+    [SkippableFact]
+    public async Task PullMembersUp_MultipleMembers_MovesAll()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+            }
+
+            public class Dog : Animal
+            {
+                public string Name { get; set; } = "";
+
+                public int Speak()
+                {
+                    return 1;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new PullMembersUpOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new PullMembersUpParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Dog",
+            Members = ["Name", "Speak"]
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        var animal = ExtractTypeBody(text, "Animal");
+        var dog = ExtractTypeBody(text, "Dog");
+        Assert.Contains("Name", animal);
+        Assert.Contains("Speak", animal);
+        Assert.DoesNotContain("Name", dog);
+        Assert.DoesNotContain("Speak", dog);
+    }
+
+    [SkippableFact]
+    public async Task PullMembersUp_PrivateMethod_BecomesProtectedVirtual()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+            }
+
+            public class Dog : Animal
+            {
+                private void Log()
+                {
+                    System.Console.WriteLine("log");
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new PullMembersUpOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new PullMembersUpParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Dog",
+            Members = ["Log"]
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        var animal = ExtractTypeBody(text, "Animal");
+        Assert.Contains("protected", animal);
+        Assert.Contains("virtual", animal);
+        Assert.Contains("void Log()", animal);
+        Assert.DoesNotContain("private", animal);
+    }
+
+    [SkippableFact]
+    public async Task PullMembersUp_MakeAbstract_LeavesOverrideOnDerived()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+            }
+
+            public class Dog : Animal
+            {
+                public int Speak()
+                {
+                    return 1;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new PullMembersUpOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new PullMembersUpParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Dog",
+            Members = ["Speak"],
+            MakeAbstract = true
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        var animal = ExtractTypeBody(text, "Animal");
+        var dog = ExtractTypeBody(text, "Dog");
+        Assert.Contains("abstract", text);
+        Assert.Contains("abstract", animal);
+        Assert.Contains("Speak", animal);
+        Assert.DoesNotContain("return 1", animal);
+        Assert.Contains("override", dog);
+        Assert.Contains("return 1", dog);
+    }
+
+    [SkippableFact]
+    public async Task PullMembersUp_MethodToInterface_AddsSignatureAndKeepsImplementation()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public interface IAnimal
+            {
+            }
+
+            public class Dog : IAnimal
+            {
+                public int Speak()
+                {
+                    return 1;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new PullMembersUpOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new PullMembersUpParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Dog",
+            Members = ["Speak"]
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        var iface = ExtractTypeBody(text, "IAnimal");
+        var dog = ExtractTypeBody(text, "Dog");
+        Assert.Contains("Speak", iface);
+        Assert.Contains(";", iface);
+        Assert.DoesNotContain("return 1", iface);
+        Assert.Contains("Speak", dog);
+        Assert.Contains("return 1", dog);
+    }
+
+    [SkippableFact]
+    public async Task PullMembersUp_Preview_ReturnsChangesAndWritesNothing()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+            }
+
+            public class Dog : Animal
+            {
+                public int Speak()
+                {
+                    return 1;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var original = await File.ReadAllTextAsync(workspace.SourcePath);
+        var operation = new PullMembersUpOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new PullMembersUpParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Dog",
+            Members = ["Speak"],
+            Preview = true
+        });
+
+        Assert.True(result.Success);
+        Assert.True(result.Preview);
+        Assert.NotNull(result.PendingChanges);
+        Assert.NotEmpty(result.PendingChanges);
+        Assert.Contains(result.PendingChanges, c => c.AfterSnippet != null && c.AfterSnippet.Contains("Speak"));
+
+        var after = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Equal(original, after);
+    }
+
+    [SkippableFact]
+    public async Task PullMembersUp_ExplicitTarget_UsesNamedBase()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Creature
+            {
+            }
+
+            public class Animal : Creature
+            {
+            }
+
+            public class Dog : Animal
+            {
+                public int Speak()
+                {
+                    return 1;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new PullMembersUpOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new PullMembersUpParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Dog",
+            Members = ["Speak"],
+            TargetBaseType = "Creature"
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Contains("Speak", ExtractTypeBody(text, "Creature"));
+        Assert.DoesNotContain("Speak", ExtractTypeBody(text, "Animal"));
+        Assert.DoesNotContain("Speak", ExtractTypeBody(text, "Dog"));
+    }
+
+    #endregion
+
+    #region P0 Rejects
+
+    [SkippableFact]
+    public async Task PullMembersUp_NoBase_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Dog
+            {
+                public int Speak()
+                {
+                    return 1;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new PullMembersUpOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new PullMembersUpParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "Dog",
+                Members = ["Speak"]
+            }));
+
+        Assert.Equal(ErrorCodes.NoCommonBase, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task PullMembersUp_MissingNamedBase_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+            }
+
+            public class Dog : Animal
+            {
+                public int Speak()
+                {
+                    return 1;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new PullMembersUpOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new PullMembersUpParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "Dog",
+                Members = ["Speak"],
+                TargetBaseType = "IDisposable"
+            }));
+
+        Assert.Equal(ErrorCodes.BaseClassNotFound, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task PullMembersUp_NameConflict_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+                public int Speak()
+                {
+                    return 0;
+                }
+            }
+
+            public class Dog : Animal
+            {
+                public new int Speak()
+                {
+                    return 1;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new PullMembersUpOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new PullMembersUpParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "Dog",
+                Members = ["Speak"]
+            }));
+
+        Assert.Equal(ErrorCodes.ConflictsWithExistingMember, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task PullMembersUp_SignatureConflict_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+                public void Log(string message)
+                {
+                }
+            }
+
+            public class Dog : Animal
+            {
+                public void Log(string message)
+                {
+                    System.Console.WriteLine(message);
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new PullMembersUpOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new PullMembersUpParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "Dog",
+                Members = ["Log"]
+            }));
+
+        Assert.Equal(ErrorCodes.ConflictsWithExistingMember, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task PullMembersUp_DependsOnDerivedField_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+            }
+
+            public class Dog : Animal
+            {
+                private int _age;
+
+                public int Age()
+                {
+                    return _age;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new PullMembersUpOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new PullMembersUpParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "Dog",
+                Members = ["Age"]
+            }));
+
+        Assert.Equal(ErrorCodes.MemberDependsOnDerived, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task PullMembersUp_FieldToInterface_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public interface IAnimal
+            {
+            }
+
+            public class Dog : IAnimal
+            {
+                public int Age;
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new PullMembersUpOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new PullMembersUpParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "Dog",
+                Members = ["Age"]
+            }));
+
+        Assert.Equal(ErrorCodes.MemberNotInterfaceCompatible, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task PullMembersUp_PrivateMethodToInterface_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public interface IAnimal
+            {
+            }
+
+            public class Dog : IAnimal
+            {
+                private void Log()
+                {
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new PullMembersUpOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new PullMembersUpParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "Dog",
+                Members = ["Log"]
+            }));
+
+        Assert.Equal(ErrorCodes.MemberNotInterfaceCompatible, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task PullMembersUp_ExternalBase_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Dog : System.Exception
+            {
+                public int Speak()
+                {
+                    return 1;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new PullMembersUpOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new PullMembersUpParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "Dog",
+                Members = ["Speak"]
+            }));
+
+        Assert.Equal(ErrorCodes.BaseClassNotEditable, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task PullMembersUp_MemberNotFound_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+            }
+
+            public class Dog : Animal
+            {
+                public int Speak()
+                {
+                    return 1;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new PullMembersUpOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new PullMembersUpParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "Dog",
+                Members = ["Missing"]
+            }));
+
+        Assert.Equal(ErrorCodes.MemberNotFound, ex.ErrorCode);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static string AbsoluteTestPath() =>
+        OperatingSystem.IsWindows() ? @"C:\test\file.cs" : "/test/file.cs";
+
+    private static string NormalizeNewlines(string text) =>
+        text.Replace("\r\n", "\n");
+
+    private static string ExtractTypeBody(string source, string typeName)
+    {
+        var normalized = NormalizeNewlines(source);
+        var start = normalized.IndexOf("class " + typeName, StringComparison.Ordinal);
+        if (start < 0)
+            start = normalized.IndexOf("interface " + typeName, StringComparison.Ordinal);
+        if (start < 0)
+            throw new InvalidOperationException($"Type '{typeName}' not found.");
+
+        var open = normalized.IndexOf('{', start);
+        var depth = 0;
+        for (var i = open; i < normalized.Length; i++)
+        {
+            if (normalized[i] == '{') depth++;
+            else if (normalized[i] == '}')
+            {
+                depth--;
+                if (depth == 0)
+                    return normalized.Substring(open, i - open + 1);
+            }
+        }
+
+        return normalized[open..];
+    }
+
+    private sealed class TempWorkspace : IAsyncDisposable
+    {
+        public required string DirectoryPath { get; init; }
+        public required string ProjectPath { get; init; }
+        public required string SourcePath { get; init; }
+        public required WorkspaceContext Context { get; init; }
+
+        public static async Task<TempWorkspace> CreateAsync(string source, string fileName = "Types.cs")
+        {
+            Skip.IfNot(ModuleInitializer.MsBuildAvailable, ModuleInitializer.MsBuildError ?? "MSBuild not available");
+
+            var directory = Path.Combine(Path.GetTempPath(), "RoslynMcpPullMembersUp_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(directory);
+
+            var projectPath = Path.Combine(directory, "TestApp.csproj");
+            var sourcePath = Path.Combine(directory, fileName);
+
+            await File.WriteAllTextAsync(projectPath, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net9.0</TargetFramework>
+                    <Nullable>enable</Nullable>
+                  </PropertyGroup>
+                </Project>
+                """);
+            await File.WriteAllTextAsync(sourcePath, source);
+
+            try
+            {
+                var provider = new MSBuildWorkspaceProvider();
+                var context = await provider.CreateContextAsync(projectPath);
+                if (context.GetDocumentByPath(sourcePath) == null)
+                {
+                    context.Dispose();
+                    throw new InvalidOperationException($"Workspace loaded but did not include {sourcePath}.");
+                }
+
+                return new TempWorkspace
+                {
+                    DirectoryPath = directory,
+                    ProjectPath = projectPath,
+                    SourcePath = sourcePath,
+                    Context = context
+                };
+            }
+            catch (Exception ex) when (ex is not SkipException)
+            {
+                try
+                {
+                    Directory.Delete(directory, recursive: true);
+                }
+                catch
+                {
+                    // ignore cleanup failures
+                }
+
+                Skip.If(true, $"Workspace load failed: {ex.Message}");
+                throw;
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            Context.Dispose();
+            await Task.Run(() =>
+            {
+                try
+                {
+                    Directory.Delete(DirectoryPath, recursive: true);
+                }
+                catch
+                {
+                    // ignore locked temp files
+                }
+            });
+        }
+    }
+
+    #endregion
+}

--- a/tests/RoslynMcp.Server.Tests/Tools/PullMembersUpToolTests.cs
+++ b/tests/RoslynMcp.Server.Tests/Tools/PullMembersUpToolTests.cs
@@ -1,0 +1,148 @@
+using System.Text.Json;
+using RoslynMcp.Server.Tests.TestHelpers;
+using RoslynMcp.Server.Tools;
+using RoslynMcp.Server.Transport;
+using Xunit;
+
+namespace RoslynMcp.Server.Tests.Tools;
+
+/// <summary>
+/// Unit tests for PullMembersUpTool.
+/// Tests tool definition and argument validation.
+/// </summary>
+public class PullMembersUpToolTests
+{
+    private readonly PullMembersUpTool _tool;
+
+    public PullMembersUpToolTests()
+    {
+        _tool = new PullMembersUpTool(new ThrowingWorkspaceProvider());
+    }
+
+    #region GetDefinition Tests
+
+    [Fact]
+    public void GetDefinition_ReturnsCorrectName()
+    {
+        Assert.Equal("pull_members_up", _tool.Name);
+    }
+
+    [Fact]
+    public void GetDefinition_ReturnsNonEmptyDescription()
+    {
+        Assert.NotNull(_tool.Description);
+        Assert.NotEmpty(_tool.Description);
+    }
+
+    [Fact]
+    public void GetDefinition_ReturnsCorrectSchema()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.Equal("object", root.GetProperty("type").GetString());
+        Assert.True(root.TryGetProperty("properties", out _));
+        Assert.True(root.TryGetProperty("required", out _));
+    }
+
+    [Fact]
+    public void GetDefinition_HasRequiredFields()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var required = doc.RootElement.GetProperty("required");
+
+        var requiredFields = new List<string>();
+        foreach (var item in required.EnumerateArray())
+        {
+            requiredFields.Add(item.GetString()!);
+        }
+
+        Assert.Contains("solutionPath", requiredFields);
+        Assert.Contains("sourceFile", requiredFields);
+        Assert.Contains("typeName", requiredFields);
+        Assert.Contains("members", requiredFields);
+    }
+
+    [Fact]
+    public void GetDefinition_HasProperties_ForAllParameters()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var properties = doc.RootElement.GetProperty("properties");
+
+        Assert.True(properties.TryGetProperty("solutionPath", out _));
+        Assert.True(properties.TryGetProperty("sourceFile", out _));
+        Assert.True(properties.TryGetProperty("typeName", out _));
+        Assert.True(properties.TryGetProperty("members", out _));
+        Assert.True(properties.TryGetProperty("targetBaseType", out _));
+        Assert.True(properties.TryGetProperty("makeAbstract", out _));
+        Assert.True(properties.TryGetProperty("preview", out _));
+    }
+
+    [Fact]
+    public void GetDefinition_MembersProperty_IsArrayOfStrings()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var members = doc.RootElement.GetProperty("properties").GetProperty("members");
+
+        Assert.Equal("array", members.GetProperty("type").GetString());
+        Assert.Equal("string", members.GetProperty("items").GetProperty("type").GetString());
+    }
+
+    #endregion
+
+    #region ExecuteAsync Argument Validation Tests
+
+    [Fact]
+    public async Task ExecuteAsync_NullArguments_ReturnsError()
+    {
+        var result = await _tool.ExecuteAsync(null);
+
+        Assert.True(result.IsError);
+        Assert.Contains("Arguments required", GetResultText(result));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EmptyArguments_ReturnsError()
+    {
+        var args = JsonDocument.Parse("{}").RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MissingRequiredField_ReturnsError()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "solutionPath": "C:/test/test.sln",
+                "sourceFile": "C:/test/Test.cs",
+                "typeName": "Derived"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static string GetResultText(ToolResult result)
+    {
+        return result.Content.FirstOrDefault()?.Text ?? string.Empty;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds a bounded `pull_members_up` / `PullMembersUpOperation` tool that moves selected members from a derived type onto an existing base class or interface.

This follows the shipped extract/inline host wiring: params in Contracts, operation under `Refactoring/Hierarchy`, MCP tool next to the other refactoring tools, and CLI registration in `ToolRegistry`.

Behavior:
- Pull one or more methods, properties, fields, or events to the nearest (or named) base class or interface
- Adjust accessibility (private → protected) and add `virtual` when moving an implementation onto a class
- `makeAbstract` declares abstract members on the base and keeps overrides on the derived type
- Interface targets receive signatures only; implementations stay on the derived type
- Preview mode returns pending changes without writing files
- Rejects missing bases, external/uneditable bases, sealed classes, derived-only dependencies, interface-incompatible members, and name/signature conflicts

## Related Issues

Closes #32

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Test additions or updates

## Testing

- [x] Solution builds (0 warnings, including TreatWarningsAsErrors)
- [x] `dotnet format --verify-no-changes` passes
- [x] New tests added for happy path, preview, and P0 rejects
- [x] Feature tests pass locally: 22 operation + 9 tool + 42 CLI registry/help

**Test Configuration**:
- OS: Linux
- .NET Version: 9.0.317

## Checklist

- [x] Code follows existing extract/inline operation patterns
- [x] XML documentation added for public APIs
- [x] README / changelog / tool counts updated
- [x] Dependabot PRs #12–#17 left alone
- [x] Out of scope left out: `push_members_down`, `use_base_type`, `inline_constant`, undo

## Additional Notes

Error codes 3105–3110 match the Phase 2 hierarchy BA range (`MEMBER_DEPENDS_ON_DERIVED`, `BASE_CLASS_IS_SEALED`, `NO_COMMON_BASE`, `CONFLICTS_WITH_EXISTING_MEMBER`, `BASE_CLASS_NOT_EDITABLE`, `MEMBER_NOT_INTERFACE_COMPATIBLE`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7c79955-cdf5-4337-8b55-baf39175c5c7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7c79955-cdf5-4337-8b55-baf39175c5c7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

