### PR TITLE
Add push_members_down hierarchy refactoring

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "roslyn-mcp",
   "version": "0.4.1",
-  "description": "Roslyn-powered C# refactoring MCP server — 43 tools for code navigation, analysis, generation, and refactoring across entire .NET solutions",
+  "description": "Roslyn-powered C# refactoring MCP server — 44 tools for code navigation, analysis, generation, and refactoring across entire .NET solutions",
   "author": {
     "name": "Joshua Ramirez"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 - `pull_members_up` — move selected members from a derived type onto an existing base class or interface, with preview mode and rejects for missing bases, interface-incompatible members, and name/signature conflicts
+- `push_members_down` — move selected members from a base type down onto derived types, with optional named targets, preview mode, and rejects for missing derived types, conflicts, interface-incompatible members, and uneditable targets
 
 ## [0.4.0] - 2026-02-23
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Let AI assistants like Claude safely refactor your C# codebase using the same Roslyn compiler platform that powers Visual Studio.
 
-Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that exposes **43 Roslyn-powered tools** to AI assistants and other MCP clients. It combines 21 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 7 code conversion tools -- giving your AI deep code intelligence, comprehensive refactoring, and modern C# syntax transformations with full solution-wide reference tracking and preview support.
+Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that exposes **44 Roslyn-powered tools** to AI assistants and other MCP clients. It combines 22 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 7 code conversion tools -- giving your AI deep code intelligence, comprehensive refactoring, and modern C# syntax transformations with full solution-wide reference tracking and preview support.
 
 ---
 
@@ -30,7 +30,7 @@ Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotoc
 
 ## Why RoslynMcpServer?
 
-- **43 tools** -- refactoring, navigation, analysis, generation, and conversion tools, the most comprehensive Roslyn MCP server available
+- **44 tools** -- refactoring, navigation, analysis, generation, and conversion tools, the most comprehensive Roslyn MCP server available
 - **Preview mode on every operation** -- see exactly what will change before applying
 - **Atomic file writes with rollback** -- if any file write fails, all changes are reverted
 - **Solution-wide reference updates** -- renames and moves propagate across your entire solution
@@ -102,7 +102,7 @@ Claude will use the `rename_symbol` tool to rename the class and update every re
 
 ## Standalone CLI
 
-All 43 tools are also available as a standalone CLI for use in scripts, CI/CD pipelines, and terminals without an AI assistant.
+All 44 tools are also available as a standalone CLI for use in scripts, CI/CD pipelines, and terminals without an AI assistant.
 
 ### Install
 
@@ -202,6 +202,7 @@ All tools accept a `solutionPath` parameter (absolute path to a `.sln`, `.slnx`,
 | `extract_interface` | Extract an interface from a class's public members. | `sourceFile`, `typeName`, `interfaceName`, `members`, `targetFile` |
 | `extract_base_class` | Extract members to a new base class. | `sourceFile`, `typeName`, `baseClassName`, `members`, `targetFile`, `makeAbstract` |
 | `pull_members_up` | Move selected members from a derived type onto an existing base class or interface. | `sourceFile`, `typeName`, `members`, `targetBaseType`, `makeAbstract` |
+| `push_members_down` | Move selected members from a base type down onto derived types. | `sourceFile`, `typeName`, `members`, `targetDerivedTypes`, `leaveAbstract` |
 
 ### Inline
 

--- a/src/RoslynMcp.Cli/ToolRegistry.cs
+++ b/src/RoslynMcp.Cli/ToolRegistry.cs
@@ -47,7 +47,7 @@ public sealed class ToolEntry
 }
 
 /// <summary>
-/// Maps tool names to execution delegates for all 42 Roslyn tools.
+/// Maps tool names to execution delegates for all 44 Roslyn tools.
 /// </summary>
 public sealed class ToolRegistry
 {
@@ -139,7 +139,7 @@ public sealed class ToolRegistry
         _tools.Values.OrderBy(t => t.Category).ThenBy(t => t.Name).ToList();
 
     /// <summary>
-    /// Build the default registry with all 43 tools registered.
+    /// Build the default registry with all 44 tools registered.
     /// </summary>
     public static ToolRegistry BuildDefault()
     {
@@ -160,6 +160,8 @@ public sealed class ToolRegistry
             "introduce-parameter", "Introduce a method parameter from an expression");
         r.RegisterRefactoring<PullMembersUpOperation, PullMembersUpParams>(
             "pull-members-up", "Move selected members from a derived type onto an existing base class or interface");
+        r.RegisterRefactoring<PushMembersDownOperation, PushMembersDownParams>(
+            "push-members-down", "Move selected members from a base type down onto derived types");
 
         // ── Refactoring: Rename (1) ───────────────────────────────────
         r.RegisterRefactoring<RenameSymbolOperation, RenameSymbolParams>(

--- a/src/RoslynMcp.Contracts/Enums/RefactoringKind.cs
+++ b/src/RoslynMcp.Contracts/Enums/RefactoringKind.cs
@@ -35,6 +35,9 @@ public enum RefactoringKind
     /// <summary>Move selected members from a derived type onto an existing base class or interface.</summary>
     PullMembersUp,
 
+    /// <summary>Move selected members from a base type down onto derived types.</summary>
+    PushMembersDown,
+
     /// <summary>Extract expression to variable.</summary>
     ExtractVariable,
 

--- a/src/RoslynMcp.Contracts/Errors/ErrorCodes.cs
+++ b/src/RoslynMcp.Contracts/Errors/ErrorCodes.cs
@@ -333,6 +333,12 @@ public static class ErrorCodes
     /// <summary>Member cannot be declared on an interface (field, constructor, static, or non-public).</summary>
     public const string MemberNotInterfaceCompatible = "3110";
 
+    /// <summary>Derived class or interface is not editable (external assembly).</summary>
+    public const string DerivedClassNotEditable = "3111";
+
+    /// <summary>Member is required by an interface or abstract contract and cannot be removed from the base.</summary>
+    public const string MemberRequiredByContract = "3112";
+
     // ============================================
     // System Errors (4xxx)
     // ============================================

--- a/src/RoslynMcp.Contracts/Models/PushMembersDownParams.cs
+++ b/src/RoslynMcp.Contracts/Models/PushMembersDownParams.cs
@@ -1,0 +1,40 @@
+namespace RoslynMcp.Contracts.Models;
+
+/// <summary>
+/// Parameters for the push_members_down tool.
+/// </summary>
+public sealed class PushMembersDownParams
+{
+    /// <summary>
+    /// Absolute path to the source file containing the base type.
+    /// </summary>
+    public required string SourceFile { get; init; }
+
+    /// <summary>
+    /// Name of the base class or interface that currently declares the members.
+    /// </summary>
+    public required string TypeName { get; init; }
+
+    /// <summary>
+    /// Names of members to push down. At least one is required.
+    /// </summary>
+    public required IReadOnlyList<string> Members { get; init; }
+
+    /// <summary>
+    /// Specific derived type names to push to. If omitted or empty, pushes
+    /// to every direct derived class, struct, or interface in the workspace.
+    /// </summary>
+    public IReadOnlyList<string>? TargetDerivedTypes { get; init; }
+
+    /// <summary>
+    /// Leave an abstract declaration on the source class and add overrides
+    /// on the derived types. Ignored when the source is an interface
+    /// (interface members always remain). Default: false.
+    /// </summary>
+    public bool LeaveAbstract { get; init; }
+
+    /// <summary>
+    /// Return computed changes without applying. Default: false.
+    /// </summary>
+    public bool Preview { get; init; }
+}

--- a/src/RoslynMcp.Core/Refactoring/Hierarchy/PushMembersDownOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Hierarchy/PushMembersDownOperation.cs
@@ -91,6 +91,8 @@ public sealed class PushMembersDownOperation : RefactoringOperationBase<PushMemb
 
         var leaveAbstract = @params.LeaveAbstract && sourceSymbol.TypeKind != TypeKind.Interface;
         ValidateMembersForPush(members, sourceSymbol, targets, leaveAbstract);
+        await ValidateNoBreakingReferencesAsync(
+            members, sourceSymbol, targets, leaveAbstract, cancellationToken);
 
         var pushedNames = members.Select(m => m.Name).ToList();
         var derivedUpdates = new List<DerivedUpdate>();
@@ -99,7 +101,7 @@ public sealed class PushMembersDownOperation : RefactoringOperationBase<PushMemb
         {
             var original = await GetTypeDeclarationAsync(target, cancellationToken);
             var copies = members
-                .Select(member => ConvertForDerived(member.Syntax, target, leaveAbstract))
+                .Select(member => ConvertForDerived(member, sourceSymbol, target, semanticModel, leaveAbstract))
                 .ToList();
             derivedUpdates.Add(new DerivedUpdate(target, original, AddMembersToType(original, copies)));
         }
@@ -358,8 +360,17 @@ public sealed class PushMembersDownOperation : RefactoringOperationBase<PushMemb
                 ImplementsInterfaceMember(member.Symbol, source))
             {
                 throw new RefactoringException(
-                    ErrorCodes.MemberNotInterfaceCompatible,
+                    ErrorCodes.MemberRequiredByContract,
                     $"Member '{member.Name}' implements an interface contract on '{source.Name}' and cannot be removed.");
+            }
+
+            if (source.TypeKind != TypeKind.Interface &&
+                !leaveAbstract &&
+                IsRequiredByAbstractBase(member.Symbol))
+            {
+                throw new RefactoringException(
+                    ErrorCodes.MemberRequiredByContract,
+                    $"Member '{member.Name}' is required by an abstract base contract and cannot be removed.");
             }
 
             foreach (var target in targets)
@@ -381,6 +392,98 @@ public sealed class PushMembersDownOperation : RefactoringOperationBase<PushMemb
         }
     }
 
+    private async Task ValidateNoBreakingReferencesAsync(
+        IReadOnlyList<PushableMember> members,
+        INamedTypeSymbol source,
+        IReadOnlyList<INamedTypeSymbol> targets,
+        bool leaveAbstract,
+        CancellationToken cancellationToken)
+    {
+        if (leaveAbstract || source.TypeKind == TypeKind.Interface)
+            return;
+
+        foreach (var member in members)
+        {
+            var references = await SymbolFinder.FindReferencesAsync(
+                member.Symbol, Context.Solution, cancellationToken);
+
+            foreach (var referenced in references)
+            {
+                foreach (var location in referenced.Locations)
+                {
+                    if (location.IsImplicit || location.Location.SourceTree == null)
+                        continue;
+
+                    if (member.Syntax.SyntaxTree == location.Location.SourceTree &&
+                        member.Syntax.Span.Contains(location.Location.SourceSpan))
+                    {
+                        continue;
+                    }
+
+                    var document = location.Document;
+                    var root = await document.GetSyntaxRootAsync(cancellationToken);
+                    var model = await document.GetSemanticModelAsync(cancellationToken);
+                    if (root == null || model == null)
+                        continue;
+
+                    var node = root.FindNode(location.Location.SourceSpan);
+                    var receiver = GetReceiverType(node, model);
+                    if (WillHaveMemberAfterPush(receiver, targets))
+                        continue;
+
+                    throw new RefactoringException(
+                        ErrorCodes.MemberRequiredByContract,
+                        $"Cannot push '{member.Name}': it is still referenced through '{source.Name}' or a type that will not receive the member.");
+                }
+            }
+        }
+    }
+
+    private static ITypeSymbol? GetReceiverType(SyntaxNode node, SemanticModel model)
+    {
+        var name = node as SimpleNameSyntax ??
+                   node.DescendantNodesAndSelf().OfType<SimpleNameSyntax>().FirstOrDefault();
+
+        if (name?.Parent is MemberAccessExpressionSyntax access && access.Name == name)
+            return model.GetTypeInfo(access.Expression).Type;
+
+        if (name?.Parent is MemberBindingExpressionSyntax &&
+            name.Parent.Parent is ConditionalAccessExpressionSyntax conditional)
+        {
+            return model.GetTypeInfo(conditional.Expression).Type;
+        }
+
+        return model.GetEnclosingSymbol(node.SpanStart)?.ContainingType;
+    }
+
+    private static bool WillHaveMemberAfterPush(ITypeSymbol? receiver, IReadOnlyList<INamedTypeSymbol> targets)
+    {
+        if (receiver is not INamedTypeSymbol type)
+            return false;
+
+        for (var current = type; current != null; current = current.BaseType)
+        {
+            if (targets.Any(target =>
+                    SymbolEqualityComparer.Default.Equals(target, current) ||
+                    SymbolEqualityComparer.Default.Equals(target.OriginalDefinition, current.OriginalDefinition)))
+            {
+                return true;
+            }
+        }
+
+        foreach (var iface in type.AllInterfaces)
+        {
+            if (targets.Any(target =>
+                    SymbolEqualityComparer.Default.Equals(target, iface) ||
+                    SymbolEqualityComparer.Default.Equals(target.OriginalDefinition, iface.OriginalDefinition)))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     /// <summary>
     /// Returns whether <paramref name="member"/> can be copied onto <paramref name="target"/>.
     /// </summary>
@@ -396,7 +499,30 @@ public sealed class PushMembersDownOperation : RefactoringOperationBase<PushMemb
     }
 
     private static bool CanBeAbstract(ISymbol member) =>
-        member is IMethodSymbol or IPropertySymbol;
+        !member.IsStatic && member is IMethodSymbol or IPropertySymbol;
+
+    private static bool IsRequiredByAbstractBase(ISymbol member)
+    {
+        if (member is IMethodSymbol method && method.IsOverride)
+        {
+            for (var overridden = method.OverriddenMethod; overridden != null; overridden = overridden.OverriddenMethod)
+            {
+                if (overridden.IsAbstract)
+                    return true;
+            }
+        }
+
+        if (member is IPropertySymbol property && property.IsOverride)
+        {
+            for (var overridden = property.OverriddenProperty; overridden != null; overridden = overridden.OverriddenProperty)
+            {
+                if (overridden.IsAbstract)
+                    return true;
+            }
+        }
+
+        return false;
+    }
 
     private static bool ImplementsInterfaceMember(ISymbol member, INamedTypeSymbol source)
     {
@@ -470,22 +596,125 @@ public sealed class PushMembersDownOperation : RefactoringOperationBase<PushMemb
     }
 
     private static MemberDeclarationSyntax ConvertForDerived(
-        MemberDeclarationSyntax member,
+        PushableMember member,
+        INamedTypeSymbol source,
         INamedTypeSymbol target,
+        SemanticModel semanticModel,
         bool leaveAbstract)
     {
-        if (target.TypeKind == TypeKind.Interface)
-            return ConvertToInterfaceMember(member);
+        var substituted = SubstituteTypeParameters(member.Syntax, semanticModel, source, target);
+        var isolated = IsolateMemberSyntax(substituted, member.Name);
 
-        return leaveAbstract
-            ? AddOverrideModifier(member)
-            : StripHierarchyModifiers(member);
+        if (target.TypeKind == TypeKind.Interface)
+            return ConvertToInterfaceMember(isolated);
+
+        var converted = leaveAbstract
+            ? AddOverrideModifier(isolated)
+            : StripHierarchyModifiers(isolated);
+
+        if (source.TypeKind == TypeKind.Interface && target.TypeKind != TypeKind.Interface)
+            converted = EnsurePublicAccessibility(converted);
+
+        return converted;
+    }
+
+    private static MemberDeclarationSyntax EnsurePublicAccessibility(MemberDeclarationSyntax member)
+    {
+        if (HasAccessibility(member.Modifiers))
+            return member;
+
+        return member.WithModifiers(
+            member.Modifiers.Insert(0, SyntaxFactory.Token(SyntaxKind.PublicKeyword)));
+    }
+
+    /// <summary>
+    /// Keeps only the requested declarator when a field or event field declares
+    /// multiple variables.
+    /// </summary>
+    internal static MemberDeclarationSyntax IsolateMemberSyntax(MemberDeclarationSyntax syntax, string name)
+    {
+        return syntax switch
+        {
+            FieldDeclarationSyntax field when field.Declaration.Variables.Count > 1 =>
+                field.WithDeclaration(field.Declaration.WithVariables(
+                    SyntaxFactory.SingletonSeparatedList(
+                        field.Declaration.Variables.First(v => v.Identifier.Text == name)))),
+            EventFieldDeclarationSyntax eventField when eventField.Declaration.Variables.Count > 1 =>
+                eventField.WithDeclaration(eventField.Declaration.WithVariables(
+                    SyntaxFactory.SingletonSeparatedList(
+                        eventField.Declaration.Variables.First(v => v.Identifier.Text == name)))),
+            _ => syntax
+        };
+    }
+
+    private static MemberDeclarationSyntax SubstituteTypeParameters(
+        MemberDeclarationSyntax member,
+        SemanticModel semanticModel,
+        INamedTypeSymbol source,
+        INamedTypeSymbol target)
+    {
+        var constructed = GetConstructedBase(source, target);
+        if (constructed == null || constructed.TypeArguments.Length == 0 || source.TypeParameters.Length == 0)
+            return member;
+
+        var replacements = new Dictionary<SyntaxNode, SyntaxNode>();
+        foreach (var identifier in member.DescendantNodes().OfType<IdentifierNameSyntax>())
+        {
+            if (replacements.ContainsKey(identifier))
+                continue;
+
+            if (semanticModel.GetSymbolInfo(identifier).Symbol is not ITypeParameterSymbol typeParameter)
+                continue;
+
+            if (typeParameter.ContainingSymbol is not INamedTypeSymbol containingType)
+                continue;
+
+            if (!SymbolEqualityComparer.Default.Equals(containingType.OriginalDefinition, source.OriginalDefinition))
+                continue;
+
+            var index = -1;
+            for (var i = 0; i < source.TypeParameters.Length; i++)
+            {
+                if (source.TypeParameters[i].Name == typeParameter.Name)
+                {
+                    index = i;
+                    break;
+                }
+            }
+
+            if (index < 0 || index >= constructed.TypeArguments.Length)
+                continue;
+
+            var replacement = SyntaxFactory
+                .ParseTypeName(constructed.TypeArguments[index].ToDisplayString())
+                .WithTriviaFrom(identifier);
+            replacements[identifier] = replacement;
+        }
+
+        return replacements.Count == 0
+            ? member
+            : member.ReplaceNodes(replacements.Keys, (original, _) => replacements[original]);
+    }
+
+    private static INamedTypeSymbol? GetConstructedBase(INamedTypeSymbol source, INamedTypeSymbol target)
+    {
+        for (var current = target.BaseType; current != null; current = current.BaseType)
+        {
+            if (SymbolEqualityComparer.Default.Equals(current.OriginalDefinition, source.OriginalDefinition))
+                return current;
+        }
+
+        return target.AllInterfaces.FirstOrDefault(iface =>
+            SymbolEqualityComparer.Default.Equals(iface.OriginalDefinition, source.OriginalDefinition));
     }
 
     private static MemberDeclarationSyntax ConvertToInterfaceMember(MemberDeclarationSyntax member)
     {
         return member switch
         {
+            MethodDeclarationSyntax method when HasImplementationBody(method) => method
+                .WithModifiers(SyntaxFactory.TokenList())
+                .NormalizeWhitespace(),
             MethodDeclarationSyntax method => method
                 .WithModifiers(SyntaxFactory.TokenList())
                 .WithBody(null)
@@ -493,6 +722,9 @@ public sealed class PushMembersDownOperation : RefactoringOperationBase<PushMemb
                 .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken))
                 .NormalizeWhitespace(),
             PropertyDeclarationSyntax property => ToInterfaceProperty(property),
+            EventDeclarationSyntax eventDecl when eventDecl.AccessorList != null => eventDecl
+                .WithModifiers(SyntaxFactory.TokenList())
+                .NormalizeWhitespace(),
             EventDeclarationSyntax eventDecl => eventDecl
                 .WithModifiers(SyntaxFactory.TokenList())
                 .WithAccessorList(null)
@@ -507,8 +739,20 @@ public sealed class PushMembersDownOperation : RefactoringOperationBase<PushMemb
         };
     }
 
+    private static bool HasImplementationBody(MethodDeclarationSyntax method) =>
+        method.Body != null || method.ExpressionBody != null;
+
     private static PropertyDeclarationSyntax ToInterfaceProperty(PropertyDeclarationSyntax property)
     {
+        if (property.ExpressionBody != null ||
+            (property.AccessorList?.Accessors.Any(accessor =>
+                accessor.Body != null || accessor.ExpressionBody != null) ?? false))
+        {
+            return property
+                .WithModifiers(SyntaxFactory.TokenList())
+                .NormalizeWhitespace();
+        }
+
         var accessors = new List<AccessorDeclarationSyntax>();
         if (property.AccessorList != null)
         {
@@ -607,39 +851,45 @@ public sealed class PushMembersDownOperation : RefactoringOperationBase<PushMemb
 
     private static MemberDeclarationSyntax StripHierarchyModifiers(MemberDeclarationSyntax member)
     {
+        // Keep virtual/override so further descendants continue to dispatch
+        // and compile. Abstract is replaced with a body plus virtual.
         return member switch
         {
-            MethodDeclarationSyntax method => EnsureMethodBody(method
-                    .WithModifiers(StripModifiers(
+            MethodDeclarationSyntax method => EnsureMethodBody(
+                    WithVirtualIfAbstract(method.WithModifiers(StripModifiers(
                         method.Modifiers,
-                        SyntaxKind.VirtualKeyword,
-                        SyntaxKind.OverrideKeyword,
                         SyntaxKind.AbstractKeyword,
                         SyntaxKind.NewKeyword,
-                        SyntaxKind.SealedKeyword)))
+                        SyntaxKind.SealedKeyword)),
+                        method.Modifiers.Any(SyntaxKind.AbstractKeyword)))
                 .NormalizeWhitespace(),
-            PropertyDeclarationSyntax property => property
-                .WithModifiers(StripModifiers(
+            PropertyDeclarationSyntax property =>
+                WithVirtualIfAbstract(property.WithModifiers(StripModifiers(
                     property.Modifiers,
-                    SyntaxKind.VirtualKeyword,
-                    SyntaxKind.OverrideKeyword,
                     SyntaxKind.AbstractKeyword,
                     SyntaxKind.NewKeyword,
-                    SyntaxKind.SealedKeyword))
+                    SyntaxKind.SealedKeyword)),
+                    property.Modifiers.Any(SyntaxKind.AbstractKeyword))
                 .NormalizeWhitespace(),
             FieldDeclarationSyntax field => field.NormalizeWhitespace(),
             EventFieldDeclarationSyntax eventField => eventField.NormalizeWhitespace(),
             EventDeclarationSyntax eventDecl => eventDecl
                 .WithModifiers(StripModifiers(
                     eventDecl.Modifiers,
-                    SyntaxKind.VirtualKeyword,
-                    SyntaxKind.OverrideKeyword,
                     SyntaxKind.AbstractKeyword,
                     SyntaxKind.NewKeyword,
                     SyntaxKind.SealedKeyword))
                 .NormalizeWhitespace(),
             _ => member.NormalizeWhitespace()
         };
+    }
+
+    private static T WithVirtualIfAbstract<T>(T member, bool wasAbstract) where T : MemberDeclarationSyntax
+    {
+        if (!wasAbstract || member.Modifiers.Any(SyntaxKind.VirtualKeyword) || member.Modifiers.Any(SyntaxKind.OverrideKeyword))
+            return member;
+
+        return (T)member.AddModifiers(SyntaxFactory.Token(SyntaxKind.VirtualKeyword));
     }
 
     private static SyntaxTokenList ToAbstractModifiers(SyntaxTokenList modifiers)
@@ -705,14 +955,23 @@ public sealed class PushMembersDownOperation : RefactoringOperationBase<PushMemb
         if (source.TypeKind == TypeKind.Interface)
             return sourceDecl;
 
-        var pushedSyntax = members.Select(m => m.Syntax).ToHashSet();
+        var pushedNamesBySyntax = members
+            .GroupBy(member => member.Syntax)
+            .ToDictionary(group => group.Key, group => group.Select(member => member.Name).ToHashSet());
+
         var newMembers = new List<MemberDeclarationSyntax>();
 
         foreach (var member in sourceDecl.Members)
         {
-            if (!pushedSyntax.Contains(member))
+            if (!pushedNamesBySyntax.TryGetValue(member, out var pushedNames))
             {
                 newMembers.Add(member);
+                continue;
+            }
+
+            if (TryKeepRemainingDeclarators(member, pushedNames, out var remaining))
+            {
+                newMembers.Add(remaining);
                 continue;
             }
 
@@ -730,6 +989,43 @@ public sealed class PushMembersDownOperation : RefactoringOperationBase<PushMemb
         }
 
         return updated;
+    }
+
+    private static bool TryKeepRemainingDeclarators(
+        MemberDeclarationSyntax member,
+        HashSet<string> pushedNames,
+        out MemberDeclarationSyntax remaining)
+    {
+        remaining = member;
+        switch (member)
+        {
+            case FieldDeclarationSyntax field:
+                {
+                    var keep = field.Declaration.Variables
+                        .Where(variable => !pushedNames.Contains(variable.Identifier.Text))
+                        .ToList();
+                    if (keep.Count == 0)
+                        return false;
+
+                    remaining = field.WithDeclaration(
+                        field.Declaration.WithVariables(SyntaxFactory.SeparatedList(keep)));
+                    return true;
+                }
+            case EventFieldDeclarationSyntax eventField:
+                {
+                    var keep = eventField.Declaration.Variables
+                        .Where(variable => !pushedNames.Contains(variable.Identifier.Text))
+                        .ToList();
+                    if (keep.Count == 0)
+                        return false;
+
+                    remaining = eventField.WithDeclaration(
+                        eventField.Declaration.WithVariables(SyntaxFactory.SeparatedList(keep)));
+                    return true;
+                }
+            default:
+                return false;
+        }
     }
 
     /// <summary>

--- a/src/RoslynMcp.Core/Refactoring/Hierarchy/PushMembersDownOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Hierarchy/PushMembersDownOperation.cs
@@ -1,0 +1,865 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.FindSymbols;
+using RoslynMcp.Contracts.Enums;
+using RoslynMcp.Contracts.Errors;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.FileSystem;
+using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Workspace;
+
+namespace RoslynMcp.Core.Refactoring.Hierarchy;
+
+/// <summary>
+/// Moves selected members from a base type down onto derived types.
+/// </summary>
+public sealed class PushMembersDownOperation : RefactoringOperationBase<PushMembersDownParams>
+{
+    /// <summary>
+    /// Creates a new push-members-down operation.
+    /// </summary>
+    public PushMembersDownOperation(WorkspaceContext context) : base(context)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override void ValidateParams(PushMembersDownParams @params) => Validate(@params);
+
+    /// <summary>
+    /// Validates push-members-down parameters. Internal so tests can exercise
+    /// input rules without loading a workspace.
+    /// </summary>
+    internal static void Validate(PushMembersDownParams @params)
+    {
+        if (string.IsNullOrWhiteSpace(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "sourceFile is required.");
+
+        if (string.IsNullOrWhiteSpace(@params.TypeName))
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "typeName is required.");
+
+        if (@params.Members == null || @params.Members.Count == 0 || @params.Members.All(string.IsNullOrWhiteSpace))
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "members is required.");
+
+        if (!PathResolver.IsAbsolutePath(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.InvalidSourcePath, "sourceFile must be an absolute path.");
+
+        if (!PathResolver.IsValidCSharpFilePath(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.InvalidSourcePath, "sourceFile must be a .cs file.");
+
+        if (!File.Exists(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.SourceFileNotFound, $"Source file not found: {@params.SourceFile}");
+    }
+
+    /// <inheritdoc />
+    protected override async Task<RefactoringResult> ExecuteCoreAsync(
+        Guid operationId,
+        PushMembersDownParams @params,
+        CancellationToken cancellationToken)
+    {
+        var document = GetDocumentOrThrow(@params.SourceFile);
+        var root = await document.GetSyntaxRootAsync(cancellationToken);
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken);
+
+        if (root == null || semanticModel == null)
+            throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse file.");
+
+        var sourceDecl = FindTypeDeclaration(root, @params.TypeName);
+        if (sourceDecl == null)
+        {
+            throw new RefactoringException(
+                ErrorCodes.TypeNotFound,
+                $"Type '{@params.TypeName}' not found in file.");
+        }
+
+        var sourceSymbol = semanticModel.GetDeclaredSymbol(sourceDecl, cancellationToken) as INamedTypeSymbol;
+        if (sourceSymbol == null)
+            throw new RefactoringException(ErrorCodes.RoslynError, "Could not resolve type symbol.");
+
+        var members = FindMembersToPush(sourceDecl, @params.Members, semanticModel, cancellationToken);
+        var targets = await GetDerivedTypes(sourceSymbol, @params.TargetDerivedTypes, cancellationToken);
+
+        if (targets.Count == 0)
+        {
+            throw new RefactoringException(
+                ErrorCodes.DerivedClassesNotFound,
+                $"Type '{sourceSymbol.Name}' has no derived types to push members to.");
+        }
+
+        foreach (var target in targets)
+            ValidateDerivedIsEditable(target);
+
+        var leaveAbstract = @params.LeaveAbstract && sourceSymbol.TypeKind != TypeKind.Interface;
+        ValidateMembersForPush(members, sourceSymbol, targets, leaveAbstract);
+
+        var pushedNames = members.Select(m => m.Name).ToList();
+        var derivedUpdates = new List<DerivedUpdate>();
+
+        foreach (var target in targets)
+        {
+            var original = await GetTypeDeclarationAsync(target, cancellationToken);
+            var copies = members
+                .Select(member => ConvertForDerived(member.Syntax, target, leaveAbstract))
+                .ToList();
+            derivedUpdates.Add(new DerivedUpdate(target, original, AddMembersToType(original, copies)));
+        }
+
+        var sourceReplacement = BuildSourceReplacement(sourceDecl, members, sourceSymbol, leaveAbstract);
+
+        if (@params.Preview)
+        {
+            return CreatePreviewResult(
+                operationId,
+                @params,
+                sourceSymbol,
+                pushedNames,
+                sourceDecl,
+                sourceReplacement,
+                derivedUpdates);
+        }
+
+        var solution = await ApplyChangesAsync(
+            document,
+            sourceDecl,
+            sourceReplacement,
+            derivedUpdates,
+            cancellationToken);
+
+        var commitResult = await CommitChangesAsync(solution, cancellationToken);
+
+        return RefactoringResult.Succeeded(
+            operationId,
+            new FileChanges
+            {
+                FilesModified = commitResult.FilesModified,
+                FilesCreated = commitResult.FilesCreated,
+                FilesDeleted = commitResult.FilesDeleted
+            },
+            new Contracts.Models.SymbolInfo
+            {
+                Name = sourceSymbol.Name,
+                FullyQualifiedName = sourceSymbol.ToDisplayString(),
+                Kind = sourceSymbol.TypeKind == TypeKind.Interface
+                    ? Contracts.Enums.SymbolKind.Interface
+                    : Contracts.Enums.SymbolKind.Class
+            },
+            0,
+            0);
+    }
+
+    private static TypeDeclarationSyntax? FindTypeDeclaration(SyntaxNode root, string typeName)
+    {
+        var simpleName = typeName.Contains('.')
+            ? typeName[(typeName.LastIndexOf('.') + 1)..]
+            : typeName;
+
+        return root.DescendantNodes()
+            .OfType<TypeDeclarationSyntax>()
+            .FirstOrDefault(t => t.Identifier.Text == simpleName);
+    }
+
+    internal static async Task<IReadOnlyList<INamedTypeSymbol>> GetDerivedTypes(
+        INamedTypeSymbol source,
+        IReadOnlyList<string>? targetNames,
+        Solution solution,
+        CancellationToken cancellationToken)
+    {
+        var discovered = new List<INamedTypeSymbol>();
+
+        if (source.TypeKind == TypeKind.Interface)
+        {
+            var derivedInterfaces = await SymbolFinder.FindDerivedInterfacesAsync(
+                source, solution, transitive: false, cancellationToken: cancellationToken);
+            discovered.AddRange(derivedInterfaces);
+
+            var implementations = await SymbolFinder.FindImplementationsAsync(
+                source, solution, cancellationToken: cancellationToken);
+            foreach (var implementation in implementations.OfType<INamedTypeSymbol>())
+            {
+                if (IsDirectInterface(implementation, source))
+                    discovered.Add(implementation);
+            }
+        }
+        else
+        {
+            var derived = await SymbolFinder.FindDerivedClassesAsync(
+                source, solution, transitive: false, cancellationToken: cancellationToken);
+            discovered.AddRange(derived);
+        }
+
+        var unique = DistinctTypes(discovered);
+
+        if (targetNames == null || targetNames.Count == 0 || targetNames.All(string.IsNullOrWhiteSpace))
+            return unique;
+
+        var selected = new List<INamedTypeSymbol>();
+        foreach (var name in targetNames.Where(n => !string.IsNullOrWhiteSpace(n)))
+        {
+            var match = unique.FirstOrDefault(candidate =>
+                candidate.Name.Equals(name, StringComparison.Ordinal) ||
+                candidate.ToDisplayString().Equals(name, StringComparison.Ordinal));
+
+            if (match == null)
+            {
+                throw new RefactoringException(
+                    ErrorCodes.TypeNotFound,
+                    $"Type '{name}' is not a derived type of '{source.Name}'.");
+            }
+
+            selected.Add(match);
+        }
+
+        return DistinctTypes(selected);
+    }
+
+    private async Task<IReadOnlyList<INamedTypeSymbol>> GetDerivedTypes(
+        INamedTypeSymbol source,
+        IReadOnlyList<string>? targetNames,
+        CancellationToken cancellationToken)
+    {
+        return await GetDerivedTypes(source, targetNames, Context.Solution, cancellationToken);
+    }
+
+    private static bool IsDirectInterface(INamedTypeSymbol type, INamedTypeSymbol iface)
+    {
+        return type.Interfaces.Any(implemented =>
+            SymbolEqualityComparer.Default.Equals(implemented, iface) ||
+            SymbolEqualityComparer.Default.Equals(implemented.OriginalDefinition, iface.OriginalDefinition));
+    }
+
+    private static List<INamedTypeSymbol> DistinctTypes(IEnumerable<INamedTypeSymbol> types)
+    {
+        var unique = new List<INamedTypeSymbol>();
+        foreach (var type in types)
+        {
+            if (unique.Any(existing => SymbolEqualityComparer.Default.Equals(existing, type)))
+                continue;
+            unique.Add(type);
+        }
+
+        return unique;
+    }
+
+    /// <summary>
+    /// Rejects derived types that live only in metadata.
+    /// </summary>
+    internal static void ValidateDerivedIsEditable(INamedTypeSymbol derived)
+    {
+        if (!derived.Locations.Any(location => location.IsInSource))
+        {
+            throw new RefactoringException(
+                ErrorCodes.DerivedClassNotEditable,
+                $"Derived type '{derived.Name}' is not editable (defined in an external assembly).");
+        }
+    }
+
+    private static List<PushableMember> FindMembersToPush(
+        TypeDeclarationSyntax typeDeclaration,
+        IReadOnlyList<string> memberNames,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        var requested = new HashSet<string>(memberNames.Where(n => !string.IsNullOrWhiteSpace(n)));
+        var found = new List<PushableMember>();
+
+        foreach (var (name, symbol, syntax) in EnumerateDeclaredMembers(typeDeclaration, semanticModel, cancellationToken))
+        {
+            if (!requested.Contains(name))
+                continue;
+
+            if (symbol == null)
+            {
+                throw new RefactoringException(
+                    ErrorCodes.RoslynError,
+                    $"Could not resolve symbol for member '{name}'.");
+            }
+
+            if (!IsSupportedMember(symbol))
+            {
+                throw new RefactoringException(
+                    ErrorCodes.MemberNotMoveable,
+                    $"Member '{name}' cannot be pushed down.");
+            }
+
+            found.Add(new PushableMember(name, symbol, syntax));
+            requested.Remove(name);
+        }
+
+        if (requested.Count > 0)
+        {
+            throw new RefactoringException(
+                ErrorCodes.MemberNotFound,
+                $"Members not found: {string.Join(", ", requested)}");
+        }
+
+        return found;
+    }
+
+    private static IEnumerable<(string Name, ISymbol? Symbol, MemberDeclarationSyntax Syntax)> EnumerateDeclaredMembers(
+        TypeDeclarationSyntax typeDeclaration,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        foreach (var member in typeDeclaration.Members)
+        {
+            switch (member)
+            {
+                case MethodDeclarationSyntax method:
+                    yield return (method.Identifier.Text, semanticModel.GetDeclaredSymbol(method, cancellationToken), method);
+                    break;
+                case PropertyDeclarationSyntax property:
+                    yield return (property.Identifier.Text, semanticModel.GetDeclaredSymbol(property, cancellationToken), property);
+                    break;
+                case FieldDeclarationSyntax field:
+                    foreach (var variable in field.Declaration.Variables)
+                    {
+                        yield return (variable.Identifier.Text, semanticModel.GetDeclaredSymbol(variable, cancellationToken), field);
+                    }
+                    break;
+                case EventFieldDeclarationSyntax eventField:
+                    foreach (var variable in eventField.Declaration.Variables)
+                    {
+                        yield return (variable.Identifier.Text, semanticModel.GetDeclaredSymbol(variable, cancellationToken), eventField);
+                    }
+                    break;
+                case EventDeclarationSyntax eventDecl:
+                    yield return (eventDecl.Identifier.Text, semanticModel.GetDeclaredSymbol(eventDecl, cancellationToken), eventDecl);
+                    break;
+            }
+        }
+    }
+
+    private static bool IsSupportedMember(ISymbol symbol) => symbol switch
+    {
+        IMethodSymbol method => method.MethodKind == MethodKind.Ordinary,
+        IPropertySymbol => true,
+        IFieldSymbol => true,
+        IEventSymbol => true,
+        _ => false
+    };
+
+    private static void ValidateMembersForPush(
+        IReadOnlyList<PushableMember> members,
+        INamedTypeSymbol source,
+        IReadOnlyList<INamedTypeSymbol> targets,
+        bool leaveAbstract)
+    {
+        foreach (var member in members)
+        {
+            if (leaveAbstract && !CanBeAbstract(member.Symbol))
+            {
+                throw new RefactoringException(
+                    ErrorCodes.MemberNotMoveable,
+                    $"Member '{member.Name}' cannot be left as abstract on '{source.Name}'.");
+            }
+
+            if (source.TypeKind != TypeKind.Interface &&
+                !leaveAbstract &&
+                ImplementsInterfaceMember(member.Symbol, source))
+            {
+                throw new RefactoringException(
+                    ErrorCodes.MemberNotInterfaceCompatible,
+                    $"Member '{member.Name}' implements an interface contract on '{source.Name}' and cannot be removed.");
+            }
+
+            foreach (var target in targets)
+            {
+                if (!CanMoveMember(member.Symbol, target))
+                {
+                    if (target.TypeKind == TypeKind.Interface && !IsInterfaceCompatible(member.Symbol))
+                    {
+                        throw new RefactoringException(
+                            ErrorCodes.MemberNotInterfaceCompatible,
+                            $"Member '{member.Name}' cannot be pushed to interface '{target.Name}'.");
+                    }
+
+                    throw new RefactoringException(
+                        ErrorCodes.ConflictsWithExistingMember,
+                        $"Member '{member.Name}' already exists in '{target.Name}'.");
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns whether <paramref name="member"/> can be copied onto <paramref name="target"/>.
+    /// </summary>
+    internal static bool CanMoveMember(ISymbol member, INamedTypeSymbol target)
+    {
+        if (HasConflict(target, member))
+            return false;
+
+        if (target.TypeKind == TypeKind.Interface && !IsInterfaceCompatible(member))
+            return false;
+
+        return true;
+    }
+
+    private static bool CanBeAbstract(ISymbol member) =>
+        member is IMethodSymbol or IPropertySymbol;
+
+    private static bool ImplementsInterfaceMember(ISymbol member, INamedTypeSymbol source)
+    {
+        foreach (var iface in source.AllInterfaces)
+        {
+            foreach (var ifaceMember in iface.GetMembers(member.Name))
+            {
+                var implementation = source.FindImplementationForInterfaceMember(ifaceMember);
+                if (implementation != null && SymbolEqualityComparer.Default.Equals(implementation, member))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasConflict(INamedTypeSymbol target, ISymbol member)
+    {
+        foreach (var existing in target.GetMembers(member.Name))
+        {
+            if (existing.IsImplicitlyDeclared)
+                continue;
+
+            if (member is IMethodSymbol method && existing is IMethodSymbol existingMethod)
+            {
+                if (SignaturesMatch(method, existingMethod))
+                    return true;
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool SignaturesMatch(IMethodSymbol left, IMethodSymbol right)
+    {
+        if (left.Parameters.Length != right.Parameters.Length)
+            return false;
+
+        if (left.TypeParameters.Length != right.TypeParameters.Length)
+            return false;
+
+        for (var i = 0; i < left.Parameters.Length; i++)
+        {
+            if (!SymbolEqualityComparer.Default.Equals(left.Parameters[i].Type, right.Parameters[i].Type))
+                return false;
+            if (left.Parameters[i].RefKind != right.Parameters[i].RefKind)
+                return false;
+        }
+
+        return true;
+    }
+
+    private static bool IsInterfaceCompatible(ISymbol member)
+    {
+        if (member.IsStatic)
+            return false;
+
+        if (member.DeclaredAccessibility != Accessibility.Public)
+            return false;
+
+        return member switch
+        {
+            IMethodSymbol method => method.MethodKind == MethodKind.Ordinary,
+            IPropertySymbol => true,
+            IEventSymbol => true,
+            _ => false
+        };
+    }
+
+    private static MemberDeclarationSyntax ConvertForDerived(
+        MemberDeclarationSyntax member,
+        INamedTypeSymbol target,
+        bool leaveAbstract)
+    {
+        if (target.TypeKind == TypeKind.Interface)
+            return ConvertToInterfaceMember(member);
+
+        return leaveAbstract
+            ? AddOverrideModifier(member)
+            : StripHierarchyModifiers(member);
+    }
+
+    private static MemberDeclarationSyntax ConvertToInterfaceMember(MemberDeclarationSyntax member)
+    {
+        return member switch
+        {
+            MethodDeclarationSyntax method => method
+                .WithModifiers(SyntaxFactory.TokenList())
+                .WithBody(null)
+                .WithExpressionBody(null)
+                .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken))
+                .NormalizeWhitespace(),
+            PropertyDeclarationSyntax property => ToInterfaceProperty(property),
+            EventDeclarationSyntax eventDecl => eventDecl
+                .WithModifiers(SyntaxFactory.TokenList())
+                .WithAccessorList(null)
+                .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken))
+                .NormalizeWhitespace(),
+            EventFieldDeclarationSyntax eventField => SyntaxFactory.EventFieldDeclaration(eventField.Declaration)
+                .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken))
+                .NormalizeWhitespace(),
+            _ => throw new RefactoringException(
+                ErrorCodes.MemberNotInterfaceCompatible,
+                "Member cannot be declared on an interface.")
+        };
+    }
+
+    private static PropertyDeclarationSyntax ToInterfaceProperty(PropertyDeclarationSyntax property)
+    {
+        var accessors = new List<AccessorDeclarationSyntax>();
+        if (property.AccessorList != null)
+        {
+            foreach (var accessor in property.AccessorList.Accessors)
+            {
+                accessors.Add(accessor
+                    .WithModifiers(SyntaxFactory.TokenList())
+                    .WithBody(null)
+                    .WithExpressionBody(null)
+                    .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken)));
+            }
+        }
+        else
+        {
+            accessors.Add(SyntaxFactory.AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
+                .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken)));
+        }
+
+        return property
+            .WithModifiers(SyntaxFactory.TokenList())
+            .WithExpressionBody(null)
+            .WithSemicolonToken(default)
+            .WithAccessorList(SyntaxFactory.AccessorList(SyntaxFactory.List(accessors)))
+            .NormalizeWhitespace();
+    }
+
+    private static MemberDeclarationSyntax ConvertToAbstract(MemberDeclarationSyntax member)
+    {
+        return member switch
+        {
+            MethodDeclarationSyntax method => method
+                .WithModifiers(ToAbstractModifiers(method.Modifiers))
+                .WithBody(null)
+                .WithExpressionBody(null)
+                .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken))
+                .NormalizeWhitespace(),
+            PropertyDeclarationSyntax property => ToAbstractProperty(property),
+            _ => throw new RefactoringException(
+                ErrorCodes.MemberNotMoveable,
+                "Only methods and properties can be left as abstract members.")
+        };
+    }
+
+    private static PropertyDeclarationSyntax ToAbstractProperty(PropertyDeclarationSyntax property)
+    {
+        var accessors = new List<AccessorDeclarationSyntax>();
+        if (property.AccessorList != null)
+        {
+            foreach (var accessor in property.AccessorList.Accessors)
+            {
+                accessors.Add(accessor
+                    .WithBody(null)
+                    .WithExpressionBody(null)
+                    .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken)));
+            }
+        }
+        else
+        {
+            accessors.Add(SyntaxFactory.AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
+                .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken)));
+        }
+
+        return property
+            .WithModifiers(ToAbstractModifiers(property.Modifiers))
+            .WithExpressionBody(null)
+            .WithSemicolonToken(default)
+            .WithAccessorList(SyntaxFactory.AccessorList(SyntaxFactory.List(accessors)))
+            .NormalizeWhitespace();
+    }
+
+    private static MemberDeclarationSyntax AddOverrideModifier(MemberDeclarationSyntax member)
+    {
+        return member switch
+        {
+            MethodDeclarationSyntax method => EnsureMethodBody(method.WithModifiers(ToOverrideModifiers(method.Modifiers)))
+                .NormalizeWhitespace(),
+            PropertyDeclarationSyntax property => property.WithModifiers(ToOverrideModifiers(property.Modifiers))
+                .NormalizeWhitespace(),
+            _ => member.NormalizeWhitespace()
+        };
+    }
+
+    private static MethodDeclarationSyntax EnsureMethodBody(MethodDeclarationSyntax method)
+    {
+        if (method.Body != null || method.ExpressionBody != null)
+            return method;
+
+        return method
+            .WithSemicolonToken(default)
+            .WithBody(SyntaxFactory.Block(
+                SyntaxFactory.ThrowStatement(
+                    SyntaxFactory.ObjectCreationExpression(
+                            SyntaxFactory.ParseTypeName("System.NotImplementedException"))
+                        .WithArgumentList(SyntaxFactory.ArgumentList()))));
+    }
+
+    private static MemberDeclarationSyntax StripHierarchyModifiers(MemberDeclarationSyntax member)
+    {
+        return member switch
+        {
+            MethodDeclarationSyntax method => EnsureMethodBody(method
+                    .WithModifiers(StripModifiers(
+                        method.Modifiers,
+                        SyntaxKind.VirtualKeyword,
+                        SyntaxKind.OverrideKeyword,
+                        SyntaxKind.AbstractKeyword,
+                        SyntaxKind.NewKeyword,
+                        SyntaxKind.SealedKeyword)))
+                .NormalizeWhitespace(),
+            PropertyDeclarationSyntax property => property
+                .WithModifiers(StripModifiers(
+                    property.Modifiers,
+                    SyntaxKind.VirtualKeyword,
+                    SyntaxKind.OverrideKeyword,
+                    SyntaxKind.AbstractKeyword,
+                    SyntaxKind.NewKeyword,
+                    SyntaxKind.SealedKeyword))
+                .NormalizeWhitespace(),
+            FieldDeclarationSyntax field => field.NormalizeWhitespace(),
+            EventFieldDeclarationSyntax eventField => eventField.NormalizeWhitespace(),
+            EventDeclarationSyntax eventDecl => eventDecl
+                .WithModifiers(StripModifiers(
+                    eventDecl.Modifiers,
+                    SyntaxKind.VirtualKeyword,
+                    SyntaxKind.OverrideKeyword,
+                    SyntaxKind.AbstractKeyword,
+                    SyntaxKind.NewKeyword,
+                    SyntaxKind.SealedKeyword))
+                .NormalizeWhitespace(),
+            _ => member.NormalizeWhitespace()
+        };
+    }
+
+    private static SyntaxTokenList ToAbstractModifiers(SyntaxTokenList modifiers)
+    {
+        var tokens = StripModifierKinds(
+                modifiers,
+                SyntaxKind.PrivateKeyword,
+                SyntaxKind.VirtualKeyword,
+                SyntaxKind.OverrideKeyword,
+                SyntaxKind.SealedKeyword,
+                SyntaxKind.AbstractKeyword,
+                SyntaxKind.NewKeyword)
+            .ToList();
+
+        if (!HasAccessibility(tokens))
+            tokens.Insert(0, SyntaxFactory.Token(SyntaxKind.ProtectedKeyword));
+
+        tokens.Add(SyntaxFactory.Token(SyntaxKind.AbstractKeyword));
+        return SyntaxFactory.TokenList(tokens);
+    }
+
+    private static SyntaxTokenList ToOverrideModifiers(SyntaxTokenList modifiers)
+    {
+        var tokens = StripModifierKinds(
+                modifiers,
+                SyntaxKind.PrivateKeyword,
+                SyntaxKind.VirtualKeyword,
+                SyntaxKind.AbstractKeyword,
+                SyntaxKind.OverrideKeyword,
+                SyntaxKind.NewKeyword,
+                SyntaxKind.SealedKeyword)
+            .ToList();
+
+        if (modifiers.Any(SyntaxKind.PrivateKeyword) || !HasAccessibility(tokens))
+            tokens.Insert(0, SyntaxFactory.Token(SyntaxKind.ProtectedKeyword));
+
+        tokens.Add(SyntaxFactory.Token(SyntaxKind.OverrideKeyword));
+        return SyntaxFactory.TokenList(tokens);
+    }
+
+    private static SyntaxTokenList StripModifiers(SyntaxTokenList modifiers, params SyntaxKind[] kinds) =>
+        SyntaxFactory.TokenList(StripModifierKinds(modifiers, kinds));
+
+    private static IEnumerable<SyntaxToken> StripModifierKinds(SyntaxTokenList modifiers, params SyntaxKind[] kinds)
+    {
+        var kindSet = kinds.ToHashSet();
+        return modifiers.Where(token => !kindSet.Contains(token.Kind()));
+    }
+
+    private static bool HasAccessibility(IEnumerable<SyntaxToken> modifiers) =>
+        modifiers.Any(token =>
+            token.IsKind(SyntaxKind.PublicKeyword) ||
+            token.IsKind(SyntaxKind.ProtectedKeyword) ||
+            token.IsKind(SyntaxKind.InternalKeyword) ||
+            token.IsKind(SyntaxKind.PrivateKeyword));
+
+    private static TypeDeclarationSyntax BuildSourceReplacement(
+        TypeDeclarationSyntax sourceDecl,
+        IReadOnlyList<PushableMember> members,
+        INamedTypeSymbol source,
+        bool leaveAbstract)
+    {
+        if (source.TypeKind == TypeKind.Interface)
+            return sourceDecl;
+
+        var pushedSyntax = members.Select(m => m.Syntax).ToHashSet();
+        var newMembers = new List<MemberDeclarationSyntax>();
+
+        foreach (var member in sourceDecl.Members)
+        {
+            if (!pushedSyntax.Contains(member))
+            {
+                newMembers.Add(member);
+                continue;
+            }
+
+            if (leaveAbstract)
+                newMembers.Add(ConvertToAbstract(member));
+        }
+
+        var updated = sourceDecl.WithMembers(SyntaxFactory.List(newMembers));
+
+        if (leaveAbstract &&
+            sourceDecl is ClassDeclarationSyntax &&
+            !sourceDecl.Modifiers.Any(SyntaxKind.AbstractKeyword))
+        {
+            updated = updated.AddModifiers(SyntaxFactory.Token(SyntaxKind.AbstractKeyword));
+        }
+
+        return updated;
+    }
+
+    /// <summary>
+    /// Inserts a member into a type declaration.
+    /// </summary>
+    internal static TypeDeclarationSyntax AddMemberToType(TypeDeclarationSyntax typeDecl, MemberDeclarationSyntax member)
+    {
+        return AddMembersToType(typeDecl, [member]);
+    }
+
+    private static TypeDeclarationSyntax AddMembersToType(
+        TypeDeclarationSyntax typeDecl,
+        IReadOnlyList<MemberDeclarationSyntax> members)
+    {
+        var formatted = members.Select(member => member
+            .WithLeadingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed)
+            .WithTrailingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed));
+
+        return typeDecl.WithMembers(typeDecl.Members.AddRange(formatted));
+    }
+
+    private static async Task<TypeDeclarationSyntax> GetTypeDeclarationAsync(
+        INamedTypeSymbol type,
+        CancellationToken cancellationToken)
+    {
+        var syntaxRef = type.DeclaringSyntaxReferences.FirstOrDefault();
+        if (syntaxRef == null)
+        {
+            throw new RefactoringException(
+                ErrorCodes.DerivedClassNotEditable,
+                $"Derived type '{type.Name}' is not editable (defined in an external assembly).");
+        }
+
+        var syntax = await syntaxRef.GetSyntaxAsync(cancellationToken) as TypeDeclarationSyntax;
+        if (syntax == null)
+        {
+            throw new RefactoringException(
+                ErrorCodes.RoslynError,
+                $"Could not locate declaration for '{type.Name}'.");
+        }
+
+        return syntax;
+    }
+
+    private async Task<Solution> ApplyChangesAsync(
+        Document sourceDocument,
+        TypeDeclarationSyntax sourceDecl,
+        TypeDeclarationSyntax newSource,
+        IReadOnlyList<DerivedUpdate> derivedUpdates,
+        CancellationToken cancellationToken)
+    {
+        var replacements = new List<(SyntaxTree Tree, SyntaxNode Original, SyntaxNode Replacement)>
+        {
+            (sourceDecl.SyntaxTree, sourceDecl, newSource)
+        };
+
+        foreach (var update in derivedUpdates)
+            replacements.Add((update.Original.SyntaxTree, update.Original, update.Updated));
+
+        var solution = sourceDocument.Project.Solution;
+
+        foreach (var group in replacements.GroupBy(replacement => replacement.Tree))
+        {
+            var document = solution.GetDocument(group.Key);
+            if (document == null)
+            {
+                throw new RefactoringException(
+                    ErrorCodes.DerivedClassNotEditable,
+                    "A target type is not part of the workspace.");
+            }
+
+            var currentRoot = await document.GetSyntaxRootAsync(cancellationToken);
+            if (currentRoot == null)
+                throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse file.");
+
+            var map = group.ToDictionary(item => item.Original, item => item.Replacement);
+            var newRoot = currentRoot.ReplaceNodes(map.Keys, (original, _) => map[original]);
+            solution = document.WithSyntaxRoot(newRoot).Project.Solution;
+        }
+
+        return solution;
+    }
+
+    private static RefactoringResult CreatePreviewResult(
+        Guid operationId,
+        PushMembersDownParams @params,
+        INamedTypeSymbol source,
+        IReadOnlyList<string> pushedNames,
+        TypeDeclarationSyntax originalSource,
+        TypeDeclarationSyntax updatedSource,
+        IReadOnlyList<DerivedUpdate> derivedUpdates)
+    {
+        var memberList = string.Join(", ", pushedNames);
+        var pendingChanges = new List<PendingChange>
+        {
+            new()
+            {
+                File = @params.SourceFile,
+                ChangeType = ChangeKind.Modify,
+                Description = source.TypeKind == TypeKind.Interface
+                    ? $"Keep {memberList} on {@params.TypeName}"
+                    : @params.LeaveAbstract
+                        ? $"Leave {memberList} as abstract on {@params.TypeName}"
+                        : $"Remove {memberList} from {@params.TypeName}",
+                BeforeSnippet = originalSource.Identifier.Text,
+                AfterSnippet = updatedSource.NormalizeWhitespace().ToFullString()
+            }
+        };
+
+        foreach (var update in derivedUpdates)
+        {
+            var location = update.Type.Locations.FirstOrDefault(l => l.IsInSource);
+            var file = location?.SourceTree?.FilePath ?? @params.SourceFile;
+            pendingChanges.Add(new PendingChange
+            {
+                File = file,
+                ChangeType = ChangeKind.Modify,
+                Description = $"Add {memberList} to {update.Type.Name}",
+                BeforeSnippet = update.Original.Identifier.Text,
+                AfterSnippet = update.Updated.NormalizeWhitespace().ToFullString()
+            });
+        }
+
+        return RefactoringResult.PreviewResult(operationId, pendingChanges);
+    }
+
+    private sealed record PushableMember(string Name, ISymbol Symbol, MemberDeclarationSyntax Syntax);
+
+    private sealed record DerivedUpdate(
+        INamedTypeSymbol Type,
+        TypeDeclarationSyntax Original,
+        TypeDeclarationSyntax Updated);
+}

--- a/src/RoslynMcp.Server/McpServerHost.cs
+++ b/src/RoslynMcp.Server/McpServerHost.cs
@@ -50,6 +50,7 @@ public sealed class McpServerHost : IAsyncDisposable
         _toolRegistry.Register(new ConvertToAsyncTool(workspaceProvider));
         _toolRegistry.Register(new ExtractBaseClassTool(workspaceProvider));
         _toolRegistry.Register(new PullMembersUpTool(workspaceProvider));
+        _toolRegistry.Register(new PushMembersDownTool(workspaceProvider));
 
         // Code Navigation / Query Tools
         _toolRegistry.Register(new FindReferencesTool(workspaceProvider));

--- a/src/RoslynMcp.Server/RoslynMcp.Server.csproj
+++ b/src/RoslynMcp.Server/RoslynMcp.Server.csproj
@@ -18,7 +18,7 @@
     <Version>0.4.0</Version>
     <Authors>Joshua Ramirez</Authors>
     <Company>RedJay</Company>
-    <Description>MCP Server for Roslyn-powered C# refactoring operations. Install as a global tool to use with Claude Code, Claude Desktop, or other MCP clients. Provides 43 tools: 21 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 7 code conversion tools.</Description>
+    <Description>MCP Server for Roslyn-powered C# refactoring operations. Install as a global tool to use with Claude Code, Claude Desktop, or other MCP clients. Provides 44 tools: 22 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 7 code conversion tools.</Description>
     <PackageTags>roslyn;mcp;refactoring;csharp;model-context-protocol;code-analysis;dotnet;ai-tools;claude</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/JoshuaRamirez/RoslynMcpServer</RepositoryUrl>

--- a/src/RoslynMcp.Server/Tools/PushMembersDownTool.cs
+++ b/src/RoslynMcp.Server/Tools/PushMembersDownTool.cs
@@ -1,0 +1,150 @@
+using System.Text.Json;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.Refactoring;
+using RoslynMcp.Core.Refactoring.Hierarchy;
+using RoslynMcp.Core.Workspace;
+using RoslynMcp.Server.Transport;
+
+namespace RoslynMcp.Server.Tools;
+
+/// <summary>
+/// MCP tool handler for push_members_down operation.
+/// </summary>
+public sealed class PushMembersDownTool : IToolHandler
+{
+    private readonly IWorkspaceProvider _workspaceProvider;
+    private readonly JsonSerializerOptions _jsonOptions;
+
+    /// <summary>
+    /// Creates a new push members down tool.
+    /// </summary>
+    public PushMembersDownTool(IWorkspaceProvider workspaceProvider)
+    {
+        _workspaceProvider = workspaceProvider;
+        _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = false
+        };
+    }
+
+    /// <inheritdoc />
+    public string Name => "push_members_down";
+
+    /// <inheritdoc />
+    public string Description => "Move selected members from a base type down onto derived types.";
+
+    /// <inheritdoc />
+    public object InputSchema => new
+    {
+        type = "object",
+        required = new[] { "solutionPath", "sourceFile", "typeName", "members" },
+        properties = new
+        {
+            solutionPath = new
+            {
+                type = "string",
+                description = "Absolute path to the .sln or .csproj file"
+            },
+            sourceFile = new
+            {
+                type = "string",
+                description = "Absolute path to the source file containing the base type"
+            },
+            typeName = new
+            {
+                type = "string",
+                description = "Name of the base class or interface"
+            },
+            members = new
+            {
+                type = "array",
+                items = new { type = "string" },
+                description = "Names of members to move to derived types"
+            },
+            targetDerivedTypes = new
+            {
+                type = "array",
+                items = new { type = "string" },
+                description = "Specific derived type names to push to. Uses all direct derived types if omitted."
+            },
+            leaveAbstract = new
+            {
+                type = "boolean",
+                description = "Leave abstract declarations on the base class and add overrides on derived types",
+                @default = false
+            },
+            preview = new
+            {
+                type = "boolean",
+                description = "Return computed changes without applying",
+                @default = false
+            }
+        },
+        additionalProperties = false
+    };
+
+    /// <inheritdoc />
+    public async Task<ToolResult> ExecuteAsync(JsonElement? arguments, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (arguments == null)
+            {
+                return ToolResult.Error("Arguments required");
+            }
+
+            var args = JsonSerializer.Deserialize<PushMembersDownArgs>(arguments.Value.GetRawText(), _jsonOptions);
+            if (args == null)
+            {
+                return ToolResult.Error("Failed to parse arguments");
+            }
+
+            using var context = await _workspaceProvider.CreateContextAsync(
+                args.SolutionPath,
+                cancellationToken);
+
+            var operation = new PushMembersDownOperation(context);
+            var @params = new PushMembersDownParams
+            {
+                SourceFile = args.SourceFile,
+                TypeName = args.TypeName,
+                Members = args.Members ?? new List<string>(),
+                TargetDerivedTypes = args.TargetDerivedTypes,
+                LeaveAbstract = args.LeaveAbstract ?? false,
+                Preview = args.Preview ?? false
+            };
+
+            var result = await operation.ExecuteAsync(@params, cancellationToken);
+
+            var json = JsonSerializer.Serialize(result, _jsonOptions);
+            return result.Success ? ToolResult.Success(json) : ToolResult.Error(json);
+        }
+        catch (RefactoringException ex)
+        {
+            var error = ex.ToError();
+            var json = JsonSerializer.Serialize(new { success = false, error }, _jsonOptions);
+            return ToolResult.Error(json);
+        }
+        catch (Exception ex)
+        {
+            var json = JsonSerializer.Serialize(new
+            {
+                success = false,
+                error = new { code = "INTERNAL_ERROR", message = ex.Message }
+            }, _jsonOptions);
+            return ToolResult.Error(json);
+        }
+    }
+
+    private sealed class PushMembersDownArgs
+    {
+        public string SolutionPath { get; init; } = "";
+        public string SourceFile { get; init; } = "";
+        public string TypeName { get; init; } = "";
+        public List<string>? Members { get; init; }
+        public List<string>? TargetDerivedTypes { get; init; }
+        public bool? LeaveAbstract { get; init; }
+        public bool? Preview { get; init; }
+    }
+}

--- a/tests/RoslynMcp.Cli.Tests/HelpGeneratorTests.cs
+++ b/tests/RoslynMcp.Cli.Tests/HelpGeneratorTests.cs
@@ -15,12 +15,13 @@ public class HelpGeneratorTests
     }
 
     [Fact]
-    public void GenerateGlobalHelp_Lists43Tools()
+    public void GenerateGlobalHelp_Lists44Tools()
     {
         var registry = ToolRegistry.BuildDefault();
         var help = HelpGenerator.GenerateGlobalHelp(registry);
-        Assert.Contains("Total: 43 tools", help);
+        Assert.Contains("Total: 44 tools", help);
         Assert.Contains("pull-members-up", help);
+        Assert.Contains("push-members-down", help);
     }
 
     [Fact]

--- a/tests/RoslynMcp.Cli.Tests/ToolRegistryTests.cs
+++ b/tests/RoslynMcp.Cli.Tests/ToolRegistryTests.cs
@@ -6,11 +6,11 @@ namespace RoslynMcp.Cli.Tests;
 public class ToolRegistryTests
 {
     [Fact]
-    public void BuildDefault_Registers43Tools()
+    public void BuildDefault_Registers44Tools()
     {
         var registry = ToolRegistry.BuildDefault();
         var tools = registry.GetAllTools();
-        Assert.Equal(43, tools.Count);
+        Assert.Equal(44, tools.Count);
     }
 
     [Fact]
@@ -85,6 +85,7 @@ public class ToolRegistryTests
     [InlineData("extract-method", "Refactoring")]
     [InlineData("inline-method", "Refactoring")]
     [InlineData("pull-members-up", "Refactoring")]
+    [InlineData("push-members-down", "Refactoring")]
     [InlineData("find-references", "Query")]
     [InlineData("get-diagnostics", "Query")]
     [InlineData("diagnose", "Diagnostic")]
@@ -103,11 +104,11 @@ public class ToolRegistryTests
     }
 
     [Fact]
-    public void RefactoringToolCount_Is30()
+    public void RefactoringToolCount_Is31()
     {
         var registry = ToolRegistry.BuildDefault();
         var count = registry.GetAllTools().Count(t => t.Category == "Refactoring");
-        Assert.Equal(30, count);
+        Assert.Equal(31, count);
     }
 
     [Fact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Hierarchy/PushMembersDownOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Hierarchy/PushMembersDownOperationTests.cs
@@ -1,0 +1,773 @@
+using Microsoft.CodeAnalysis;
+using RoslynMcp.Contracts.Errors;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.Refactoring;
+using RoslynMcp.Core.Refactoring.Hierarchy;
+using RoslynMcp.Core.Workspace;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Refactoring.Hierarchy;
+
+/// <summary>
+/// Operation-level tests for <see cref="PushMembersDownOperation"/>.
+/// </summary>
+public class PushMembersDownOperationTests
+{
+    #region Input Validation
+
+    [Fact]
+    public void Validate_MissingSourceFile_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            PushMembersDownOperation.Validate(new PushMembersDownParams
+            {
+                SourceFile = "",
+                TypeName = "Animal",
+                Members = ["Foo"]
+            }));
+
+        Assert.Equal(ErrorCodes.MissingRequiredParam, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_MissingTypeName_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            PushMembersDownOperation.Validate(new PushMembersDownParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                TypeName = "",
+                Members = ["Foo"]
+            }));
+
+        Assert.Equal(ErrorCodes.MissingRequiredParam, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_MissingMembers_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            PushMembersDownOperation.Validate(new PushMembersDownParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                TypeName = "Animal",
+                Members = []
+            }));
+
+        Assert.Equal(ErrorCodes.MissingRequiredParam, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_RelativePath_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            PushMembersDownOperation.Validate(new PushMembersDownParams
+            {
+                SourceFile = "Types.cs",
+                TypeName = "Animal",
+                Members = ["Foo"]
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidSourcePath, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_MissingFile_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            PushMembersDownOperation.Validate(new PushMembersDownParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                TypeName = "Animal",
+                Members = ["Foo"]
+            }));
+
+        Assert.Equal(ErrorCodes.SourceFileNotFound, ex.ErrorCode);
+    }
+
+    #endregion
+
+    #region P0 Happy Path
+
+    [SkippableFact]
+    public async Task PushMembersDown_MethodToAllDerived_MovesMember()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+                public int Speak()
+                {
+                    return 1;
+                }
+            }
+
+            public class Dog : Animal
+            {
+            }
+
+            public class Cat : Animal
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new PushMembersDownOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new PushMembersDownParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Animal",
+            Members = ["Speak"]
+        });
+
+        Assert.True(result.Success);
+        Assert.False(result.Preview);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        var animal = ExtractTypeBody(text, "Animal");
+        var dog = ExtractTypeBody(text, "Dog");
+        var cat = ExtractTypeBody(text, "Cat");
+        Assert.DoesNotContain("Speak", animal);
+        Assert.Contains("Speak", dog);
+        Assert.Contains("return 1", dog);
+        Assert.Contains("Speak", cat);
+        Assert.Contains("return 1", cat);
+        Assert.DoesNotContain("virtual", dog);
+    }
+
+    [SkippableFact]
+    public async Task PushMembersDown_PropertyToAllDerived_MovesProperty()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+                public string Name { get; set; } = "";
+            }
+
+            public class Dog : Animal
+            {
+            }
+
+            public class Cat : Animal
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new PushMembersDownOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new PushMembersDownParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Animal",
+            Members = ["Name"]
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.DoesNotContain("Name", ExtractTypeBody(text, "Animal"));
+        Assert.Contains("Name", ExtractTypeBody(text, "Dog"));
+        Assert.Contains("Name", ExtractTypeBody(text, "Cat"));
+    }
+
+    [SkippableFact]
+    public async Task PushMembersDown_MultipleMembers_MovesAll()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+                public string Name { get; set; } = "";
+
+                public int Speak()
+                {
+                    return 1;
+                }
+            }
+
+            public class Dog : Animal
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new PushMembersDownOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new PushMembersDownParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Animal",
+            Members = ["Name", "Speak"]
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        var animal = ExtractTypeBody(text, "Animal");
+        var dog = ExtractTypeBody(text, "Dog");
+        Assert.DoesNotContain("Name", animal);
+        Assert.DoesNotContain("Speak", animal);
+        Assert.Contains("Name", dog);
+        Assert.Contains("Speak", dog);
+    }
+
+    [SkippableFact]
+    public async Task PushMembersDown_NamedSubset_PushesOnlySpecifiedDerived()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+                public int Speak()
+                {
+                    return 1;
+                }
+            }
+
+            public class Dog : Animal
+            {
+            }
+
+            public class Cat : Animal
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new PushMembersDownOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new PushMembersDownParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Animal",
+            Members = ["Speak"],
+            TargetDerivedTypes = ["Dog"]
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.DoesNotContain("Speak", ExtractTypeBody(text, "Animal"));
+        Assert.Contains("Speak", ExtractTypeBody(text, "Dog"));
+        Assert.DoesNotContain("Speak", ExtractTypeBody(text, "Cat"));
+    }
+
+    [SkippableFact]
+    public async Task PushMembersDown_LeaveAbstract_KeepsAbstractOnBase()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+                public int Speak()
+                {
+                    return 1;
+                }
+            }
+
+            public class Dog : Animal
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new PushMembersDownOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new PushMembersDownParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Animal",
+            Members = ["Speak"],
+            LeaveAbstract = true
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        var animal = ExtractTypeBody(text, "Animal");
+        var dog = ExtractTypeBody(text, "Dog");
+        Assert.Contains("abstract", text);
+        Assert.Contains("abstract", animal);
+        Assert.Contains("Speak", animal);
+        Assert.DoesNotContain("return 1", animal);
+        Assert.Contains("override", dog);
+        Assert.Contains("return 1", dog);
+    }
+
+    [SkippableFact]
+    public async Task PushMembersDown_Preview_ReturnsChangesAndWritesNothing()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+                public int Speak()
+                {
+                    return 1;
+                }
+            }
+
+            public class Dog : Animal
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var original = await File.ReadAllTextAsync(workspace.SourcePath);
+        var operation = new PushMembersDownOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new PushMembersDownParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Animal",
+            Members = ["Speak"],
+            Preview = true
+        });
+
+        Assert.True(result.Success);
+        Assert.True(result.Preview);
+        Assert.NotNull(result.PendingChanges);
+        Assert.NotEmpty(result.PendingChanges);
+        Assert.Contains(result.PendingChanges, c => c.AfterSnippet != null && c.AfterSnippet.Contains("Speak"));
+
+        var after = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Equal(original, after);
+    }
+
+    [SkippableFact]
+    public async Task PushMembersDown_DefaultInterfaceMethod_CopiesToImplementers()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public interface IAnimal
+            {
+                int Speak()
+                {
+                    return 1;
+                }
+            }
+
+            public class Dog : IAnimal
+            {
+            }
+
+            public class Cat : IAnimal
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new PushMembersDownOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new PushMembersDownParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "IAnimal",
+            Members = ["Speak"]
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Contains("Speak", ExtractTypeBody(text, "IAnimal"));
+        Assert.Contains("Speak", ExtractTypeBody(text, "Dog"));
+        Assert.Contains("Speak", ExtractTypeBody(text, "Cat"));
+    }
+
+    #endregion
+
+    #region P0 Rejects
+
+    [SkippableFact]
+    public async Task PushMembersDown_NoDerived_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+                public int Speak()
+                {
+                    return 1;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new PushMembersDownOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new PushMembersDownParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "Animal",
+                Members = ["Speak"]
+            }));
+
+        Assert.Equal(ErrorCodes.DerivedClassesNotFound, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task PushMembersDown_MissingNamedDerived_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+                public int Speak()
+                {
+                    return 1;
+                }
+            }
+
+            public class Dog : Animal
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new PushMembersDownOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new PushMembersDownParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "Animal",
+                Members = ["Speak"],
+                TargetDerivedTypes = ["Bird"]
+            }));
+
+        Assert.Equal(ErrorCodes.TypeNotFound, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task PushMembersDown_NameConflict_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+                public int Speak()
+                {
+                    return 0;
+                }
+            }
+
+            public class Dog : Animal
+            {
+                public new int Speak()
+                {
+                    return 1;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new PushMembersDownOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new PushMembersDownParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "Animal",
+                Members = ["Speak"]
+            }));
+
+        Assert.Equal(ErrorCodes.ConflictsWithExistingMember, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task PushMembersDown_SignatureConflict_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+                public void Log(string message)
+                {
+                }
+            }
+
+            public class Dog : Animal
+            {
+                public void Log(string message)
+                {
+                    System.Console.WriteLine(message);
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new PushMembersDownOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new PushMembersDownParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "Animal",
+                Members = ["Log"]
+            }));
+
+        Assert.Equal(ErrorCodes.ConflictsWithExistingMember, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task PushMembersDown_InterfaceImplementation_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public interface IAnimal
+            {
+                int Speak();
+            }
+
+            public class Animal : IAnimal
+            {
+                public int Speak()
+                {
+                    return 1;
+                }
+            }
+
+            public class Dog : Animal
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new PushMembersDownOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new PushMembersDownParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "Animal",
+                Members = ["Speak"]
+            }));
+
+        Assert.Equal(ErrorCodes.MemberNotInterfaceCompatible, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task PushMembersDown_StaticFieldToDerivedInterface_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public interface IAnimal
+            {
+                public static int Count = 1;
+            }
+
+            public interface IDog : IAnimal
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new PushMembersDownOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new PushMembersDownParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "IAnimal",
+                Members = ["Count"]
+            }));
+
+        Assert.Equal(ErrorCodes.MemberNotInterfaceCompatible, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task PushMembersDown_ExternalDerived_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+                public int Speak()
+                {
+                    return 1;
+                }
+            }
+
+            public class Dog : Animal
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var compilation = await workspace.Context.Solution.Projects.First().GetCompilationAsync();
+        Assert.NotNull(compilation);
+        var exception = compilation.GetTypeByMetadataName("System.Exception");
+        Assert.NotNull(exception);
+
+        var ex = Assert.Throws<RefactoringException>(() =>
+            PushMembersDownOperation.ValidateDerivedIsEditable(exception));
+
+        Assert.Equal(ErrorCodes.DerivedClassNotEditable, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task PushMembersDown_MemberNotFound_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+                public int Speak()
+                {
+                    return 1;
+                }
+            }
+
+            public class Dog : Animal
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new PushMembersDownOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new PushMembersDownParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "Animal",
+                Members = ["Missing"]
+            }));
+
+        Assert.Equal(ErrorCodes.MemberNotFound, ex.ErrorCode);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static string AbsoluteTestPath() =>
+        OperatingSystem.IsWindows() ? @"C:\test\file.cs" : "/test/file.cs";
+
+    private static string NormalizeNewlines(string text) =>
+        text.Replace("\r\n", "\n");
+
+    private static string ExtractTypeBody(string source, string typeName)
+    {
+        var normalized = NormalizeNewlines(source);
+        var start = normalized.IndexOf("class " + typeName, StringComparison.Ordinal);
+        if (start < 0)
+            start = normalized.IndexOf("interface " + typeName, StringComparison.Ordinal);
+        if (start < 0)
+            throw new InvalidOperationException($"Type '{typeName}' not found.");
+
+        var open = normalized.IndexOf('{', start);
+        var depth = 0;
+        for (var i = open; i < normalized.Length; i++)
+        {
+            if (normalized[i] == '{') depth++;
+            else if (normalized[i] == '}')
+            {
+                depth--;
+                if (depth == 0)
+                    return normalized.Substring(open, i - open + 1);
+            }
+        }
+
+        return normalized[open..];
+    }
+
+    private sealed class TempWorkspace : IAsyncDisposable
+    {
+        public required string DirectoryPath { get; init; }
+        public required string ProjectPath { get; init; }
+        public required string SourcePath { get; init; }
+        public required WorkspaceContext Context { get; init; }
+
+        public static async Task<TempWorkspace> CreateAsync(string source, string fileName = "Types.cs")
+        {
+            Skip.IfNot(ModuleInitializer.MsBuildAvailable, ModuleInitializer.MsBuildError ?? "MSBuild not available");
+
+            var directory = Path.Combine(Path.GetTempPath(), "RoslynMcpPushMembersDown_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(directory);
+
+            var projectPath = Path.Combine(directory, "TestApp.csproj");
+            var sourcePath = Path.Combine(directory, fileName);
+
+            await File.WriteAllTextAsync(projectPath, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net9.0</TargetFramework>
+                    <Nullable>enable</Nullable>
+                  </PropertyGroup>
+                </Project>
+                """);
+            await File.WriteAllTextAsync(sourcePath, source);
+
+            try
+            {
+                var provider = new MSBuildWorkspaceProvider();
+                var context = await provider.CreateContextAsync(projectPath);
+                if (context.GetDocumentByPath(sourcePath) == null)
+                {
+                    context.Dispose();
+                    throw new InvalidOperationException($"Workspace loaded but did not include {sourcePath}.");
+                }
+
+                return new TempWorkspace
+                {
+                    DirectoryPath = directory,
+                    ProjectPath = projectPath,
+                    SourcePath = sourcePath,
+                    Context = context
+                };
+            }
+            catch (Exception ex) when (ex is not SkipException)
+            {
+                try
+                {
+                    Directory.Delete(directory, recursive: true);
+                }
+                catch
+                {
+                    // ignore cleanup failures
+                }
+
+                Skip.If(true, $"Workspace load failed: {ex.Message}");
+                throw;
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            Context.Dispose();
+            await Task.Run(() =>
+            {
+                try
+                {
+                    Directory.Delete(DirectoryPath, recursive: true);
+                }
+                catch
+                {
+                    // ignore locked temp files
+                }
+            });
+        }
+    }
+
+    #endregion
+}

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Hierarchy/PushMembersDownOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Hierarchy/PushMembersDownOperationTests.cs
@@ -380,8 +380,214 @@ public class PushMembersDownOperationTests
 
         var text = await File.ReadAllTextAsync(workspace.SourcePath);
         Assert.Contains("Speak", ExtractTypeBody(text, "IAnimal"));
+        Assert.Contains("public", ExtractTypeBody(text, "Dog"));
         Assert.Contains("Speak", ExtractTypeBody(text, "Dog"));
+        Assert.Contains("public", ExtractTypeBody(text, "Cat"));
         Assert.Contains("Speak", ExtractTypeBody(text, "Cat"));
+    }
+
+    [SkippableFact]
+    public async Task PushMembersDown_GenericBase_SubstitutesTypeArguments()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Box<T>
+            {
+                public T GetValue()
+                {
+                    return default;
+                }
+            }
+
+            public class StringBox : Box<string>
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new PushMembersDownOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new PushMembersDownParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Box",
+            Members = ["GetValue"]
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        var box = ExtractTypeBody(text, "Box");
+        var stringBox = ExtractTypeBody(text, "StringBox");
+        Assert.DoesNotContain("GetValue", box);
+        Assert.Contains("string GetValue()", stringBox);
+        Assert.DoesNotContain("T GetValue()", stringBox);
+    }
+
+    [SkippableFact]
+    public async Task PushMembersDown_VirtualMember_KeepsVirtualForFurtherOverrides()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+                public virtual int Speak()
+                {
+                    return 1;
+                }
+            }
+
+            public class Dog : Animal
+            {
+            }
+
+            public class Puppy : Dog
+            {
+                public override int Speak()
+                {
+                    return 2;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new PushMembersDownOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new PushMembersDownParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Animal",
+            Members = ["Speak"]
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        var dog = ExtractTypeBody(text, "Dog");
+        var puppy = ExtractTypeBody(text, "Puppy");
+        Assert.DoesNotContain("Speak", ExtractTypeBody(text, "Animal"));
+        Assert.Contains("virtual", dog);
+        Assert.Contains("Speak", dog);
+        Assert.Contains("override", puppy);
+        Assert.Contains("Speak", puppy);
+    }
+
+    [SkippableFact]
+    public async Task PushMembersDown_DefaultInterfaceMethod_KeepsBodyOnDerivedInterface()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public interface IAnimal
+            {
+                int Speak()
+                {
+                    return 1;
+                }
+            }
+
+            public interface IDog : IAnimal
+            {
+            }
+
+            public class Cat : IDog
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new PushMembersDownOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new PushMembersDownParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "IAnimal",
+            Members = ["Speak"]
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        var derived = ExtractTypeBody(text, "IDog");
+        Assert.Contains("Speak", derived);
+        Assert.Contains("return 1", derived);
+        Assert.DoesNotContain("Speak", ExtractTypeBody(text, "Cat"));
+    }
+
+    [SkippableFact]
+    public async Task PushMembersDown_OneVariableFromMultiField_LeavesSibling()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+                public int Selected, Untouched;
+            }
+
+            public class Dog : Animal
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new PushMembersDownOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new PushMembersDownParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Animal",
+            Members = ["Selected"]
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        var animal = ExtractTypeBody(text, "Animal");
+        var dog = ExtractTypeBody(text, "Dog");
+        Assert.DoesNotContain("Selected", animal);
+        Assert.Contains("Untouched", animal);
+        Assert.Contains("Selected", dog);
+        Assert.DoesNotContain("Untouched", dog);
+    }
+
+    [SkippableFact]
+    public async Task PushMembersDown_BothVariablesFromMultiField_CopiesEachOnce()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+                public int Selected, Untouched;
+            }
+
+            public class Dog : Animal
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new PushMembersDownOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new PushMembersDownParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Animal",
+            Members = ["Selected", "Untouched"]
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        var animal = ExtractTypeBody(text, "Animal");
+        var dog = ExtractTypeBody(text, "Dog");
+        Assert.DoesNotContain("Selected", animal);
+        Assert.DoesNotContain("Untouched", animal);
+        Assert.Equal(1, CountOccurrences(dog, "Selected"));
+        Assert.Equal(1, CountOccurrences(dog, "Untouched"));
     }
 
     #endregion
@@ -559,7 +765,7 @@ public class PushMembersDownOperationTests
                 Members = ["Speak"]
             }));
 
-        Assert.Equal(ErrorCodes.MemberNotInterfaceCompatible, ex.ErrorCode);
+        Assert.Equal(ErrorCodes.MemberRequiredByContract, ex.ErrorCode);
     }
 
     [SkippableFact]
@@ -656,6 +862,119 @@ public class PushMembersDownOperationTests
         Assert.Equal(ErrorCodes.MemberNotFound, ex.ErrorCode);
     }
 
+    [SkippableFact]
+    public async Task PushMembersDown_ReferencedThroughBaseType_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+                public int Speak()
+                {
+                    return 1;
+                }
+            }
+
+            public class Dog : Animal
+            {
+            }
+
+            public static class Uses
+            {
+                public static int Call(Animal animal)
+                {
+                    return animal.Speak();
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new PushMembersDownOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new PushMembersDownParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "Animal",
+                Members = ["Speak"]
+            }));
+
+        Assert.Equal(ErrorCodes.MemberRequiredByContract, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task PushMembersDown_OverrideRequiredByAbstractBase_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public abstract class Creature
+            {
+                public abstract int Speak();
+            }
+
+            public class Animal : Creature
+            {
+                public override int Speak()
+                {
+                    return 1;
+                }
+            }
+
+            public class Dog : Animal
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new PushMembersDownOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new PushMembersDownParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "Animal",
+                Members = ["Speak"]
+            }));
+
+        Assert.Equal(ErrorCodes.MemberRequiredByContract, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task PushMembersDown_LeaveAbstractOnStatic_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+                public static int Speak()
+                {
+                    return 1;
+                }
+            }
+
+            public class Dog : Animal
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new PushMembersDownOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new PushMembersDownParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "Animal",
+                Members = ["Speak"],
+                LeaveAbstract = true
+            }));
+
+        Assert.Equal(ErrorCodes.MemberNotMoveable, ex.ErrorCode);
+    }
+
     #endregion
 
     #region Helpers
@@ -665,6 +984,20 @@ public class PushMembersDownOperationTests
 
     private static string NormalizeNewlines(string text) =>
         text.Replace("\r\n", "\n");
+
+    private static int CountOccurrences(string text, string value)
+    {
+        var count = 0;
+        var start = 0;
+        while (true)
+        {
+            var index = text.IndexOf(value, start, StringComparison.Ordinal);
+            if (index < 0)
+                return count;
+            count++;
+            start = index + value.Length;
+        }
+    }
 
     private static string ExtractTypeBody(string source, string typeName)
     {

--- a/tests/RoslynMcp.Server.Tests/Tools/PushMembersDownToolTests.cs
+++ b/tests/RoslynMcp.Server.Tests/Tools/PushMembersDownToolTests.cs
@@ -1,0 +1,160 @@
+using System.Text.Json;
+using RoslynMcp.Server.Tests.TestHelpers;
+using RoslynMcp.Server.Tools;
+using RoslynMcp.Server.Transport;
+using Xunit;
+
+namespace RoslynMcp.Server.Tests.Tools;
+
+/// <summary>
+/// Unit tests for PushMembersDownTool.
+/// Tests tool definition and argument validation.
+/// </summary>
+public class PushMembersDownToolTests
+{
+    private readonly PushMembersDownTool _tool;
+
+    public PushMembersDownToolTests()
+    {
+        _tool = new PushMembersDownTool(new ThrowingWorkspaceProvider());
+    }
+
+    #region GetDefinition Tests
+
+    [Fact]
+    public void GetDefinition_ReturnsCorrectName()
+    {
+        Assert.Equal("push_members_down", _tool.Name);
+    }
+
+    [Fact]
+    public void GetDefinition_ReturnsNonEmptyDescription()
+    {
+        Assert.NotNull(_tool.Description);
+        Assert.NotEmpty(_tool.Description);
+    }
+
+    [Fact]
+    public void GetDefinition_ReturnsCorrectSchema()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.Equal("object", root.GetProperty("type").GetString());
+        Assert.True(root.TryGetProperty("properties", out _));
+        Assert.True(root.TryGetProperty("required", out _));
+    }
+
+    [Fact]
+    public void GetDefinition_HasRequiredFields()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var required = doc.RootElement.GetProperty("required");
+
+        var requiredFields = new List<string>();
+        foreach (var item in required.EnumerateArray())
+        {
+            requiredFields.Add(item.GetString()!);
+        }
+
+        Assert.Contains("solutionPath", requiredFields);
+        Assert.Contains("sourceFile", requiredFields);
+        Assert.Contains("typeName", requiredFields);
+        Assert.Contains("members", requiredFields);
+    }
+
+    [Fact]
+    public void GetDefinition_HasProperties_ForAllParameters()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var properties = doc.RootElement.GetProperty("properties");
+
+        Assert.True(properties.TryGetProperty("solutionPath", out _));
+        Assert.True(properties.TryGetProperty("sourceFile", out _));
+        Assert.True(properties.TryGetProperty("typeName", out _));
+        Assert.True(properties.TryGetProperty("members", out _));
+        Assert.True(properties.TryGetProperty("targetDerivedTypes", out _));
+        Assert.True(properties.TryGetProperty("leaveAbstract", out _));
+        Assert.True(properties.TryGetProperty("preview", out _));
+    }
+
+    [Fact]
+    public void GetDefinition_MembersProperty_IsArrayOfStrings()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var members = doc.RootElement.GetProperty("properties").GetProperty("members");
+
+        Assert.Equal("array", members.GetProperty("type").GetString());
+        Assert.Equal("string", members.GetProperty("items").GetProperty("type").GetString());
+    }
+
+    [Fact]
+    public void GetDefinition_TargetDerivedTypesProperty_IsArrayOfStrings()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var targets = doc.RootElement.GetProperty("properties").GetProperty("targetDerivedTypes");
+
+        Assert.Equal("array", targets.GetProperty("type").GetString());
+        Assert.Equal("string", targets.GetProperty("items").GetProperty("type").GetString());
+    }
+
+    #endregion
+
+    #region ExecuteAsync Argument Validation Tests
+
+    [Fact]
+    public async Task ExecuteAsync_NullArguments_ReturnsError()
+    {
+        var result = await _tool.ExecuteAsync(null);
+
+        Assert.True(result.IsError);
+        Assert.Contains("Arguments required", GetResultText(result));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EmptyArguments_ReturnsError()
+    {
+        var args = JsonDocument.Parse("{}").RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MissingRequiredField_ReturnsError()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "solutionPath": "C:/test/test.sln",
+                "sourceFile": "C:/test/Test.cs",
+                "typeName": "Base"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static string GetResultText(ToolResult result)
+    {
+        return result.Content.FirstOrDefault()?.Text ?? string.Empty;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds a bounded `push_members_down` / `PushMembersDownOperation` tool that moves selected members from a base type down onto derived types.

This follows the just-shipped `pull_members_up` pattern (PR #33): params in Contracts, operation under `Refactoring/Hierarchy`, MCP tool next to the other refactoring tools, and CLI registration in `ToolRegistry`.

Behavior:
- Push one or more methods, properties, fields, or events to all direct derived types
- Optional `targetDerivedTypes` limits the push to a named subset
- `leaveAbstract` keeps an abstract declaration on the source class and adds overrides on derived types
- Interface sources keep their members (the contract stays) and copy implementations to implementers
- Preview mode returns pending changes without writing files
- Rejects missing derived types, name/signature conflicts, interface-incompatible members, uneditable targets, leftover base-type references, inherited abstract contracts, and `leaveAbstract` on static members
- Substitutes closed generic type arguments, keeps virtual dispatch, splits multi-variable field declarations, retains default interface bodies, and emits `public` when copying implicit-public interface members onto classes

## Related Issues

Closes #34

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Test additions or updates

## Testing

- [x] Solution builds (0 warnings, including TreatWarningsAsErrors)
- [x] `dotnet format --verify-no-changes` passes
- [x] New tests added for happy path, preview, P0 rejects, and review correctness cases
- [x] Feature tests pass locally: 28 operation + 10 tool + 43 CLI registry/help

**Test Configuration**:
- OS: Linux
- .NET Version: 9.0.317

## Checklist

- [x] Code follows the existing `pull_members_up` operation pattern
- [x] XML documentation added for public APIs
- [x] README / changelog / tool counts updated (44 tools)
- [x] Dependabot PRs #12–#17 left alone
- [x] Out of scope left out: `use_base_type`, `inline_constant`, undo
- [x] Codex/Copilot correctness threads addressed on this PR

## Additional Notes

Error codes reuse the shipped hierarchy set (`DERIVED_CLASSES_NOT_FOUND` 2011, `CONFLICTS_WITH_EXISTING_MEMBER` 3108, `MEMBER_NOT_INTERFACE_COMPATIBLE` 3110) and add `DERIVED_CLASS_NOT_EDITABLE` (3111) plus `MEMBER_REQUIRED_BY_CONTRACT` (3112). Contract removals (interface implementations, inherited abstract overrides, leftover base-type references) now use 3112. 3110 remains the “cannot declare this member on an interface” case.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fee220c4-1fce-41ce-ad76-658e03a39105?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fee220c4-1fce-41ce-ad76-658e03a39105&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

