### PR TITLE
Add use_base_type hierarchy refactoring

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "roslyn-mcp",
   "version": "0.4.1",
-  "description": "Roslyn-powered C# refactoring MCP server — 44 tools for code navigation, analysis, generation, and refactoring across entire .NET solutions",
+  "description": "Roslyn-powered C# refactoring MCP server — 45 tools for code navigation, analysis, generation, and refactoring across entire .NET solutions",
   "author": {
     "name": "Joshua Ramirez"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Added
 - `pull_members_up` — move selected members from a derived type onto an existing base class or interface, with preview mode and rejects for missing bases, interface-incompatible members, and name/signature conflicts
 - `push_members_down` — move selected members from a base type down onto derived types, with optional named targets, preview mode, and rejects for missing derived types, conflicts, interface-incompatible members, and uneditable targets
+- `use_base_type` — replace derived-type references with a compatible base type or interface, rewriting only usages whose members exist on that base, with preview mode and rejects for missing bases, uneditable documents, and no eligible references
 
 ## [0.4.0] - 2026-02-23
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Let AI assistants like Claude safely refactor your C# codebase using the same Roslyn compiler platform that powers Visual Studio.
 
-Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that exposes **44 Roslyn-powered tools** to AI assistants and other MCP clients. It combines 22 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 7 code conversion tools -- giving your AI deep code intelligence, comprehensive refactoring, and modern C# syntax transformations with full solution-wide reference tracking and preview support.
+Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that exposes **45 Roslyn-powered tools** to AI assistants and other MCP clients. It combines 23 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 7 code conversion tools -- giving your AI deep code intelligence, comprehensive refactoring, and modern C# syntax transformations with full solution-wide reference tracking and preview support.
 
 ---
 
@@ -30,7 +30,7 @@ Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotoc
 
 ## Why RoslynMcpServer?
 
-- **44 tools** -- refactoring, navigation, analysis, generation, and conversion tools, the most comprehensive Roslyn MCP server available
+- **45 tools** -- refactoring, navigation, analysis, generation, and conversion tools, the most comprehensive Roslyn MCP server available
 - **Preview mode on every operation** -- see exactly what will change before applying
 - **Atomic file writes with rollback** -- if any file write fails, all changes are reverted
 - **Solution-wide reference updates** -- renames and moves propagate across your entire solution
@@ -102,7 +102,7 @@ Claude will use the `rename_symbol` tool to rename the class and update every re
 
 ## Standalone CLI
 
-All 44 tools are also available as a standalone CLI for use in scripts, CI/CD pipelines, and terminals without an AI assistant.
+All 45 tools are also available as a standalone CLI for use in scripts, CI/CD pipelines, and terminals without an AI assistant.
 
 ### Install
 
@@ -203,6 +203,7 @@ All tools accept a `solutionPath` parameter (absolute path to a `.sln`, `.slnx`,
 | `extract_base_class` | Extract members to a new base class. | `sourceFile`, `typeName`, `baseClassName`, `members`, `targetFile`, `makeAbstract` |
 | `pull_members_up` | Move selected members from a derived type onto an existing base class or interface. | `sourceFile`, `typeName`, `members`, `targetBaseType`, `makeAbstract` |
 | `push_members_down` | Move selected members from a base type down onto derived types. | `sourceFile`, `typeName`, `members`, `targetDerivedTypes`, `leaveAbstract` |
+| `use_base_type` | Replace derived-type references with a compatible base type or interface. | `sourceFile`, `typeName`, `targetBaseType` |
 
 ### Inline
 

--- a/src/RoslynMcp.Cli/ToolRegistry.cs
+++ b/src/RoslynMcp.Cli/ToolRegistry.cs
@@ -47,7 +47,7 @@ public sealed class ToolEntry
 }
 
 /// <summary>
-/// Maps tool names to execution delegates for all 44 Roslyn tools.
+/// Maps tool names to execution delegates for all 45 Roslyn tools.
 /// </summary>
 public sealed class ToolRegistry
 {
@@ -139,7 +139,7 @@ public sealed class ToolRegistry
         _tools.Values.OrderBy(t => t.Category).ThenBy(t => t.Name).ToList();
 
     /// <summary>
-    /// Build the default registry with all 44 tools registered.
+    /// Build the default registry with all 45 tools registered.
     /// </summary>
     public static ToolRegistry BuildDefault()
     {
@@ -162,6 +162,8 @@ public sealed class ToolRegistry
             "pull-members-up", "Move selected members from a derived type onto an existing base class or interface");
         r.RegisterRefactoring<PushMembersDownOperation, PushMembersDownParams>(
             "push-members-down", "Move selected members from a base type down onto derived types");
+        r.RegisterRefactoring<UseBaseTypeOperation, UseBaseTypeParams>(
+            "use-base-type", "Replace derived-type references with a compatible base type or interface");
 
         // ── Refactoring: Rename (1) ───────────────────────────────────
         r.RegisterRefactoring<RenameSymbolOperation, RenameSymbolParams>(

--- a/src/RoslynMcp.Contracts/Enums/RefactoringKind.cs
+++ b/src/RoslynMcp.Contracts/Enums/RefactoringKind.cs
@@ -38,6 +38,9 @@ public enum RefactoringKind
     /// <summary>Move selected members from a base type down onto derived types.</summary>
     PushMembersDown,
 
+    /// <summary>Replace derived-type references with a compatible base type or interface.</summary>
+    UseBaseType,
+
     /// <summary>Extract expression to variable.</summary>
     ExtractVariable,
 

--- a/src/RoslynMcp.Contracts/Errors/ErrorCodes.cs
+++ b/src/RoslynMcp.Contracts/Errors/ErrorCodes.cs
@@ -339,6 +339,15 @@ public static class ErrorCodes
     /// <summary>Member is required by an interface or abstract contract and cannot be removed from the base.</summary>
     public const string MemberRequiredByContract = "3112";
 
+    /// <summary>No type-annotation references can be rewritten to the chosen base.</summary>
+    public const string NoEligibleReferences = "3113";
+
+    /// <summary>Candidate references use members that do not exist on the chosen base.</summary>
+    public const string BaseCannotSatisfyUsedMembers = "3114";
+
+    /// <summary>A document containing eligible references is not editable.</summary>
+    public const string DocumentNotEditable = "3115";
+
     // ============================================
     // System Errors (4xxx)
     // ============================================

--- a/src/RoslynMcp.Contracts/Models/UseBaseTypeParams.cs
+++ b/src/RoslynMcp.Contracts/Models/UseBaseTypeParams.cs
@@ -1,0 +1,29 @@
+namespace RoslynMcp.Contracts.Models;
+
+/// <summary>
+/// Parameters for the use_base_type tool.
+/// </summary>
+public sealed class UseBaseTypeParams
+{
+    /// <summary>
+    /// Absolute path to the source file containing the derived type.
+    /// </summary>
+    public required string SourceFile { get; init; }
+
+    /// <summary>
+    /// Name of the derived class, struct, or interface whose references
+    /// should be rewritten to a compatible base type.
+    /// </summary>
+    public required string TypeName { get; init; }
+
+    /// <summary>
+    /// Target base class or interface name. If omitted, uses the nearest base
+    /// class, or the single implemented interface when there is no class base.
+    /// </summary>
+    public string? TargetBaseType { get; init; }
+
+    /// <summary>
+    /// Return computed changes without applying. Default: false.
+    /// </summary>
+    public bool Preview { get; init; }
+}

--- a/src/RoslynMcp.Core/Refactoring/Hierarchy/UseBaseTypeOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Hierarchy/UseBaseTypeOperation.cs
@@ -62,7 +62,7 @@ public sealed class UseBaseTypeOperation : RefactoringOperationBase<UseBaseTypeP
         if (root == null || semanticModel == null)
             throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse file.");
 
-        var derivedDecl = FindTypeDeclaration(root, @params.TypeName);
+        var derivedDecl = FindTypeDeclaration(root, semanticModel, @params.TypeName, cancellationToken);
         if (derivedDecl == null)
         {
             throw new RefactoringException(
@@ -96,11 +96,12 @@ public sealed class UseBaseTypeOperation : RefactoringOperationBase<UseBaseTypeP
                 continue;
             }
 
+            var constructed = GetConstructedTarget(target, candidate.TypeSyntax, candidate.SemanticModel);
             rewrites.Add(new RewritableReference(
                 candidate.Document,
                 candidate.TypeSyntax,
-                CreateBaseTypeReference(target, candidate.TypeSyntax),
-                target));
+                CreateBaseTypeReference(constructed, candidate.TypeSyntax, candidate.SemanticModel),
+                constructed));
         }
 
         if (rewrites.Count == 0)
@@ -140,15 +141,59 @@ public sealed class UseBaseTypeOperation : RefactoringOperationBase<UseBaseTypeP
             0);
     }
 
-    private static TypeDeclarationSyntax? FindTypeDeclaration(SyntaxNode root, string typeName)
+    private static TypeDeclarationSyntax? FindTypeDeclaration(
+        SyntaxNode root,
+        SemanticModel model,
+        string typeName,
+        CancellationToken cancellationToken)
     {
         var simpleName = typeName.Contains('.')
             ? typeName[(typeName.LastIndexOf('.') + 1)..]
             : typeName;
 
-        return root.DescendantNodes()
+        var matches = root.DescendantNodes()
             .OfType<TypeDeclarationSyntax>()
-            .FirstOrDefault(t => t.Identifier.Text == simpleName);
+            .Where(type => type.Identifier.Text == simpleName)
+            .ToList();
+
+        if (matches.Count == 0)
+            return null;
+
+        if (!typeName.Contains('.') || matches.Count == 1)
+            return matches[0];
+
+        foreach (var match in matches)
+        {
+            if (model.GetDeclaredSymbol(match, cancellationToken) is not INamedTypeSymbol symbol)
+                continue;
+
+            if (TypeNameMatches(symbol, typeName))
+                return match;
+        }
+
+        return null;
+    }
+
+    internal static bool TypeNameMatches(INamedTypeSymbol symbol, string typeName)
+    {
+        if (symbol.Name.Equals(typeName, StringComparison.Ordinal) ||
+            symbol.ToDisplayString().Equals(typeName, StringComparison.Ordinal) ||
+            symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
+                .Equals(typeName, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        var metadata = symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat
+            .WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted));
+        if (metadata.Equals(typeName, StringComparison.Ordinal))
+            return true;
+
+        var containing = symbol.ContainingNamespace?.ToDisplayString();
+        if (string.IsNullOrWhiteSpace(containing) || symbol.ContainingNamespace!.IsGlobalNamespace)
+            return false;
+
+        return $"{containing}.{symbol.Name}".Equals(typeName, StringComparison.Ordinal);
     }
 
     /// <summary>
@@ -362,7 +407,7 @@ public sealed class UseBaseTypeOperation : RefactoringOperationBase<UseBaseTypeP
         if (!CanUseBaseType(derived, baseType))
             return false;
 
-        if (HasTargetTypedNew(candidate.TypeSyntax))
+        if (HasTargetTypedNew(candidate.TypeSyntax, candidate.SemanticModel, derived))
             return false;
 
         var declared = GetDeclaredSymbols(candidate.TypeSyntax, candidate.SemanticModel, cancellationToken);
@@ -381,18 +426,95 @@ public sealed class UseBaseTypeOperation : RefactoringOperationBase<UseBaseTypeP
         return true;
     }
 
-    private static bool HasTargetTypedNew(TypeSyntax annotation)
+    private static bool HasTargetTypedNew(
+        TypeSyntax annotation,
+        SemanticModel model,
+        INamedTypeSymbol derived)
     {
         var outermost = GetOutermostTypeSyntax(annotation);
-        return outermost.Parent switch
+        foreach (var creation in EnumerateInferredCreations(outermost.Parent))
         {
-            VariableDeclarationSyntax variables =>
-                variables.Variables.Any(variable =>
-                    variable.Initializer?.Value is ImplicitObjectCreationExpressionSyntax),
-            PropertyDeclarationSyntax property =>
-                property.Initializer?.Value is ImplicitObjectCreationExpressionSyntax,
-            _ => false
-        };
+            var converted = model.GetTypeInfo(creation).ConvertedType;
+            if (converted != null && IsSameOrConstructed(converted, derived))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<ImplicitObjectCreationExpressionSyntax> EnumerateInferredCreations(SyntaxNode? parent)
+    {
+        switch (parent)
+        {
+            case VariableDeclarationSyntax variables:
+                foreach (var variable in variables.Variables)
+                {
+                    if (variable.Initializer?.Value is ImplicitObjectCreationExpressionSyntax creation)
+                        yield return creation;
+                }
+
+                break;
+            case PropertyDeclarationSyntax property:
+                if (property.Initializer?.Value is ImplicitObjectCreationExpressionSyntax propertyCreation)
+                    yield return propertyCreation;
+                foreach (var creation in EnumerateReturnCreations(property.ExpressionBody, GetAccessorBodies(property)))
+                    yield return creation;
+                break;
+            case MethodDeclarationSyntax method:
+                foreach (var creation in EnumerateReturnCreations(method.ExpressionBody, method.Body))
+                    yield return creation;
+                break;
+            case LocalFunctionStatementSyntax localFunction:
+                foreach (var creation in EnumerateReturnCreations(localFunction.ExpressionBody, localFunction.Body))
+                    yield return creation;
+                break;
+        }
+    }
+
+    private static IEnumerable<BlockSyntax?> GetAccessorBodies(PropertyDeclarationSyntax property)
+    {
+        if (property.AccessorList == null)
+            yield break;
+
+        foreach (var accessor in property.AccessorList.Accessors)
+            yield return accessor.Body;
+    }
+
+    private static IEnumerable<ImplicitObjectCreationExpressionSyntax> EnumerateReturnCreations(
+        ArrowExpressionClauseSyntax? expressionBody,
+        BlockSyntax? body)
+    {
+        if (expressionBody != null)
+        {
+            foreach (var creation in expressionBody.DescendantNodesAndSelf().OfType<ImplicitObjectCreationExpressionSyntax>())
+                yield return creation;
+        }
+
+        if (body == null)
+            yield break;
+
+        foreach (var ret in body.DescendantNodes().OfType<ReturnStatementSyntax>())
+        {
+            if (ret.Expression == null)
+                continue;
+
+            foreach (var creation in ret.Expression.DescendantNodesAndSelf().OfType<ImplicitObjectCreationExpressionSyntax>())
+                yield return creation;
+        }
+    }
+
+    private static IEnumerable<ImplicitObjectCreationExpressionSyntax> EnumerateReturnCreations(
+        ArrowExpressionClauseSyntax? expressionBody,
+        IEnumerable<BlockSyntax?> bodies)
+    {
+        foreach (var creation in EnumerateReturnCreations(expressionBody, (BlockSyntax?)null))
+            yield return creation;
+
+        foreach (var body in bodies)
+        {
+            foreach (var creation in EnumerateReturnCreations(null, body))
+                yield return creation;
+        }
     }
 
     private static List<ISymbol> GetDeclaredSymbols(
@@ -451,8 +573,10 @@ public sealed class UseBaseTypeOperation : RefactoringOperationBase<UseBaseTypeP
 
     private static bool IsSignatureLocked(ISymbol symbol, TypeSyntax annotation)
     {
-        var method = symbol as IMethodSymbol;
-        var property = symbol as IPropertySymbol;
+        var method = symbol as IMethodSymbol
+            ?? (symbol as IParameterSymbol)?.ContainingSymbol as IMethodSymbol;
+        var property = symbol as IPropertySymbol
+            ?? (symbol as IParameterSymbol)?.ContainingSymbol as IPropertySymbol;
         if (method == null && property == null)
             return false;
 
@@ -828,28 +952,63 @@ public sealed class UseBaseTypeOperation : RefactoringOperationBase<UseBaseTypeP
         return named.AllInterfaces.Any(iface => SymbolEqualityComparer.Default.Equals(iface, baseType));
     }
 
-    internal static TypeSyntax CreateBaseTypeReference(INamedTypeSymbol baseType, TypeSyntax original)
+    internal static INamedTypeSymbol GetConstructedTarget(
+        INamedTypeSymbol target,
+        TypeSyntax original,
+        SemanticModel model)
     {
-        if (original is GenericNameSyntax generic)
+        var referenced = model.GetTypeInfo(original).Type as INamedTypeSymbol
+            ?? model.GetSymbolInfo(original).Symbol as INamedTypeSymbol;
+        if (referenced == null)
+            return target;
+
+        if (target.TypeKind == TypeKind.Interface)
         {
-            return SyntaxFactory.GenericName(
-                    SyntaxFactory.Identifier(
-                        generic.Identifier.LeadingTrivia,
-                        baseType.Name,
-                        generic.Identifier.TrailingTrivia),
-                    generic.TypeArgumentList)
-                .WithLeadingTrivia(original.GetLeadingTrivia())
-                .WithTrailingTrivia(original.GetTrailingTrivia());
+            return referenced.AllInterfaces.FirstOrDefault(iface =>
+                SymbolEqualityComparer.Default.Equals(iface.OriginalDefinition, target.OriginalDefinition))
+                ?? target;
         }
 
-        var display = original is QualifiedNameSyntax or AliasQualifiedNameSyntax
-            ? baseType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat
-                .WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted))
-            : baseType.Name;
+        for (var current = referenced.BaseType; current != null; current = current.BaseType)
+        {
+            if (SymbolEqualityComparer.Default.Equals(current.OriginalDefinition, target.OriginalDefinition))
+                return current;
+        }
+
+        return target;
+    }
+
+    internal static TypeSyntax CreateBaseTypeReference(
+        INamedTypeSymbol baseType,
+        TypeSyntax original,
+        SemanticModel model)
+    {
+        var display = baseType.ToMinimalDisplayString(model, original.SpanStart);
+        if (string.IsNullOrWhiteSpace(display) ||
+            NameBindsToDifferentType(display, baseType, model, original.SpanStart))
+        {
+            display = baseType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat
+                .WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted));
+        }
 
         return SyntaxFactory.ParseTypeName(display)
             .WithLeadingTrivia(original.GetLeadingTrivia())
             .WithTrailingTrivia(original.GetTrailingTrivia());
+    }
+
+    private static bool NameBindsToDifferentType(
+        string display,
+        INamedTypeSymbol expected,
+        SemanticModel model,
+        int position)
+    {
+        var parsed = SyntaxFactory.ParseTypeName(display);
+        var spec = model.GetSpeculativeTypeInfo(position, parsed, SpeculativeBindingOption.BindAsTypeOrNamespace);
+        if (spec.Type is not INamedTypeSymbol bound)
+            return true;
+
+        return !SymbolEqualityComparer.Default.Equals(bound.OriginalDefinition, expected.OriginalDefinition) &&
+               !SymbolEqualityComparer.Default.Equals(bound, expected);
     }
 
     private static async Task<Solution> ApplyRewritesAsync(
@@ -879,8 +1038,11 @@ public sealed class UseBaseTypeOperation : RefactoringOperationBase<UseBaseTypeP
             }
 
             var newRoot = root.ReplaceNodes(map.Keys, (original, _) => map[original]);
-            if (newRoot is CompilationUnitSyntax unit)
+            if (newRoot is CompilationUnitSyntax unit &&
+                group.Any(rewrite => rewrite.Replacement is IdentifierNameSyntax))
+            {
                 newRoot = EnsureUsing(unit, group.First().BaseType);
+            }
 
             solution = document.WithSyntaxRoot(newRoot).Project.Solution;
         }

--- a/src/RoslynMcp.Core/Refactoring/Hierarchy/UseBaseTypeOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Hierarchy/UseBaseTypeOperation.cs
@@ -1,0 +1,870 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.FindSymbols;
+using RoslynMcp.Contracts.Enums;
+using RoslynMcp.Contracts.Errors;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.FileSystem;
+using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Workspace;
+
+namespace RoslynMcp.Core.Refactoring.Hierarchy;
+
+/// <summary>
+/// Replaces selected derived-type references with a compatible base type or
+/// interface where every used member exists on that base.
+/// </summary>
+public sealed class UseBaseTypeOperation : RefactoringOperationBase<UseBaseTypeParams>
+{
+    /// <summary>
+    /// Creates a new use-base-type operation.
+    /// </summary>
+    public UseBaseTypeOperation(WorkspaceContext context) : base(context)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override void ValidateParams(UseBaseTypeParams @params) => Validate(@params);
+
+    /// <summary>
+    /// Validates use-base-type parameters. Internal so tests can exercise
+    /// input rules without loading a workspace.
+    /// </summary>
+    internal static void Validate(UseBaseTypeParams @params)
+    {
+        if (string.IsNullOrWhiteSpace(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "sourceFile is required.");
+
+        if (string.IsNullOrWhiteSpace(@params.TypeName))
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "typeName is required.");
+
+        if (!PathResolver.IsAbsolutePath(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.InvalidSourcePath, "sourceFile must be an absolute path.");
+
+        if (!PathResolver.IsValidCSharpFilePath(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.InvalidSourcePath, "sourceFile must be a .cs file.");
+
+        if (!File.Exists(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.SourceFileNotFound, $"Source file not found: {@params.SourceFile}");
+    }
+
+    /// <inheritdoc />
+    protected override async Task<RefactoringResult> ExecuteCoreAsync(
+        Guid operationId,
+        UseBaseTypeParams @params,
+        CancellationToken cancellationToken)
+    {
+        var document = GetDocumentOrThrow(@params.SourceFile);
+        var root = await document.GetSyntaxRootAsync(cancellationToken);
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken);
+
+        if (root == null || semanticModel == null)
+            throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse file.");
+
+        var derivedDecl = FindTypeDeclaration(root, @params.TypeName);
+        if (derivedDecl == null)
+        {
+            throw new RefactoringException(
+                ErrorCodes.TypeNotFound,
+                $"Type '{@params.TypeName}' not found in file.");
+        }
+
+        var derivedSymbol = semanticModel.GetDeclaredSymbol(derivedDecl, cancellationToken) as INamedTypeSymbol;
+        if (derivedSymbol == null)
+            throw new RefactoringException(ErrorCodes.RoslynError, "Could not resolve type symbol.");
+
+        var target = GetTargetBaseType(derivedSymbol, @params.TargetBaseType);
+        var candidates = await FindTypeReferencesAsync(derivedSymbol, cancellationToken);
+        if (candidates.Count == 0)
+        {
+            throw new RefactoringException(
+                ErrorCodes.NoEligibleReferences,
+                $"No eligible type references of '{derivedSymbol.Name}' can be rewritten to '{target.Name}'.");
+        }
+
+        var rewrites = new List<RewritableReference>();
+        var sawIncompatibleMembers = false;
+
+        foreach (var candidate in candidates)
+        {
+            ValidateDocumentIsEditable(candidate.Document, Context.Workspace);
+
+            if (!await CanUseBaseTypeAsync(candidate, derivedSymbol, target, cancellationToken))
+            {
+                sawIncompatibleMembers = true;
+                continue;
+            }
+
+            rewrites.Add(new RewritableReference(
+                candidate.Document,
+                candidate.TypeSyntax,
+                CreateBaseTypeReference(target, candidate.TypeSyntax),
+                target));
+        }
+
+        if (rewrites.Count == 0)
+        {
+            throw new RefactoringException(
+                sawIncompatibleMembers
+                    ? ErrorCodes.BaseCannotSatisfyUsedMembers
+                    : ErrorCodes.NoEligibleReferences,
+                sawIncompatibleMembers
+                    ? $"Base type '{target.Name}' cannot satisfy members used through '{derivedSymbol.Name}'."
+                    : $"No eligible type references of '{derivedSymbol.Name}' can be rewritten to '{target.Name}'.");
+        }
+
+        if (@params.Preview)
+            return CreatePreviewResult(operationId, rewrites, derivedSymbol, target);
+
+        var solution = await ApplyRewritesAsync(rewrites, cancellationToken);
+        var commitResult = await CommitChangesAsync(solution, cancellationToken);
+
+        return RefactoringResult.Succeeded(
+            operationId,
+            new FileChanges
+            {
+                FilesModified = commitResult.FilesModified,
+                FilesCreated = commitResult.FilesCreated,
+                FilesDeleted = commitResult.FilesDeleted
+            },
+            new Contracts.Models.SymbolInfo
+            {
+                Name = target.Name,
+                FullyQualifiedName = target.ToDisplayString(),
+                Kind = target.TypeKind == TypeKind.Interface
+                    ? Contracts.Enums.SymbolKind.Interface
+                    : Contracts.Enums.SymbolKind.Class
+            },
+            rewrites.Count,
+            0);
+    }
+
+    private static TypeDeclarationSyntax? FindTypeDeclaration(SyntaxNode root, string typeName)
+    {
+        var simpleName = typeName.Contains('.')
+            ? typeName[(typeName.LastIndexOf('.') + 1)..]
+            : typeName;
+
+        return root.DescendantNodes()
+            .OfType<TypeDeclarationSyntax>()
+            .FirstOrDefault(t => t.Identifier.Text == simpleName);
+    }
+
+    /// <summary>
+    /// Resolves the base class or interface that references should use.
+    /// </summary>
+    internal static INamedTypeSymbol GetTargetBaseType(INamedTypeSymbol derived, string? targetTypeName)
+    {
+        var classBases = new List<INamedTypeSymbol>();
+        for (var baseType = derived.BaseType; baseType != null; baseType = baseType.BaseType)
+            classBases.Add(baseType);
+
+        var interfaces = derived.AllInterfaces.ToList();
+
+        if (string.IsNullOrWhiteSpace(targetTypeName))
+        {
+            var meaningful = classBases
+                .Where(candidate => candidate.SpecialType != SpecialType.System_Object)
+                .ToList();
+            if (meaningful.Count > 0)
+                return meaningful[0];
+
+            if (derived.Interfaces.Length == 1)
+                return derived.Interfaces[0];
+
+            if (derived.Interfaces.Length > 1)
+            {
+                throw new RefactoringException(
+                    ErrorCodes.NoCommonBase,
+                    $"Type '{derived.Name}' implements multiple interfaces; specify targetBaseType.");
+            }
+
+            throw new RefactoringException(
+                ErrorCodes.NoCommonBase,
+                $"Type '{derived.Name}' has no base class or interface to use.");
+        }
+
+        var match = classBases.Concat(interfaces).FirstOrDefault(candidate =>
+            candidate.Name.Equals(targetTypeName, StringComparison.Ordinal) ||
+            candidate.ToDisplayString().Equals(targetTypeName, StringComparison.Ordinal));
+
+        if (match == null)
+        {
+            throw new RefactoringException(
+                ErrorCodes.BaseClassNotFound,
+                $"Type '{targetTypeName}' is not a base class or interface of '{derived.Name}'.");
+        }
+
+        return match;
+    }
+
+    /// <summary>
+    /// Rejects documents that cannot receive source edits.
+    /// </summary>
+    internal static void ValidateDocumentIsEditable(Document document, Microsoft.CodeAnalysis.Workspace workspace)
+    {
+        if (document is SourceGeneratedDocument)
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable (source-generated).");
+        }
+
+        if (string.IsNullOrWhiteSpace(document.FilePath) || !File.Exists(document.FilePath))
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable.");
+        }
+
+        if (!workspace.CanApplyChange(ApplyChangesKind.ChangeDocument))
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable (workspace cannot apply changes).");
+        }
+    }
+
+    private async Task<List<TypeReference>> FindTypeReferencesAsync(
+        INamedTypeSymbol type,
+        CancellationToken cancellationToken)
+    {
+        var search = await ReferenceTracker.FindAllReferencesAsync(type, cancellationToken);
+        var results = new List<TypeReference>();
+        var seen = new HashSet<(DocumentId Id, int Start, int End)>();
+
+        foreach (var (documentId, locations) in search.ReferencesByDocument)
+        {
+            var document = Context.Solution.GetDocument(documentId);
+            if (document == null)
+                continue;
+
+            var root = await document.GetSyntaxRootAsync(cancellationToken);
+            var model = await document.GetSemanticModelAsync(cancellationToken);
+            if (root == null || model == null)
+                continue;
+
+            foreach (var location in locations)
+            {
+                if (location.IsImplicit || !location.Location.IsInSource)
+                    continue;
+
+                var node = root.FindNode(location.Location.SourceSpan, getInnermostNodeForTie: true);
+                var typeSyntax = GetReplaceableTypeSyntax(node);
+                if (typeSyntax == null || !IsRewritableAnnotation(typeSyntax))
+                    continue;
+
+                var key = (document.Id, typeSyntax.Span.Start, typeSyntax.Span.End);
+                if (!seen.Add(key))
+                    continue;
+
+                results.Add(new TypeReference(document, typeSyntax, model));
+            }
+        }
+
+        return results;
+    }
+
+    internal static TypeSyntax? GetReplaceableTypeSyntax(SyntaxNode node)
+    {
+        if (node is IdentifierNameSyntax identifier &&
+            identifier.Parent is QualifiedNameSyntax qualified &&
+            qualified.Right == identifier)
+        {
+            var current = qualified;
+            while (current.Parent is QualifiedNameSyntax parent)
+                current = parent;
+            return current;
+        }
+
+        if (node is TypeSyntax typeSyntax)
+            return typeSyntax;
+
+        return node.FirstAncestorOrSelf<TypeSyntax>();
+    }
+
+    internal static bool IsRewritableAnnotation(TypeSyntax type)
+    {
+        if (type.Parent is ArrayTypeSyntax or PointerTypeSyntax)
+            return false;
+
+        var outermost = GetOutermostTypeSyntax(type);
+        var parent = outermost.Parent;
+
+        switch (parent)
+        {
+            case ObjectCreationExpressionSyntax:
+            case ImplicitObjectCreationExpressionSyntax:
+            case TypeOfExpressionSyntax:
+            case SizeOfExpressionSyntax:
+            case DefaultExpressionSyntax:
+            case CastExpressionSyntax:
+            case BaseListSyntax:
+            case SimpleBaseTypeSyntax:
+            case PrimaryConstructorBaseTypeSyntax:
+            case TypeArgumentListSyntax:
+            case TypeParameterConstraintClauseSyntax:
+            case TypeConstraintSyntax:
+            case AttributeSyntax:
+            case AttributeArgumentSyntax:
+            case DeclarationPatternSyntax:
+            case TypePatternSyntax:
+            case RecursivePatternSyntax:
+            case ConstantPatternSyntax:
+            case OperatorDeclarationSyntax:
+            case ConversionOperatorDeclarationSyntax:
+                return false;
+            case BinaryExpressionSyntax binary
+                when binary.IsKind(SyntaxKind.AsExpression) || binary.IsKind(SyntaxKind.IsExpression):
+                return false;
+            case VariableDeclarationSyntax:
+            case ParameterSyntax:
+            case MethodDeclarationSyntax:
+            case LocalFunctionStatementSyntax:
+            case PropertyDeclarationSyntax:
+            case EventDeclarationSyntax:
+            case IndexerDeclarationSyntax:
+            case DelegateDeclarationSyntax:
+            case ForEachStatementSyntax:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static TypeSyntax GetOutermostTypeSyntax(TypeSyntax type)
+    {
+        var current = type;
+        while (current.Parent is NullableTypeSyntax or RefTypeSyntax parent)
+            current = parent;
+        return current;
+    }
+
+    /// <summary>
+    /// True when <paramref name="usage"/> is the chosen base or a type that
+    /// inherits or implements it.
+    /// </summary>
+    internal static bool CanUseBaseType(ITypeSymbol usage, ITypeSymbol baseType)
+    {
+        if (usage.TypeKind == TypeKind.Error || baseType.TypeKind == TypeKind.Error)
+            return false;
+
+        return IsSameOrDerived(usage, baseType);
+    }
+
+    private async Task<bool> CanUseBaseTypeAsync(
+        TypeReference candidate,
+        INamedTypeSymbol derived,
+        INamedTypeSymbol baseType,
+        CancellationToken cancellationToken)
+    {
+        if (!CanUseBaseType(derived, baseType))
+            return false;
+
+        if (HasTargetTypedNew(candidate.TypeSyntax))
+            return false;
+
+        var declared = GetDeclaredSymbols(candidate.TypeSyntax, candidate.SemanticModel, cancellationToken);
+        if (declared.Count == 0)
+            return false;
+
+        foreach (var symbol in declared)
+        {
+            if (IsSignatureLocked(symbol, candidate.TypeSyntax))
+                return false;
+
+            if (!await UsagesCompatibleWithBaseAsync(symbol, candidate, derived, baseType, cancellationToken))
+                return false;
+        }
+
+        return true;
+    }
+
+    private static bool HasTargetTypedNew(TypeSyntax annotation)
+    {
+        var outermost = GetOutermostTypeSyntax(annotation);
+        return outermost.Parent switch
+        {
+            VariableDeclarationSyntax variables =>
+                variables.Variables.Any(variable =>
+                    variable.Initializer?.Value is ImplicitObjectCreationExpressionSyntax),
+            PropertyDeclarationSyntax property =>
+                property.Initializer?.Value is ImplicitObjectCreationExpressionSyntax,
+            _ => false
+        };
+    }
+
+    private static List<ISymbol> GetDeclaredSymbols(
+        TypeSyntax type,
+        SemanticModel model,
+        CancellationToken cancellationToken)
+    {
+        var symbols = new List<ISymbol>();
+        var parent = GetOutermostTypeSyntax(type).Parent;
+
+        switch (parent)
+        {
+            case VariableDeclarationSyntax variables:
+                foreach (var variable in variables.Variables)
+                {
+                    var symbol = model.GetDeclaredSymbol(variable, cancellationToken);
+                    if (symbol != null)
+                        symbols.Add(symbol);
+                }
+
+                break;
+            case ParameterSyntax parameter:
+                AddIfNotNull(symbols, model.GetDeclaredSymbol(parameter, cancellationToken));
+                break;
+            case MethodDeclarationSyntax method:
+                AddIfNotNull(symbols, model.GetDeclaredSymbol(method, cancellationToken));
+                break;
+            case LocalFunctionStatementSyntax localFunction:
+                AddIfNotNull(symbols, model.GetDeclaredSymbol(localFunction, cancellationToken));
+                break;
+            case PropertyDeclarationSyntax property:
+                AddIfNotNull(symbols, model.GetDeclaredSymbol(property, cancellationToken));
+                break;
+            case EventDeclarationSyntax @event:
+                AddIfNotNull(symbols, model.GetDeclaredSymbol(@event, cancellationToken));
+                break;
+            case IndexerDeclarationSyntax indexer:
+                AddIfNotNull(symbols, model.GetDeclaredSymbol(indexer, cancellationToken));
+                break;
+            case ForEachStatementSyntax forEach:
+                AddIfNotNull(symbols, model.GetDeclaredSymbol(forEach, cancellationToken));
+                break;
+            case DelegateDeclarationSyntax @delegate:
+                AddIfNotNull(symbols, model.GetDeclaredSymbol(@delegate, cancellationToken));
+                break;
+        }
+
+        return symbols;
+    }
+
+    private static void AddIfNotNull(List<ISymbol> symbols, ISymbol? symbol)
+    {
+        if (symbol != null)
+            symbols.Add(symbol);
+    }
+
+    private static bool IsSignatureLocked(ISymbol symbol, TypeSyntax annotation)
+    {
+        var method = symbol as IMethodSymbol;
+        var property = symbol as IPropertySymbol;
+        if (method == null && property == null)
+            return false;
+
+        var outermost = GetOutermostTypeSyntax(annotation);
+        var changesSignature = outermost.Parent is MethodDeclarationSyntax
+            or LocalFunctionStatementSyntax
+            or ParameterSyntax
+            or PropertyDeclarationSyntax
+            or IndexerDeclarationSyntax
+            or DelegateDeclarationSyntax;
+
+        if (!changesSignature)
+            return false;
+
+        if (method != null)
+        {
+            if (method.IsOverride || method.IsAbstract || method.ExplicitInterfaceImplementations.Length > 0)
+                return true;
+
+            return ImplementsInterfaceMember(method);
+        }
+
+        if (property!.IsOverride || property.IsAbstract || property.ExplicitInterfaceImplementations.Length > 0)
+            return true;
+
+        return ImplementsInterfaceMember(property);
+    }
+
+    private static bool ImplementsInterfaceMember(ISymbol symbol)
+    {
+        var containing = symbol.ContainingType;
+        if (containing == null)
+            return false;
+
+        foreach (var iface in containing.AllInterfaces)
+        {
+            foreach (var member in iface.GetMembers(symbol.Name))
+            {
+                var implementation = containing.FindImplementationForInterfaceMember(member);
+                if (implementation != null && SymbolEqualityComparer.Default.Equals(implementation, symbol))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    private async Task<bool> UsagesCompatibleWithBaseAsync(
+        ISymbol symbol,
+        TypeReference candidate,
+        INamedTypeSymbol derived,
+        INamedTypeSymbol baseType,
+        CancellationToken cancellationToken)
+    {
+        if (symbol is IMethodSymbol method &&
+            GetOutermostTypeSyntax(candidate.TypeSyntax).Parent is MethodDeclarationSyntax or LocalFunctionStatementSyntax)
+        {
+            return await AnalyzeMethodReturnUsagesAsync(method, derived, baseType, cancellationToken);
+        }
+
+        var references = await SymbolFinder.FindReferencesAsync(symbol, Context.Solution, cancellationToken);
+        foreach (var referenced in references)
+        {
+            foreach (var location in referenced.Locations)
+            {
+                if (location.IsImplicit || !location.Location.IsInSource)
+                    continue;
+
+                var document = location.Document;
+                var root = await document.GetSyntaxRootAsync(cancellationToken);
+                var model = await document.GetSemanticModelAsync(cancellationToken);
+                if (root == null || model == null)
+                    continue;
+
+                var node = root.FindNode(location.Location.SourceSpan, getInnermostNodeForTie: true);
+                if (!UsageCompatible(node, derived, baseType, model))
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private async Task<bool> AnalyzeMethodReturnUsagesAsync(
+        IMethodSymbol method,
+        INamedTypeSymbol derived,
+        INamedTypeSymbol baseType,
+        CancellationToken cancellationToken)
+    {
+        var references = await SymbolFinder.FindReferencesAsync(method, Context.Solution, cancellationToken);
+        foreach (var referenced in references)
+        {
+            foreach (var location in referenced.Locations)
+            {
+                if (location.IsImplicit || !location.Location.IsInSource)
+                    continue;
+
+                var document = location.Document;
+                var root = await document.GetSyntaxRootAsync(cancellationToken);
+                var model = await document.GetSemanticModelAsync(cancellationToken);
+                if (root == null || model == null)
+                    continue;
+
+                var node = root.FindNode(location.Location.SourceSpan, getInnermostNodeForTie: true);
+                var invocation = node.FirstAncestorOrSelf<InvocationExpressionSyntax>();
+                if (invocation == null)
+                    continue;
+
+                if (!UsageCompatible(invocation, derived, baseType, model))
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    internal static bool UsageCompatible(
+        SyntaxNode node,
+        INamedTypeSymbol derived,
+        INamedTypeSymbol baseType,
+        SemanticModel model)
+    {
+        var expression = node as ExpressionSyntax ?? node.FirstAncestorOrSelf<ExpressionSyntax>();
+        if (expression == null)
+            return true;
+
+        if (expression.Parent is MemberAccessExpressionSyntax memberAccess &&
+            memberAccess.Expression == expression)
+        {
+            var member = model.GetSymbolInfo(memberAccess).Symbol ?? model.GetSymbolInfo(memberAccess.Name).Symbol;
+            return member != null && IsAvailableOn(member, baseType);
+        }
+
+        if (expression.Parent is ConditionalAccessExpressionSyntax conditional &&
+            conditional.Expression == expression)
+        {
+            var member = conditional.WhenNotNull switch
+            {
+                MemberBindingExpressionSyntax binding => model.GetSymbolInfo(binding).Symbol,
+                ElementBindingExpressionSyntax element => model.GetSymbolInfo(element).Symbol,
+                _ => model.GetSymbolInfo(conditional.WhenNotNull).Symbol
+            };
+            return member != null && IsAvailableOn(member, baseType);
+        }
+
+        if (expression.Parent is ElementAccessExpressionSyntax elementAccess &&
+            elementAccess.Expression == expression)
+        {
+            var member = model.GetSymbolInfo(elementAccess).Symbol;
+            return member != null && IsAvailableOn(member, baseType);
+        }
+
+        if (expression.Parent is VariableDeclaratorSyntax or ParameterSyntax or PropertyDeclarationSyntax)
+            return true;
+
+        if (expression.Parent is ExpressionStatementSyntax)
+            return true;
+
+        if (IsNullComparison(expression) || IsNameOfArgument(expression))
+            return true;
+
+        if (expression.Parent is EqualsValueClauseSyntax equals &&
+            equals.Parent is VariableDeclaratorSyntax declarator &&
+            declarator.Parent is VariableDeclarationSyntax declaration &&
+            declaration.Type.IsVar)
+        {
+            return VarUsagesCompatible(declarator, derived, baseType, model);
+        }
+
+        var typeInfo = model.GetTypeInfo(expression);
+        if (typeInfo.ConvertedType == null)
+            return true;
+
+        if (SymbolEqualityComparer.Default.Equals(typeInfo.Type, typeInfo.ConvertedType) &&
+            IsSameOrConstructed(typeInfo.ConvertedType, derived))
+        {
+            return false;
+        }
+
+        var conversion = model.Compilation.ClassifyConversion(baseType, typeInfo.ConvertedType);
+        return conversion.IsImplicit;
+    }
+
+    private static bool VarUsagesCompatible(
+        VariableDeclaratorSyntax declarator,
+        INamedTypeSymbol derived,
+        INamedTypeSymbol baseType,
+        SemanticModel model)
+    {
+        var local = model.GetDeclaredSymbol(declarator);
+        if (local == null)
+            return false;
+
+        var root = declarator.SyntaxTree.GetRoot();
+        foreach (var identifier in root.DescendantNodes().OfType<IdentifierNameSyntax>())
+        {
+            if (identifier.Span == declarator.Identifier.Span)
+                continue;
+
+            var symbol = model.GetSymbolInfo(identifier).Symbol;
+            if (symbol == null || !SymbolEqualityComparer.Default.Equals(symbol, local))
+                continue;
+
+            if (!UsageCompatible(identifier, derived, baseType, model))
+                return false;
+        }
+
+        return true;
+    }
+
+    private static bool IsNullComparison(ExpressionSyntax expression)
+    {
+        if (expression.Parent is BinaryExpressionSyntax binary &&
+            (binary.IsKind(SyntaxKind.EqualsExpression) || binary.IsKind(SyntaxKind.NotEqualsExpression)))
+        {
+            var other = binary.Left == expression ? binary.Right : binary.Left;
+            return other.IsKind(SyntaxKind.NullLiteralExpression);
+        }
+
+        if (expression.Parent is IsPatternExpressionSyntax pattern && pattern.Expression == expression)
+            return IsNullPattern(pattern.Pattern);
+
+        return false;
+    }
+
+    private static bool IsNullPattern(PatternSyntax pattern)
+    {
+        if (pattern is ConstantPatternSyntax constant &&
+            constant.Expression.IsKind(SyntaxKind.NullLiteralExpression))
+        {
+            return true;
+        }
+
+        return pattern is UnaryPatternSyntax unary && IsNullPattern(unary.Pattern);
+    }
+
+    private static bool IsNameOfArgument(ExpressionSyntax expression)
+    {
+        return expression.Parent is ArgumentSyntax argument &&
+               argument.Parent?.Parent is InvocationExpressionSyntax invocation &&
+               invocation.Expression is IdentifierNameSyntax name &&
+               name.Identifier.Text == "nameof";
+    }
+
+    internal static bool IsAvailableOn(ISymbol member, INamedTypeSymbol baseType)
+    {
+        if (member is IMethodSymbol { MethodKind: MethodKind.ReducedExtension })
+            return false;
+
+        var container = member.ContainingType;
+        if (container == null)
+            return false;
+
+        if (container.SpecialType == SpecialType.System_Object)
+            return true;
+
+        if (SymbolEqualityComparer.Default.Equals(container, baseType) ||
+            SymbolEqualityComparer.Default.Equals(container.OriginalDefinition, baseType.OriginalDefinition))
+        {
+            return true;
+        }
+
+        if (baseType.AllInterfaces.Any(iface =>
+                SymbolEqualityComparer.Default.Equals(iface, container) ||
+                SymbolEqualityComparer.Default.Equals(iface.OriginalDefinition, container.OriginalDefinition)))
+        {
+            return true;
+        }
+
+        for (var current = baseType.BaseType; current != null; current = current.BaseType)
+        {
+            if (SymbolEqualityComparer.Default.Equals(current, container) ||
+                SymbolEqualityComparer.Default.Equals(current.OriginalDefinition, container.OriginalDefinition))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsSameOrConstructed(ITypeSymbol type, INamedTypeSymbol derived)
+    {
+        return SymbolEqualityComparer.Default.Equals(type, derived) ||
+               SymbolEqualityComparer.Default.Equals(type.OriginalDefinition, derived.OriginalDefinition);
+    }
+
+    private static bool IsSameOrDerived(ITypeSymbol usage, ITypeSymbol baseType)
+    {
+        if (SymbolEqualityComparer.Default.Equals(usage, baseType))
+            return true;
+
+        if (usage is not INamedTypeSymbol named)
+            return false;
+
+        for (var current = named.BaseType; current != null; current = current.BaseType)
+        {
+            if (SymbolEqualityComparer.Default.Equals(current, baseType))
+                return true;
+        }
+
+        return named.AllInterfaces.Any(iface => SymbolEqualityComparer.Default.Equals(iface, baseType));
+    }
+
+    internal static TypeSyntax CreateBaseTypeReference(INamedTypeSymbol baseType, TypeSyntax original)
+    {
+        if (original is GenericNameSyntax generic)
+        {
+            return SyntaxFactory.GenericName(
+                    SyntaxFactory.Identifier(
+                        generic.Identifier.LeadingTrivia,
+                        baseType.Name,
+                        generic.Identifier.TrailingTrivia),
+                    generic.TypeArgumentList)
+                .WithLeadingTrivia(original.GetLeadingTrivia())
+                .WithTrailingTrivia(original.GetTrailingTrivia());
+        }
+
+        var display = original is QualifiedNameSyntax or AliasQualifiedNameSyntax
+            ? baseType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat
+                .WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted))
+            : baseType.Name;
+
+        return SyntaxFactory.ParseTypeName(display)
+            .WithLeadingTrivia(original.GetLeadingTrivia())
+            .WithTrailingTrivia(original.GetTrailingTrivia());
+    }
+
+    private static async Task<Solution> ApplyRewritesAsync(
+        IReadOnlyList<RewritableReference> rewrites,
+        CancellationToken cancellationToken)
+    {
+        var solution = rewrites[0].Document.Project.Solution;
+
+        foreach (var group in rewrites.GroupBy(rewrite => rewrite.Document.Id))
+        {
+            var document = solution.GetDocument(group.Key);
+            if (document == null)
+                throw new RefactoringException(ErrorCodes.RoslynError, "Could not locate document to update.");
+
+            ValidateDocumentIsEditable(document, document.Project.Solution.Workspace);
+
+            var root = await document.GetSyntaxRootAsync(cancellationToken);
+            if (root == null)
+                throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse file.");
+
+            var map = new Dictionary<SyntaxNode, SyntaxNode>();
+            foreach (var rewrite in group)
+            {
+                var current = root.FindNode(rewrite.Original.Span, getInnermostNodeForTie: true);
+                var type = GetReplaceableTypeSyntax(current) ?? rewrite.Original;
+                map[type] = rewrite.Replacement.WithTriviaFrom(type);
+            }
+
+            var newRoot = root.ReplaceNodes(map.Keys, (original, _) => map[original]);
+            if (newRoot is CompilationUnitSyntax unit)
+                newRoot = EnsureUsing(unit, group.First().BaseType);
+
+            solution = document.WithSyntaxRoot(newRoot).Project.Solution;
+        }
+
+        return solution;
+    }
+
+    private static CompilationUnitSyntax EnsureUsing(CompilationUnitSyntax root, INamedTypeSymbol baseType)
+    {
+        var namespaceName = baseType.ContainingNamespace?.ToDisplayString();
+        if (string.IsNullOrWhiteSpace(namespaceName) || baseType.ContainingNamespace!.IsGlobalNamespace)
+            return root;
+
+        if (root.Usings.Any(directive => directive.Name?.ToString() == namespaceName))
+            return root;
+
+        var fileScoped = root.Members.OfType<FileScopedNamespaceDeclarationSyntax>().FirstOrDefault();
+        if (fileScoped?.Name.ToString() == namespaceName)
+            return root;
+
+        var blockScoped = root.Members.OfType<NamespaceDeclarationSyntax>().FirstOrDefault();
+        if (blockScoped?.Name.ToString() == namespaceName)
+            return root;
+
+        var usingDirective = SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(namespaceName))
+            .WithTrailingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed);
+        return root.AddUsings(usingDirective);
+    }
+
+    private static RefactoringResult CreatePreviewResult(
+        Guid operationId,
+        IReadOnlyList<RewritableReference> rewrites,
+        INamedTypeSymbol derived,
+        INamedTypeSymbol baseType)
+    {
+        var pendingChanges = rewrites
+            .GroupBy(rewrite => rewrite.Document.FilePath ?? rewrite.Document.Name)
+            .Select(group => new PendingChange
+            {
+                File = group.Key,
+                ChangeType = ChangeKind.Modify,
+                Description = $"Replace {derived.Name} with {baseType.Name} in {group.Count()} type reference(s)",
+                BeforeSnippet = string.Join(", ", group.Select(item => item.Original.ToString()).Distinct()),
+                AfterSnippet = string.Join(", ", group.Select(item => item.Replacement.ToString()).Distinct())
+            })
+            .ToList();
+
+        return RefactoringResult.PreviewResult(operationId, pendingChanges);
+    }
+
+    private sealed record TypeReference(Document Document, TypeSyntax TypeSyntax, SemanticModel SemanticModel);
+
+    private sealed record RewritableReference(
+        Document Document,
+        TypeSyntax Original,
+        TypeSyntax Replacement,
+        INamedTypeSymbol BaseType);
+}

--- a/src/RoslynMcp.Core/Refactoring/Hierarchy/UseBaseTypeOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Hierarchy/UseBaseTypeOperation.cs
@@ -479,12 +479,11 @@ public sealed class UseBaseTypeOperation : RefactoringOperationBase<UseBaseTypeP
         return outermost.Parent switch
         {
             VariableDeclarationSyntax or ParameterSyntax =>
-                outermost.FirstAncestorOrSelf<MethodDeclarationSyntax>() as SyntaxNode
-                ?? outermost.FirstAncestorOrSelf<LocalFunctionStatementSyntax>()
-                ?? outermost.FirstAncestorOrSelf<AccessorDeclarationSyntax>()
-                ?? outermost.FirstAncestorOrSelf<ConstructorDeclarationSyntax>(),
-            PropertyDeclarationSyntax or EventDeclarationSyntax or FieldDeclarationSyntax =>
-                outermost.FirstAncestorOrSelf<TypeDeclarationSyntax>(),
+                outermost.AncestorsAndSelf().FirstOrDefault(node =>
+                    node is MethodDeclarationSyntax
+                        or LocalFunctionStatementSyntax
+                        or AccessorDeclarationSyntax
+                        or ConstructorDeclarationSyntax),
             _ => outermost.FirstAncestorOrSelf<TypeDeclarationSyntax>()
         };
     }

--- a/src/RoslynMcp.Core/Refactoring/Hierarchy/UseBaseTypeOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Hierarchy/UseBaseTypeOperation.cs
@@ -210,7 +210,10 @@ public sealed class UseBaseTypeOperation : RefactoringOperationBase<UseBaseTypeP
         if (string.IsNullOrWhiteSpace(targetTypeName))
         {
             var meaningful = classBases
-                .Where(candidate => candidate.SpecialType != SpecialType.System_Object)
+                .Where(candidate =>
+                    candidate.SpecialType != SpecialType.System_Object &&
+                    candidate.SpecialType != SpecialType.System_ValueType &&
+                    candidate.SpecialType != SpecialType.System_Enum)
                 .ToList();
             if (meaningful.Count > 0)
                 return meaningful[0];
@@ -735,6 +738,9 @@ public sealed class UseBaseTypeOperation : RefactoringOperationBase<UseBaseTypeP
         if (expression.Parent is ExpressionStatementSyntax)
             return true;
 
+        if (IsTargetTypedNewAssignment(expression))
+            return false;
+
         if (IsNullComparison(expression) || IsNameOfArgument(expression))
             return true;
 
@@ -785,6 +791,13 @@ public sealed class UseBaseTypeOperation : RefactoringOperationBase<UseBaseTypeP
         }
 
         return true;
+    }
+
+    private static bool IsTargetTypedNewAssignment(ExpressionSyntax expression)
+    {
+        return expression.Parent is AssignmentExpressionSyntax assignment &&
+               assignment.Left == expression &&
+               assignment.Right is ImplicitObjectCreationExpressionSyntax;
     }
 
     private static bool IsNullComparison(ExpressionSyntax expression)

--- a/src/RoslynMcp.Core/Refactoring/Hierarchy/UseBaseTypeOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Hierarchy/UseBaseTypeOperation.cs
@@ -336,8 +336,8 @@ public sealed class UseBaseTypeOperation : RefactoringOperationBase<UseBaseTypeP
     private static TypeSyntax GetOutermostTypeSyntax(TypeSyntax type)
     {
         var current = type;
-        while (current.Parent is NullableTypeSyntax or RefTypeSyntax parent)
-            current = parent;
+        while (current.Parent is NullableTypeSyntax or RefTypeSyntax)
+            current = (TypeSyntax)current.Parent;
         return current;
     }
 
@@ -702,7 +702,53 @@ public sealed class UseBaseTypeOperation : RefactoringOperationBase<UseBaseTypeP
         if (member is IMethodSymbol { MethodKind: MethodKind.ReducedExtension })
             return false;
 
-        var container = member.ContainingType;
+        if (IsDeclaredOnHierarchy(member.ContainingType, baseType))
+            return true;
+
+        switch (member)
+        {
+            case IMethodSymbol method:
+                if (method.OverriddenMethod != null && IsAvailableOn(method.OverriddenMethod, baseType))
+                    return true;
+
+                foreach (var implemented in method.ExplicitInterfaceImplementations)
+                {
+                    if (IsAvailableOn(implemented, baseType))
+                        return true;
+                }
+
+                return ImplementsBaseInterfaceMember(method, baseType);
+
+            case IPropertySymbol property:
+                if (property.OverriddenProperty != null && IsAvailableOn(property.OverriddenProperty, baseType))
+                    return true;
+
+                foreach (var implemented in property.ExplicitInterfaceImplementations)
+                {
+                    if (IsAvailableOn(implemented, baseType))
+                        return true;
+                }
+
+                return ImplementsBaseInterfaceMember(property, baseType);
+
+            case IEventSymbol @event:
+                if (@event.OverriddenEvent != null && IsAvailableOn(@event.OverriddenEvent, baseType))
+                    return true;
+
+                foreach (var implemented in @event.ExplicitInterfaceImplementations)
+                {
+                    if (IsAvailableOn(implemented, baseType))
+                        return true;
+                }
+
+                return ImplementsBaseInterfaceMember(@event, baseType);
+        }
+
+        return false;
+    }
+
+    private static bool IsDeclaredOnHierarchy(INamedTypeSymbol? container, INamedTypeSymbol baseType)
+    {
         if (container == null)
             return false;
 
@@ -728,6 +774,31 @@ public sealed class UseBaseTypeOperation : RefactoringOperationBase<UseBaseTypeP
                 SymbolEqualityComparer.Default.Equals(current.OriginalDefinition, container.OriginalDefinition))
             {
                 return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ImplementsBaseInterfaceMember(ISymbol member, INamedTypeSymbol baseType)
+    {
+        var containing = member.ContainingType;
+        if (containing == null)
+            return false;
+
+        foreach (var iface in containing.AllInterfaces)
+        {
+            if (!IsDeclaredOnHierarchy(iface, baseType) &&
+                !SymbolEqualityComparer.Default.Equals(iface, baseType))
+            {
+                continue;
+            }
+
+            foreach (var ifaceMember in iface.GetMembers(member.Name))
+            {
+                var implementation = containing.FindImplementationForInterfaceMember(ifaceMember);
+                if (implementation != null && SymbolEqualityComparer.Default.Equals(implementation, member))
+                    return true;
             }
         }
 

--- a/src/RoslynMcp.Core/Refactoring/Hierarchy/UseBaseTypeOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Hierarchy/UseBaseTypeOperation.cs
@@ -410,11 +410,11 @@ public sealed class UseBaseTypeOperation : RefactoringOperationBase<UseBaseTypeP
         if (!CanUseBaseType(derived, baseType))
             return false;
 
-        if (HasTargetTypedNew(candidate.TypeSyntax, candidate.SemanticModel, derived))
-            return false;
-
         var declared = GetDeclaredSymbols(candidate.TypeSyntax, candidate.SemanticModel, cancellationToken);
         if (declared.Count == 0)
+            return false;
+
+        if (HasTargetTypedNew(candidate.TypeSyntax, declared, candidate.SemanticModel, derived))
             return false;
 
         foreach (var symbol in declared)
@@ -431,6 +431,7 @@ public sealed class UseBaseTypeOperation : RefactoringOperationBase<UseBaseTypeP
 
     private static bool HasTargetTypedNew(
         TypeSyntax annotation,
+        IReadOnlyList<ISymbol> declared,
         SemanticModel model,
         INamedTypeSymbol derived)
     {
@@ -442,7 +443,50 @@ public sealed class UseBaseTypeOperation : RefactoringOperationBase<UseBaseTypeP
                 return true;
         }
 
+        return HasTargetTypedNewAssignment(annotation, declared, model, derived);
+    }
+
+    private static bool HasTargetTypedNewAssignment(
+        TypeSyntax annotation,
+        IReadOnlyList<ISymbol> declared,
+        SemanticModel model,
+        INamedTypeSymbol derived)
+    {
+        var scope = GetAssignmentSearchScope(annotation);
+        if (scope == null)
+            return false;
+
+        foreach (var assignment in scope.DescendantNodes().OfType<AssignmentExpressionSyntax>())
+        {
+            if (assignment.Right is not ImplicitObjectCreationExpressionSyntax)
+                continue;
+
+            var left = model.GetSymbolInfo(assignment.Left).Symbol;
+            if (left == null || declared.All(symbol => !SymbolEqualityComparer.Default.Equals(symbol, left)))
+                continue;
+
+            var converted = model.GetTypeInfo(assignment.Right).ConvertedType;
+            if (converted != null && IsSameOrConstructed(converted, derived))
+                return true;
+        }
+
         return false;
+    }
+
+    private static SyntaxNode? GetAssignmentSearchScope(TypeSyntax annotation)
+    {
+        var outermost = GetOutermostTypeSyntax(annotation);
+        return outermost.Parent switch
+        {
+            VariableDeclarationSyntax or ParameterSyntax =>
+                outermost.FirstAncestorOrSelf<MethodDeclarationSyntax>() as SyntaxNode
+                ?? outermost.FirstAncestorOrSelf<LocalFunctionStatementSyntax>()
+                ?? outermost.FirstAncestorOrSelf<AccessorDeclarationSyntax>()
+                ?? outermost.FirstAncestorOrSelf<ConstructorDeclarationSyntax>(),
+            PropertyDeclarationSyntax or EventDeclarationSyntax or FieldDeclarationSyntax =>
+                outermost.FirstAncestorOrSelf<TypeDeclarationSyntax>(),
+            _ => outermost.FirstAncestorOrSelf<TypeDeclarationSyntax>()
+        };
     }
 
     private static IEnumerable<ImplicitObjectCreationExpressionSyntax> EnumerateInferredCreations(SyntaxNode? parent)

--- a/src/RoslynMcp.Server/McpServerHost.cs
+++ b/src/RoslynMcp.Server/McpServerHost.cs
@@ -51,6 +51,7 @@ public sealed class McpServerHost : IAsyncDisposable
         _toolRegistry.Register(new ExtractBaseClassTool(workspaceProvider));
         _toolRegistry.Register(new PullMembersUpTool(workspaceProvider));
         _toolRegistry.Register(new PushMembersDownTool(workspaceProvider));
+        _toolRegistry.Register(new UseBaseTypeTool(workspaceProvider));
 
         // Code Navigation / Query Tools
         _toolRegistry.Register(new FindReferencesTool(workspaceProvider));

--- a/src/RoslynMcp.Server/RoslynMcp.Server.csproj
+++ b/src/RoslynMcp.Server/RoslynMcp.Server.csproj
@@ -18,7 +18,7 @@
     <Version>0.4.0</Version>
     <Authors>Joshua Ramirez</Authors>
     <Company>RedJay</Company>
-    <Description>MCP Server for Roslyn-powered C# refactoring operations. Install as a global tool to use with Claude Code, Claude Desktop, or other MCP clients. Provides 44 tools: 22 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 7 code conversion tools.</Description>
+    <Description>MCP Server for Roslyn-powered C# refactoring operations. Install as a global tool to use with Claude Code, Claude Desktop, or other MCP clients. Provides 45 tools: 23 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 7 code conversion tools.</Description>
     <PackageTags>roslyn;mcp;refactoring;csharp;model-context-protocol;code-analysis;dotnet;ai-tools;claude</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/JoshuaRamirez/RoslynMcpServer</RepositoryUrl>

--- a/src/RoslynMcp.Server/Tools/UseBaseTypeTool.cs
+++ b/src/RoslynMcp.Server/Tools/UseBaseTypeTool.cs
@@ -1,0 +1,133 @@
+using System.Text.Json;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.Refactoring;
+using RoslynMcp.Core.Refactoring.Hierarchy;
+using RoslynMcp.Core.Workspace;
+using RoslynMcp.Server.Transport;
+
+namespace RoslynMcp.Server.Tools;
+
+/// <summary>
+/// MCP tool handler for use_base_type operation.
+/// </summary>
+public sealed class UseBaseTypeTool : IToolHandler
+{
+    private readonly IWorkspaceProvider _workspaceProvider;
+    private readonly JsonSerializerOptions _jsonOptions;
+
+    /// <summary>
+    /// Creates a new use base type tool.
+    /// </summary>
+    public UseBaseTypeTool(IWorkspaceProvider workspaceProvider)
+    {
+        _workspaceProvider = workspaceProvider;
+        _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = false
+        };
+    }
+
+    /// <inheritdoc />
+    public string Name => "use_base_type";
+
+    /// <inheritdoc />
+    public string Description => "Replace derived-type references with a compatible base type or interface.";
+
+    /// <inheritdoc />
+    public object InputSchema => new
+    {
+        type = "object",
+        required = new[] { "solutionPath", "sourceFile", "typeName" },
+        properties = new
+        {
+            solutionPath = new
+            {
+                type = "string",
+                description = "Absolute path to the .sln or .csproj file"
+            },
+            sourceFile = new
+            {
+                type = "string",
+                description = "Absolute path to the source file containing the derived type"
+            },
+            typeName = new
+            {
+                type = "string",
+                description = "Name of the derived class, struct, or interface"
+            },
+            targetBaseType = new
+            {
+                type = "string",
+                description = "Target base class or interface name. Uses the nearest base if omitted."
+            },
+            preview = new
+            {
+                type = "boolean",
+                description = "Return computed changes without applying",
+                @default = false
+            }
+        },
+        additionalProperties = false
+    };
+
+    /// <inheritdoc />
+    public async Task<ToolResult> ExecuteAsync(JsonElement? arguments, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (arguments == null)
+            {
+                return ToolResult.Error("Arguments required");
+            }
+
+            var args = JsonSerializer.Deserialize<UseBaseTypeArgs>(arguments.Value.GetRawText(), _jsonOptions);
+            if (args == null)
+            {
+                return ToolResult.Error("Failed to parse arguments");
+            }
+
+            using var context = await _workspaceProvider.CreateContextAsync(
+                args.SolutionPath,
+                cancellationToken);
+
+            var operation = new UseBaseTypeOperation(context);
+            var @params = new UseBaseTypeParams
+            {
+                SourceFile = args.SourceFile,
+                TypeName = args.TypeName,
+                TargetBaseType = args.TargetBaseType,
+                Preview = args.Preview ?? false
+            };
+
+            var result = await operation.ExecuteAsync(@params, cancellationToken);
+
+            var json = JsonSerializer.Serialize(result, _jsonOptions);
+            return result.Success ? ToolResult.Success(json) : ToolResult.Error(json);
+        }
+        catch (RefactoringException ex)
+        {
+            var error = ex.ToError();
+            var json = JsonSerializer.Serialize(new { success = false, error }, _jsonOptions);
+            return ToolResult.Error(json);
+        }
+        catch (Exception ex)
+        {
+            var json = JsonSerializer.Serialize(new
+            {
+                success = false,
+                error = new { code = "INTERNAL_ERROR", message = ex.Message }
+            }, _jsonOptions);
+            return ToolResult.Error(json);
+        }
+    }
+
+    private sealed class UseBaseTypeArgs
+    {
+        public string SolutionPath { get; init; } = "";
+        public string SourceFile { get; init; } = "";
+        public string TypeName { get; init; } = "";
+        public string? TargetBaseType { get; init; }
+        public bool? Preview { get; init; }
+    }
+}

--- a/tests/RoslynMcp.Cli.Tests/HelpGeneratorTests.cs
+++ b/tests/RoslynMcp.Cli.Tests/HelpGeneratorTests.cs
@@ -15,13 +15,14 @@ public class HelpGeneratorTests
     }
 
     [Fact]
-    public void GenerateGlobalHelp_Lists44Tools()
+    public void GenerateGlobalHelp_Lists45Tools()
     {
         var registry = ToolRegistry.BuildDefault();
         var help = HelpGenerator.GenerateGlobalHelp(registry);
-        Assert.Contains("Total: 44 tools", help);
+        Assert.Contains("Total: 45 tools", help);
         Assert.Contains("pull-members-up", help);
         Assert.Contains("push-members-down", help);
+        Assert.Contains("use-base-type", help);
     }
 
     [Fact]

--- a/tests/RoslynMcp.Cli.Tests/ToolRegistryTests.cs
+++ b/tests/RoslynMcp.Cli.Tests/ToolRegistryTests.cs
@@ -6,11 +6,11 @@ namespace RoslynMcp.Cli.Tests;
 public class ToolRegistryTests
 {
     [Fact]
-    public void BuildDefault_Registers44Tools()
+    public void BuildDefault_Registers45Tools()
     {
         var registry = ToolRegistry.BuildDefault();
         var tools = registry.GetAllTools();
-        Assert.Equal(44, tools.Count);
+        Assert.Equal(45, tools.Count);
     }
 
     [Fact]
@@ -86,6 +86,7 @@ public class ToolRegistryTests
     [InlineData("inline-method", "Refactoring")]
     [InlineData("pull-members-up", "Refactoring")]
     [InlineData("push-members-down", "Refactoring")]
+    [InlineData("use-base-type", "Refactoring")]
     [InlineData("find-references", "Query")]
     [InlineData("get-diagnostics", "Query")]
     [InlineData("diagnose", "Diagnostic")]
@@ -104,11 +105,11 @@ public class ToolRegistryTests
     }
 
     [Fact]
-    public void RefactoringToolCount_Is31()
+    public void RefactoringToolCount_Is32()
     {
         var registry = ToolRegistry.BuildDefault();
         var count = registry.GetAllTools().Count(t => t.Category == "Refactoring");
-        Assert.Equal(31, count);
+        Assert.Equal(32, count);
     }
 
     [Fact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Hierarchy/UseBaseTypeOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Hierarchy/UseBaseTypeOperationTests.cs
@@ -583,6 +583,220 @@ public class UseBaseTypeOperationTests
         Assert.Equal(ErrorCodes.BaseCannotSatisfyUsedMembers, ex.ErrorCode);
     }
 
+    [SkippableFact]
+    public async Task UseBaseType_QualifiedTypeName_SelectsMatchingNamespace()
+    {
+        const string source = """
+            namespace A
+            {
+                public class Animal
+                {
+                    public int Eat() => 1;
+                }
+
+                public class Dog : Animal
+                {
+                    public int Bark() => 2;
+                }
+
+                public static class Use
+                {
+                    public static int Feed(Dog dog) => dog.Eat();
+                }
+            }
+
+            namespace B
+            {
+                public class Animal
+                {
+                    public int Eat() => 1;
+                }
+
+                public class Dog : Animal
+                {
+                    public int Bark() => 2;
+                }
+
+                public static class Use
+                {
+                    public static int Feed(Dog dog) => dog.Eat();
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new UseBaseTypeOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new UseBaseTypeParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "B.Dog"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("namespace A", updated);
+        Assert.Contains("public static int Feed(Dog dog) => dog.Eat();", updated);
+        Assert.Contains("namespace B", updated);
+        Assert.Contains("public static int Feed(Animal dog) => dog.Eat();", updated);
+    }
+
+    [SkippableFact]
+    public async Task UseBaseType_TargetTypedNewReturn_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+                public int Eat() => 1;
+            }
+
+            public class Dog : Animal
+            {
+            }
+
+            public static class Use
+            {
+                public static Dog Create() => new();
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new UseBaseTypeOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new UseBaseTypeParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "Dog"
+            }));
+
+        Assert.Equal(ErrorCodes.BaseCannotSatisfyUsedMembers, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task UseBaseType_ConflictingSimpleName_QualifiesReplacement()
+    {
+        const string source = """
+            namespace Other
+            {
+                public class Animal
+                {
+                    public int Eat() => 1;
+                }
+            }
+
+            namespace TestApp
+            {
+                public class Animal
+                {
+                }
+
+                public class Dog : Other.Animal
+                {
+                }
+
+                public static class Use
+                {
+                    public static int Feed(Dog dog) => dog.Eat();
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new UseBaseTypeOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new UseBaseTypeParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "TestApp.Dog",
+            TargetBaseType = "Animal"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("Feed(Other.Animal dog)", updated);
+        Assert.DoesNotContain("Feed(Animal dog)", updated);
+    }
+
+    [SkippableFact]
+    public async Task UseBaseType_OverrideParameter_IsNotRewritten()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+                public int Eat() => 1;
+            }
+
+            public class Dog : Animal
+            {
+            }
+
+            public abstract class BaseHandler
+            {
+                public abstract int Feed(Dog dog);
+            }
+
+            public class Handler : BaseHandler
+            {
+                public override int Feed(Dog dog) => dog.Eat();
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new UseBaseTypeOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new UseBaseTypeParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "Dog"
+            }));
+
+        Assert.Equal(ErrorCodes.BaseCannotSatisfyUsedMembers, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task UseBaseType_GenericBaseMapping_UsesConstructedArguments()
+    {
+        const string source = """
+            using System.Collections.Generic;
+
+            namespace TestApp;
+
+            public class Base<T>
+            {
+                public T Value { get; set; } = default!;
+            }
+
+            public class Dog<T> : Base<List<T>>
+            {
+            }
+
+            public static class Use
+            {
+                public static int Count(Dog<int> dog) => dog.Value.Count;
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new UseBaseTypeOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new UseBaseTypeParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Dog"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("Count(Base<List<int>> dog)", updated);
+        Assert.DoesNotContain("Count(Base<int> dog)", updated);
+    }
+
     #endregion
 
     #region Helpers

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Hierarchy/UseBaseTypeOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Hierarchy/UseBaseTypeOperationTests.cs
@@ -797,6 +797,81 @@ public class UseBaseTypeOperationTests
         Assert.DoesNotContain("Count(Base<int> dog)", updated);
     }
 
+    [SkippableFact]
+    public async Task UseBaseType_TargetTypedNewAssignment_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+                public int Eat() => 1;
+            }
+
+            public class Dog : Animal
+            {
+            }
+
+            public static class Use
+            {
+                public static int Feed()
+                {
+                    Dog dog;
+                    dog = new();
+                    return dog.Eat();
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new UseBaseTypeOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new UseBaseTypeParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "Dog"
+            }));
+
+        Assert.Equal(ErrorCodes.BaseCannotSatisfyUsedMembers, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task UseBaseType_StructWithSingleInterface_UsesInterface()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public interface IAnimal
+            {
+                int Eat();
+            }
+
+            public struct Dog : IAnimal
+            {
+                public int Eat() => 1;
+            }
+
+            public static class Use
+            {
+                public static int Feed(Dog dog) => dog.Eat();
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new UseBaseTypeOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new UseBaseTypeParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Dog"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("Feed(IAnimal dog)", updated);
+    }
+
     #endregion
 
     #region Helpers

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Hierarchy/UseBaseTypeOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Hierarchy/UseBaseTypeOperationTests.cs
@@ -1,0 +1,675 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+using RoslynMcp.Contracts.Errors;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.Refactoring;
+using RoslynMcp.Core.Refactoring.Hierarchy;
+using RoslynMcp.Core.Workspace;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Refactoring.Hierarchy;
+
+/// <summary>
+/// Operation-level tests for <see cref="UseBaseTypeOperation"/>.
+/// </summary>
+public class UseBaseTypeOperationTests
+{
+    #region Input Validation
+
+    [Fact]
+    public void Validate_MissingSourceFile_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            UseBaseTypeOperation.Validate(new UseBaseTypeParams
+            {
+                SourceFile = "",
+                TypeName = "Dog"
+            }));
+
+        Assert.Equal(ErrorCodes.MissingRequiredParam, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_MissingTypeName_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            UseBaseTypeOperation.Validate(new UseBaseTypeParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                TypeName = ""
+            }));
+
+        Assert.Equal(ErrorCodes.MissingRequiredParam, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_RelativePath_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            UseBaseTypeOperation.Validate(new UseBaseTypeParams
+            {
+                SourceFile = "Types.cs",
+                TypeName = "Dog"
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidSourcePath, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_MissingFile_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            UseBaseTypeOperation.Validate(new UseBaseTypeParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                TypeName = "Dog"
+            }));
+
+        Assert.Equal(ErrorCodes.SourceFileNotFound, ex.ErrorCode);
+    }
+
+    #endregion
+
+    #region P0 Happy Path
+
+    [SkippableFact]
+    public async Task UseBaseType_ParameterUsingOnlyBaseMembers_RewritesToBase()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+                public int Eat()
+                {
+                    return 1;
+                }
+            }
+
+            public class Dog : Animal
+            {
+                public int Bark()
+                {
+                    return 2;
+                }
+            }
+
+            public static class Use
+            {
+                public static int Feed(Dog dog)
+                {
+                    return dog.Eat();
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new UseBaseTypeOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new UseBaseTypeParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Dog"
+        });
+
+        Assert.True(result.Success);
+        var updated = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Contains("Feed(Animal dog)", NormalizeNewlines(updated));
+        Assert.DoesNotContain("Feed(Dog dog)", NormalizeNewlines(updated));
+        Assert.Contains("class Dog : Animal", updated);
+    }
+
+    [SkippableFact]
+    public async Task UseBaseType_InterfaceBase_RewritesCompatibleParameter()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public interface IAnimal
+            {
+                int Eat();
+            }
+
+            public class Dog : IAnimal
+            {
+                public int Eat()
+                {
+                    return 1;
+                }
+
+                public int Bark()
+                {
+                    return 2;
+                }
+            }
+
+            public static class Use
+            {
+                public static int Feed(Dog dog)
+                {
+                    return dog.Eat();
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new UseBaseTypeOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new UseBaseTypeParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Dog",
+            TargetBaseType = "IAnimal"
+        });
+
+        Assert.True(result.Success);
+        var updated = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Contains("Feed(IAnimal dog)", NormalizeNewlines(updated));
+    }
+
+    [SkippableFact]
+    public async Task UseBaseType_MixedUsages_RewritesOnlyCompatibleReferences()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+                public int Eat()
+                {
+                    return 1;
+                }
+            }
+
+            public class Dog : Animal
+            {
+                public int Bark()
+                {
+                    return 2;
+                }
+            }
+
+            public static class Use
+            {
+                public static int Feed(Dog dog)
+                {
+                    return dog.Eat();
+                }
+
+                public static int Speak(Dog dog)
+                {
+                    return dog.Bark();
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new UseBaseTypeOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new UseBaseTypeParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Dog"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("Feed(Animal dog)", updated);
+        Assert.Contains("Speak(Dog dog)", updated);
+    }
+
+    [SkippableFact]
+    public async Task UseBaseType_ExplicitTarget_UsesNamedBase()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Creature
+            {
+                public int Live()
+                {
+                    return 1;
+                }
+            }
+
+            public class Animal : Creature
+            {
+                public int Eat()
+                {
+                    return 2;
+                }
+            }
+
+            public class Dog : Animal
+            {
+            }
+
+            public static class Use
+            {
+                public static int Keep(Dog dog)
+                {
+                    return dog.Live();
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new UseBaseTypeOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new UseBaseTypeParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Dog",
+            TargetBaseType = "Creature"
+        });
+
+        Assert.True(result.Success);
+        var updated = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Contains("Keep(Creature dog)", NormalizeNewlines(updated));
+    }
+
+    [SkippableFact]
+    public async Task UseBaseType_Preview_ReturnsChangesAndWritesNothing()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+                public int Eat()
+                {
+                    return 1;
+                }
+            }
+
+            public class Dog : Animal
+            {
+            }
+
+            public static class Use
+            {
+                public static int Feed(Dog dog)
+                {
+                    return dog.Eat();
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var original = await File.ReadAllTextAsync(workspace.SourcePath);
+        var operation = new UseBaseTypeOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new UseBaseTypeParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Dog",
+            Preview = true
+        });
+
+        Assert.True(result.Success);
+        Assert.True(result.Preview);
+        Assert.NotNull(result.PendingChanges);
+        Assert.NotEmpty(result.PendingChanges);
+        Assert.Contains(result.PendingChanges, change =>
+            change.AfterSnippet != null && change.AfterSnippet.Contains("Animal"));
+
+        var after = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Equal(original, after);
+    }
+
+    [SkippableFact]
+    public async Task UseBaseType_LocalVariable_RewritesDeclaration()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+                public int Eat()
+                {
+                    return 1;
+                }
+            }
+
+            public class Dog : Animal
+            {
+            }
+
+            public static class Use
+            {
+                public static int Feed()
+                {
+                    Dog dog = new Dog();
+                    return dog.Eat();
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new UseBaseTypeOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new UseBaseTypeParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Dog"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("Animal dog = new Dog();", updated);
+    }
+
+    #endregion
+
+    #region P0 Rejects
+
+    [SkippableFact]
+    public async Task UseBaseType_NoBase_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Dog
+            {
+                public int Bark()
+                {
+                    return 2;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new UseBaseTypeOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new UseBaseTypeParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "Dog"
+            }));
+
+        Assert.Equal(ErrorCodes.NoCommonBase, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task UseBaseType_MissingNamedBase_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+            }
+
+            public class Dog : Animal
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new UseBaseTypeOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new UseBaseTypeParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "Dog",
+                TargetBaseType = "Creature"
+            }));
+
+        Assert.Equal(ErrorCodes.BaseClassNotFound, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task UseBaseType_NoEligibleReferences_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+                public int Eat()
+                {
+                    return 1;
+                }
+            }
+
+            public class Dog : Animal
+            {
+            }
+
+            public static class Use
+            {
+                public static object Create()
+                {
+                    return new Dog();
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new UseBaseTypeOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new UseBaseTypeParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "Dog"
+            }));
+
+        Assert.Equal(ErrorCodes.NoEligibleReferences, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task UseBaseType_BaseCannotSatisfyUsedMembers_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+                public int Eat()
+                {
+                    return 1;
+                }
+            }
+
+            public class Dog : Animal
+            {
+                public int Bark()
+                {
+                    return 2;
+                }
+            }
+
+            public static class Use
+            {
+                public static int Speak(Dog dog)
+                {
+                    return dog.Bark();
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new UseBaseTypeOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new UseBaseTypeParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "Dog"
+            }));
+
+        Assert.Equal(ErrorCodes.BaseCannotSatisfyUsedMembers, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void UseBaseType_UneditableDocument_Throws()
+    {
+        var workspace = new AdhocWorkspace();
+        var project = workspace.AddProject("P", LanguageNames.CSharp);
+        var document = workspace.AddDocument(project.Id, "Generated.cs", SourceText.From("class C {}"));
+
+        var ex = Assert.Throws<RefactoringException>(() =>
+            UseBaseTypeOperation.ValidateDocumentIsEditable(document, workspace));
+
+        Assert.Equal(ErrorCodes.DocumentNotEditable, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task UseBaseType_TypeNotFound_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new UseBaseTypeOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new UseBaseTypeParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "Dog"
+            }));
+
+        Assert.Equal(ErrorCodes.TypeNotFound, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task UseBaseType_TargetTypedNew_IsNotRewritten()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Animal
+            {
+                public int Eat()
+                {
+                    return 1;
+                }
+            }
+
+            public class Dog : Animal
+            {
+            }
+
+            public static class Use
+            {
+                public static int Feed()
+                {
+                    Dog dog = new();
+                    return dog.Eat();
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new UseBaseTypeOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new UseBaseTypeParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "Dog"
+            }));
+
+        Assert.Equal(ErrorCodes.BaseCannotSatisfyUsedMembers, ex.ErrorCode);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static string AbsoluteTestPath() =>
+        OperatingSystem.IsWindows() ? @"C:\test\file.cs" : "/test/file.cs";
+
+    private static string NormalizeNewlines(string text) =>
+        text.Replace("\r\n", "\n");
+
+    private sealed class TempWorkspace : IAsyncDisposable
+    {
+        public required string DirectoryPath { get; init; }
+        public required string ProjectPath { get; init; }
+        public required string SourcePath { get; init; }
+        public required WorkspaceContext Context { get; init; }
+
+        public static async Task<TempWorkspace> CreateAsync(string source, string fileName = "Types.cs")
+        {
+            Skip.IfNot(ModuleInitializer.MsBuildAvailable, ModuleInitializer.MsBuildError ?? "MSBuild not available");
+
+            var directory = Path.Combine(Path.GetTempPath(), "RoslynMcpUseBaseType_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(directory);
+
+            var projectPath = Path.Combine(directory, "TestApp.csproj");
+            var sourcePath = Path.Combine(directory, fileName);
+
+            await File.WriteAllTextAsync(projectPath, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net9.0</TargetFramework>
+                    <Nullable>enable</Nullable>
+                  </PropertyGroup>
+                </Project>
+                """);
+            await File.WriteAllTextAsync(sourcePath, source);
+
+            try
+            {
+                var provider = new MSBuildWorkspaceProvider();
+                var context = await provider.CreateContextAsync(projectPath);
+                if (context.GetDocumentByPath(sourcePath) == null)
+                {
+                    context.Dispose();
+                    throw new InvalidOperationException($"Workspace loaded but did not include {sourcePath}.");
+                }
+
+                return new TempWorkspace
+                {
+                    DirectoryPath = directory,
+                    ProjectPath = projectPath,
+                    SourcePath = sourcePath,
+                    Context = context
+                };
+            }
+            catch (Exception ex) when (ex is not SkipException)
+            {
+                try
+                {
+                    Directory.Delete(directory, recursive: true);
+                }
+                catch
+                {
+                    // ignore cleanup failures
+                }
+
+                Skip.If(true, $"Workspace load failed: {ex.Message}");
+                throw;
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            Context.Dispose();
+            await Task.Run(() =>
+            {
+                try
+                {
+                    Directory.Delete(DirectoryPath, recursive: true);
+                }
+                catch
+                {
+                    // ignore locked temp files
+                }
+            });
+        }
+    }
+
+    #endregion
+}

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Hierarchy/UseBaseTypeOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Hierarchy/UseBaseTypeOperationTests.cs
@@ -814,11 +814,13 @@ public class UseBaseTypeOperationTests
 
             public static class Use
             {
+                public static Dog GetDog() => new Dog();
+
                 public static int Feed()
                 {
-                    Dog dog;
-                    dog = new();
-                    return dog.Eat();
+                    Dog x = GetDog();
+                    x = new();
+                    return x.Eat();
                 }
             }
             """;

--- a/tests/RoslynMcp.Server.Tests/Tools/UseBaseTypeToolTests.cs
+++ b/tests/RoslynMcp.Server.Tests/Tools/UseBaseTypeToolTests.cs
@@ -1,0 +1,132 @@
+using System.Text.Json;
+using RoslynMcp.Server.Tests.TestHelpers;
+using RoslynMcp.Server.Tools;
+using RoslynMcp.Server.Transport;
+using Xunit;
+
+namespace RoslynMcp.Server.Tests.Tools;
+
+/// <summary>
+/// Unit tests for UseBaseTypeTool.
+/// Tests tool definition and argument validation.
+/// </summary>
+public class UseBaseTypeToolTests
+{
+    private readonly UseBaseTypeTool _tool;
+
+    public UseBaseTypeToolTests()
+    {
+        _tool = new UseBaseTypeTool(new ThrowingWorkspaceProvider());
+    }
+
+    #region GetDefinition Tests
+
+    [Fact]
+    public void GetDefinition_ReturnsCorrectName()
+    {
+        Assert.Equal("use_base_type", _tool.Name);
+    }
+
+    [Fact]
+    public void GetDefinition_ReturnsNonEmptyDescription()
+    {
+        Assert.NotNull(_tool.Description);
+        Assert.NotEmpty(_tool.Description);
+    }
+
+    [Fact]
+    public void GetDefinition_ReturnsCorrectSchema()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.Equal("object", root.GetProperty("type").GetString());
+        Assert.True(root.TryGetProperty("properties", out _));
+        Assert.True(root.TryGetProperty("required", out _));
+    }
+
+    [Fact]
+    public void GetDefinition_HasRequiredFields()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var required = doc.RootElement.GetProperty("required");
+
+        var requiredFields = new List<string>();
+        foreach (var item in required.EnumerateArray())
+        {
+            requiredFields.Add(item.GetString()!);
+        }
+
+        Assert.Contains("solutionPath", requiredFields);
+        Assert.Contains("sourceFile", requiredFields);
+        Assert.Contains("typeName", requiredFields);
+    }
+
+    [Fact]
+    public void GetDefinition_HasProperties_ForAllParameters()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var properties = doc.RootElement.GetProperty("properties");
+
+        Assert.True(properties.TryGetProperty("solutionPath", out _));
+        Assert.True(properties.TryGetProperty("sourceFile", out _));
+        Assert.True(properties.TryGetProperty("typeName", out _));
+        Assert.True(properties.TryGetProperty("targetBaseType", out _));
+        Assert.True(properties.TryGetProperty("preview", out _));
+    }
+
+    #endregion
+
+    #region ExecuteAsync Argument Validation Tests
+
+    [Fact]
+    public async Task ExecuteAsync_NullArguments_ReturnsError()
+    {
+        var result = await _tool.ExecuteAsync(null);
+
+        Assert.True(result.IsError);
+        Assert.Contains("Arguments required", GetResultText(result));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EmptyArguments_ReturnsError()
+    {
+        var args = JsonDocument.Parse("{}").RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MissingRequiredField_ReturnsError()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "solutionPath": "C:/test/test.sln",
+                "sourceFile": "C:/test/Test.cs"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static string GetResultText(ToolResult result)
+    {
+        return result.Content.FirstOrDefault()?.Text ?? string.Empty;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds a bounded `use_base_type` / `UseBaseTypeOperation` tool that replaces derived-type references with a compatible base type or interface when every used member exists on that base.

This follows the shipped `pull_members_up` / `push_members_down` pattern: params in Contracts, operation under `Refactoring/Hierarchy`, MCP tool next to the other refactoring tools, and CLI registration in `ToolRegistry`.

Behavior:
- Find type-annotation references (parameters, locals, fields, properties, return types) to the selected derived type
- Rewrite only usages that can legally use the chosen base or interface
- Leave remaining references (object creation, inheritance, derived-only members) unchanged
- Optional `targetBaseType` selects a named base; nearest class base or single interface is used when omitted
- Preview mode returns pending changes without writing files
- Rejects missing bases, uneditable documents, no eligible references, and cases where the base cannot satisfy used members

Review follow-up (Codex + Copilot):
- Qualified `typeName` values resolve by namespace
- Target-typed `new()` is rejected on returns and on assignment LHS (`Dog x = GetDog(); x = new();`) via `HasTargetTypedNew` / `CanUseBaseTypeAsync`
- Replacement names use `ToMinimalDisplayString` or a fully qualified fallback
- Override/abstract/interface parameters keep inherited signatures
- Generic replacements use the constructed inheritance mapping
- `GetTargetBaseType` skips `System.Object` and `System.ValueType`, so a struct with one interface defaults to that interface

## Related Issues

Closes #36

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Test additions or updates

## Testing

- [x] Solution builds (0 warnings, including TreatWarningsAsErrors)
- [x] `dotnet format --verify-no-changes` passes
- [x] New tests added for happy path, preview, P0 rejects, and review cases
- [x] Feature tests pass locally: 24 operation + 8 tool + 44 CLI registry/help

**Test Configuration**:
- OS: Linux
- .NET Version: 9.0.317

## Checklist

- [x] Code follows the existing hierarchy operation pattern
- [x] XML documentation added for public APIs
- [x] README / changelog / tool counts updated (45 tools)
- [x] Dependabot PRs left alone
- [x] Out of scope left out: `introduce_field`, `make_static`, `make_non_static`, `safe_delete`, undo

## Additional Notes

Error codes reuse the shipped hierarchy set (`NO_COMMON_BASE` 3107, `BASE_CLASS_NOT_FOUND` 2010) and add `NO_ELIGIBLE_REFERENCES` (3113), `BASE_CANNOT_SATISFY_USED_MEMBERS` (3114), and `DOCUMENT_NOT_EDITABLE` (3115).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07a88433-83dd-4f27-a075-42462f54d9a5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07a88433-83dd-4f27-a075-42462f54d9a5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

