### PR TITLE
Add introduce_field refactoring

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "roslyn-mcp",
   "version": "0.4.1",
-  "description": "Roslyn-powered C# refactoring MCP server — 45 tools for code navigation, analysis, generation, and refactoring across entire .NET solutions",
+  "description": "Roslyn-powered C# refactoring MCP server — 46 tools for code navigation, analysis, generation, and refactoring across entire .NET solutions",
   "author": {
     "name": "Joshua Ramirez"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - `pull_members_up` — move selected members from a derived type onto an existing base class or interface, with preview mode and rejects for missing bases, interface-incompatible members, and name/signature conflicts
 - `push_members_down` — move selected members from a base type down onto derived types, with optional named targets, preview mode, and rejects for missing derived types, conflicts, interface-incompatible members, and uneditable targets
 - `use_base_type` — replace derived-type references with a compatible base type or interface, rewriting only usages whose members exist on that base, with preview mode and rejects for missing bases, uneditable documents, and no eligible references
+- `introduce_field` — turn a selected local variable or expression into a class field, optionally initializing it in a constructor, with preview mode and rejects for missing expressions, uneditable documents, and invalid target types
 
 ## [0.4.0] - 2026-02-23
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Let AI assistants like Claude safely refactor your C# codebase using the same Roslyn compiler platform that powers Visual Studio.
 
-Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that exposes **45 Roslyn-powered tools** to AI assistants and other MCP clients. It combines 23 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 7 code conversion tools -- giving your AI deep code intelligence, comprehensive refactoring, and modern C# syntax transformations with full solution-wide reference tracking and preview support.
+Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that exposes **46 Roslyn-powered tools** to AI assistants and other MCP clients. It combines 24 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 7 code conversion tools -- giving your AI deep code intelligence, comprehensive refactoring, and modern C# syntax transformations with full solution-wide reference tracking and preview support.
 
 ---
 
@@ -30,7 +30,7 @@ Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotoc
 
 ## Why RoslynMcpServer?
 
-- **45 tools** -- refactoring, navigation, analysis, generation, and conversion tools, the most comprehensive Roslyn MCP server available
+- **46 tools** -- refactoring, navigation, analysis, generation, and conversion tools, the most comprehensive Roslyn MCP server available
 - **Preview mode on every operation** -- see exactly what will change before applying
 - **Atomic file writes with rollback** -- if any file write fails, all changes are reverted
 - **Solution-wide reference updates** -- renames and moves propagate across your entire solution
@@ -102,7 +102,7 @@ Claude will use the `rename_symbol` tool to rename the class and update every re
 
 ## Standalone CLI
 
-All 45 tools are also available as a standalone CLI for use in scripts, CI/CD pipelines, and terminals without an AI assistant.
+All 46 tools are also available as a standalone CLI for use in scripts, CI/CD pipelines, and terminals without an AI assistant.
 
 ### Install
 
@@ -204,6 +204,7 @@ All tools accept a `solutionPath` parameter (absolute path to a `.sln`, `.slnx`,
 | `pull_members_up` | Move selected members from a derived type onto an existing base class or interface. | `sourceFile`, `typeName`, `members`, `targetBaseType`, `makeAbstract` |
 | `push_members_down` | Move selected members from a base type down onto derived types. | `sourceFile`, `typeName`, `members`, `targetDerivedTypes`, `leaveAbstract` |
 | `use_base_type` | Replace derived-type references with a compatible base type or interface. | `sourceFile`, `typeName`, `targetBaseType` |
+| `introduce_field` | Turn a selected local variable or expression into a class field, optionally initializing it in a constructor. | `sourceFile`, `startLine`, `startColumn`, `endLine`, `endColumn`, `fieldName`, `isReadonly`, `isStatic`, `initializeInConstructor`, `replaceAll` |
 
 ### Inline
 

--- a/src/RoslynMcp.Cli/ToolRegistry.cs
+++ b/src/RoslynMcp.Cli/ToolRegistry.cs
@@ -47,7 +47,7 @@ public sealed class ToolEntry
 }
 
 /// <summary>
-/// Maps tool names to execution delegates for all 45 Roslyn tools.
+/// Maps tool names to execution delegates for all 46 Roslyn tools.
 /// </summary>
 public sealed class ToolRegistry
 {
@@ -139,13 +139,13 @@ public sealed class ToolRegistry
         _tools.Values.OrderBy(t => t.Category).ThenBy(t => t.Name).ToList();
 
     /// <summary>
-    /// Build the default registry with all 45 tools registered.
+    /// Build the default registry with all 46 tools registered.
     /// </summary>
     public static ToolRegistry BuildDefault()
     {
         var r = new ToolRegistry();
 
-        // ── Refactoring: Extract (6) ──────────────────────────────────
+        // ── Refactoring: Extract (7) ──────────────────────────────────
         r.RegisterRefactoring<ExtractMethodOperation, ExtractMethodParams>(
             "extract-method", "Extract selected code into a new method");
         r.RegisterRefactoring<ExtractVariableOperation, ExtractVariableParams>(
@@ -164,6 +164,8 @@ public sealed class ToolRegistry
             "push-members-down", "Move selected members from a base type down onto derived types");
         r.RegisterRefactoring<UseBaseTypeOperation, UseBaseTypeParams>(
             "use-base-type", "Replace derived-type references with a compatible base type or interface");
+        r.RegisterRefactoring<IntroduceFieldOperation, IntroduceFieldParams>(
+            "introduce-field", "Turn a selected local variable or expression into a class field");
 
         // ── Refactoring: Rename (1) ───────────────────────────────────
         r.RegisterRefactoring<RenameSymbolOperation, RenameSymbolParams>(

--- a/src/RoslynMcp.Contracts/Enums/RefactoringKind.cs
+++ b/src/RoslynMcp.Contracts/Enums/RefactoringKind.cs
@@ -41,6 +41,9 @@ public enum RefactoringKind
     /// <summary>Replace derived-type references with a compatible base type or interface.</summary>
     UseBaseType,
 
+    /// <summary>Promote a local variable or expression to a class field.</summary>
+    IntroduceField,
+
     /// <summary>Extract expression to variable.</summary>
     ExtractVariable,
 

--- a/src/RoslynMcp.Contracts/Errors/ErrorCodes.cs
+++ b/src/RoslynMcp.Contracts/Errors/ErrorCodes.cs
@@ -348,6 +348,19 @@ public static class ErrorCodes
     /// <summary>A document containing eligible references is not editable.</summary>
     public const string DocumentNotEditable = "3115";
 
+    // --------------------------------------------
+    // Introduce Field Errors (3116-3118)
+    // --------------------------------------------
+
+    /// <summary>Containing type cannot host the field, or the expression type is not a valid field type.</summary>
+    public const string InvalidTargetType = "3116";
+
+    /// <summary>Expression cannot be used as a field initializer.</summary>
+    public const string ExpressionNotFieldInitializable = "3117";
+
+    /// <summary>Expression captures local variable or parameter state.</summary>
+    public const string ExpressionCapturesLocal = "3118";
+
     // ============================================
     // System Errors (4xxx)
     // ============================================

--- a/src/RoslynMcp.Contracts/Models/IntroduceFieldParams.cs
+++ b/src/RoslynMcp.Contracts/Models/IntroduceFieldParams.cs
@@ -1,0 +1,62 @@
+namespace RoslynMcp.Contracts.Models;
+
+/// <summary>
+/// Parameters for the introduce_field tool.
+/// </summary>
+public sealed class IntroduceFieldParams
+{
+    /// <summary>
+    /// Absolute path to the source file.
+    /// </summary>
+    public required string SourceFile { get; init; }
+
+    /// <summary>
+    /// Start line of the local variable or expression (1-based).
+    /// </summary>
+    public required int StartLine { get; init; }
+
+    /// <summary>
+    /// Start column of the local variable or expression (1-based).
+    /// </summary>
+    public required int StartColumn { get; init; }
+
+    /// <summary>
+    /// End line of the local variable or expression (1-based).
+    /// </summary>
+    public required int EndLine { get; init; }
+
+    /// <summary>
+    /// End column of the local variable or expression (1-based).
+    /// </summary>
+    public required int EndColumn { get; init; }
+
+    /// <summary>
+    /// Name for the new field.
+    /// </summary>
+    public required string FieldName { get; init; }
+
+    /// <summary>
+    /// Create as a readonly field. Default: false.
+    /// </summary>
+    public bool IsReadonly { get; init; }
+
+    /// <summary>
+    /// Create as a static field. Default: false.
+    /// </summary>
+    public bool IsStatic { get; init; }
+
+    /// <summary>
+    /// Initialize the field in a constructor instead of inline. Default: false.
+    /// </summary>
+    public bool InitializeInConstructor { get; init; }
+
+    /// <summary>
+    /// Replace all identical expressions in the containing type. Default: false.
+    /// </summary>
+    public bool ReplaceAll { get; init; }
+
+    /// <summary>
+    /// Return computed changes without applying. Default: false.
+    /// </summary>
+    public bool Preview { get; init; }
+}

--- a/src/RoslynMcp.Core/Refactoring/Extract/IntroduceFieldOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/IntroduceFieldOperation.cs
@@ -1,0 +1,830 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+using RoslynMcp.Contracts.Enums;
+using RoslynMcp.Contracts.Errors;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.FileSystem;
+using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Workspace;
+
+namespace RoslynMcp.Core.Refactoring.Extract;
+
+/// <summary>
+/// Promotes a local variable or expression to a class field, optionally
+/// initializing the field in a constructor.
+/// </summary>
+public sealed class IntroduceFieldOperation : RefactoringOperationBase<IntroduceFieldParams>
+{
+    /// <summary>
+    /// Creates a new introduce-field operation.
+    /// </summary>
+    public IntroduceFieldOperation(WorkspaceContext context) : base(context)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override void ValidateParams(IntroduceFieldParams @params) => Validate(@params);
+
+    /// <summary>
+    /// Validates introduce-field parameters. Internal so tests can exercise
+    /// input rules without loading a workspace.
+    /// </summary>
+    internal static void Validate(IntroduceFieldParams @params)
+    {
+        if (string.IsNullOrWhiteSpace(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "sourceFile is required.");
+
+        if (string.IsNullOrWhiteSpace(@params.FieldName))
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "fieldName is required.");
+
+        if (!PathResolver.IsAbsolutePath(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.InvalidSourcePath, "sourceFile must be an absolute path.");
+
+        if (!PathResolver.IsValidCSharpFilePath(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.InvalidSourcePath, "sourceFile must be a .cs file.");
+
+        if (@params.StartLine < 1)
+            throw new RefactoringException(ErrorCodes.InvalidLineNumber, "startLine must be >= 1.");
+
+        if (@params.StartColumn < 1)
+            throw new RefactoringException(ErrorCodes.InvalidColumnNumber, "startColumn must be >= 1.");
+
+        if (@params.EndLine < 1)
+            throw new RefactoringException(ErrorCodes.InvalidLineNumber, "endLine must be >= 1.");
+
+        if (@params.EndColumn < 1)
+            throw new RefactoringException(ErrorCodes.InvalidColumnNumber, "endColumn must be >= 1.");
+
+        if (@params.EndLine < @params.StartLine ||
+            (@params.EndLine == @params.StartLine && @params.EndColumn < @params.StartColumn))
+            throw new RefactoringException(ErrorCodes.InvalidSelectionRange, "End must be after start.");
+
+        if (!IsValidIdentifier(@params.FieldName))
+            throw new RefactoringException(ErrorCodes.InvalidSymbolName, $"Invalid field name: {@params.FieldName}");
+
+        if (!File.Exists(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.SourceFileNotFound, $"Source file not found: {@params.SourceFile}");
+    }
+
+    /// <summary>
+    /// Rejects documents that cannot receive source edits.
+    /// </summary>
+    internal static void ValidateDocumentIsEditable(Document document, Microsoft.CodeAnalysis.Workspace workspace)
+    {
+        if (document is SourceGeneratedDocument)
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable (source-generated).");
+        }
+
+        if (string.IsNullOrWhiteSpace(document.FilePath) || !File.Exists(document.FilePath))
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable.");
+        }
+
+        if (!workspace.CanApplyChange(ApplyChangesKind.ChangeDocument))
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable (workspace cannot apply changes).");
+        }
+    }
+
+    /// <inheritdoc />
+    protected override async Task<RefactoringResult> ExecuteCoreAsync(
+        Guid operationId,
+        IntroduceFieldParams @params,
+        CancellationToken cancellationToken)
+    {
+        var document = GetDocumentOrThrow(@params.SourceFile);
+        ValidateDocumentIsEditable(document, Context.Workspace);
+
+        var root = await document.GetSyntaxRootAsync(cancellationToken);
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken);
+        if (root == null || semanticModel == null)
+            throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse file.");
+
+        var sourceText = await document.GetTextAsync(cancellationToken);
+        var span = GetSelectionSpan(sourceText, @params);
+        var node = root.FindNode(span);
+
+        var plan = BuildPlan(node, span, semanticModel, @params, cancellationToken);
+
+        if (@params.Preview)
+            return CreatePreviewResult(operationId, @params, plan);
+
+        var newRoot = ApplyPlan((CompilationUnitSyntax)root, plan, @params);
+        var newDocument = document.WithSyntaxRoot(newRoot);
+        var commitResult = await CommitChangesAsync(newDocument.Project.Solution, cancellationToken);
+
+        return RefactoringResult.Succeeded(
+            operationId,
+            new FileChanges
+            {
+                FilesModified = commitResult.FilesModified,
+                FilesCreated = commitResult.FilesCreated,
+                FilesDeleted = commitResult.FilesDeleted
+            },
+            new Contracts.Models.SymbolInfo
+            {
+                Name = @params.FieldName,
+                FullyQualifiedName = $"{plan.ContainingTypeName}.{@params.FieldName}",
+                Kind = Contracts.Enums.SymbolKind.Field
+            },
+            plan.ReplacementCount,
+            0);
+    }
+
+    private static TextSpan GetSelectionSpan(SourceText sourceText, IntroduceFieldParams @params)
+    {
+        if (@params.StartLine > sourceText.Lines.Count || @params.EndLine > sourceText.Lines.Count)
+            throw new RefactoringException(ErrorCodes.InvalidLineNumber, "Selection is outside the file.");
+
+        var startLine = sourceText.Lines[@params.StartLine - 1];
+        var endLine = sourceText.Lines[@params.EndLine - 1];
+        if (@params.StartColumn - 1 > startLine.Span.Length || @params.EndColumn - 1 > endLine.SpanIncludingLineBreak.Length)
+            throw new RefactoringException(ErrorCodes.InvalidColumnNumber, "Selection column is outside the line.");
+
+        var startPosition = startLine.Start + @params.StartColumn - 1;
+        var endPosition = endLine.Start + @params.EndColumn - 1;
+        if (endPosition < startPosition)
+            throw new RefactoringException(ErrorCodes.InvalidSelectionRange, "End must be after start.");
+
+        return TextSpan.FromBounds(startPosition, endPosition);
+    }
+
+    private static FieldPlan BuildPlan(
+        SyntaxNode node,
+        TextSpan span,
+        SemanticModel semanticModel,
+        IntroduceFieldParams @params,
+        CancellationToken cancellationToken)
+    {
+        var local = FindPromotableLocal(node, span, semanticModel, cancellationToken);
+        ExpressionSyntax? expression = null;
+        ExpressionSyntax? initializer;
+        ITypeSymbol fieldType;
+        IReadOnlyList<SyntaxNode> replacements;
+        LocalDeclarationStatementSyntax? declarationToRemove = null;
+        VariableDeclaratorSyntax? declaratorToRemove = null;
+
+        if (local != null)
+        {
+            var declarator = local.DeclaringSyntaxReferences
+                .Select(r => r.GetSyntax(cancellationToken))
+                .OfType<VariableDeclaratorSyntax>()
+                .FirstOrDefault(v => v.Parent?.Parent is LocalDeclarationStatementSyntax);
+
+            if (declarator == null)
+            {
+                throw new RefactoringException(
+                    ErrorCodes.ExpressionNotFieldInitializable,
+                    $"Local variable '{local.Name}' cannot be promoted to a field.");
+            }
+
+            var declaration = (LocalDeclarationStatementSyntax)declarator.Parent!.Parent!;
+            initializer = declarator.Initializer?.Value;
+            fieldType = local.Type;
+            ValidateFieldType(fieldType);
+
+            if (initializer != null)
+                ValidateExpressionCaptures(initializer, semanticModel, local, @params.IsStatic, cancellationToken);
+
+            var references = FindLocalReferences(declaration.SyntaxTree.GetRoot(), semanticModel, local, cancellationToken)
+                .Where(id => id.Span != declarator.Identifier.Span)
+                .Cast<SyntaxNode>()
+                .ToList();
+
+            replacements = references;
+            if (declaration.Declaration.Variables.Count == 1)
+                declarationToRemove = declaration;
+            else
+                declaratorToRemove = declarator;
+        }
+        else
+        {
+            expression = FindEnclosingExpression(node, span);
+            if (expression == null || IsTypeContext(expression))
+            {
+                throw new RefactoringException(
+                    ErrorCodes.ExpressionNotFound,
+                    "No valid expression found at the specified location.");
+            }
+
+            var typeInfo = semanticModel.GetTypeInfo(expression, cancellationToken);
+            fieldType = typeInfo.ConvertedType ?? typeInfo.Type
+                ?? throw new RefactoringException(ErrorCodes.RoslynError, "Could not determine expression type.");
+
+            ValidateFieldType(fieldType);
+            ValidateExpressionCaptures(expression, semanticModel, excludedLocal: null, @params.IsStatic, cancellationToken);
+
+            if (ContainsAwait(expression))
+            {
+                throw new RefactoringException(
+                    ErrorCodes.ExpressionNotFieldInitializable,
+                    "Expression cannot be used as a field initializer.");
+            }
+
+            if (expression is AssignmentExpressionSyntax)
+            {
+                throw new RefactoringException(
+                    ErrorCodes.ExpressionNotFieldInitializable,
+                    "Expression cannot be used as a field initializer.");
+            }
+
+            initializer = expression;
+            replacements = @params.ReplaceAll
+                ? FindMatchingExpressions(GetContainingTypeOrThrow(expression), expression)
+                : new List<SyntaxNode> { expression };
+        }
+
+        var containingType = GetContainingTypeOrThrow(local?.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax() ?? expression!);
+        ValidateContainingType(containingType, @params.IsStatic, semanticModel, cancellationToken);
+        ValidateNameAvailable(containingType, semanticModel, @params.FieldName, cancellationToken);
+        ValidateStaticUsage(local?.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax() ?? expression!, @params.IsStatic);
+
+        if (!@params.InitializeInConstructor && initializer != null)
+            ValidateInlineInitializer(initializer, semanticModel, @params.IsStatic, cancellationToken);
+
+        if (@params.InitializeInConstructor && initializer == null)
+        {
+            throw new RefactoringException(
+                ErrorCodes.ExpressionNotFieldInitializable,
+                "Cannot initialize in a constructor without an initializer expression.");
+        }
+
+        var field = CreateFieldDeclaration(@params, fieldType, @params.InitializeInConstructor ? null : initializer);
+
+        return new FieldPlan(
+            containingType.Identifier.Text,
+            fieldType.ToDisplayString(),
+            field,
+            replacements,
+            declarationToRemove,
+            declaratorToRemove,
+            initializer,
+            replacements.Count + (declarationToRemove != null || declaratorToRemove != null ? 1 : 0));
+    }
+
+    private static CompilationUnitSyntax ApplyPlan(
+        CompilationUnitSyntax root,
+        FieldPlan plan,
+        IntroduceFieldParams @params)
+    {
+        var replaceAnn = new SyntaxAnnotation("introduce-field-replace");
+        var removeDeclAnn = new SyntaxAnnotation("introduce-field-remove-decl");
+        var removeVarAnn = new SyntaxAnnotation("introduce-field-remove-var");
+        var typeAnn = new SyntaxAnnotation("introduce-field-type");
+
+        var annotateTargets = plan.Replacements
+            .Concat(plan.DeclarationToRemove != null ? new SyntaxNode[] { plan.DeclarationToRemove } : Array.Empty<SyntaxNode>())
+            .Concat(plan.DeclaratorToRemove != null ? new SyntaxNode[] { plan.DeclaratorToRemove } : Array.Empty<SyntaxNode>())
+            .Distinct()
+            .ToList();
+
+        var containingType = root.DescendantNodes()
+            .OfType<TypeDeclarationSyntax>()
+            .First(t => t.Identifier.Text == plan.ContainingTypeName);
+        annotateTargets.Add(containingType);
+
+        var annotated = root.ReplaceNodes(annotateTargets, (original, _) =>
+        {
+            var node = original;
+            if (plan.Replacements.Contains(original))
+                node = node.WithAdditionalAnnotations(replaceAnn);
+            if (plan.DeclarationToRemove == original)
+                node = node.WithAdditionalAnnotations(removeDeclAnn);
+            if (plan.DeclaratorToRemove == original)
+                node = node.WithAdditionalAnnotations(removeVarAnn);
+            if (original == containingType)
+                node = node.WithAdditionalAnnotations(typeAnn);
+            return node;
+        });
+
+        var fieldRef = SyntaxFactory.IdentifierName(@params.FieldName);
+        var replacements = annotated.GetAnnotatedNodes(replaceAnn).ToList();
+        SyntaxNode newRoot = replacements.Count == 0
+            ? annotated
+            : annotated.ReplaceNodes(replacements, (original, _) => fieldRef.WithTriviaFrom(original));
+
+        var declToRemove = newRoot.GetAnnotatedNodes(removeDeclAnn).FirstOrDefault();
+        if (declToRemove != null)
+        {
+            newRoot = newRoot.RemoveNode(declToRemove, SyntaxRemoveOptions.KeepNoTrivia)
+                ?? throw new RefactoringException(ErrorCodes.RoslynError, "Failed to remove local declaration.");
+        }
+
+        var varToRemove = newRoot.GetAnnotatedNodes(removeVarAnn).FirstOrDefault();
+        if (varToRemove != null)
+        {
+            var declaration = varToRemove.Parent as VariableDeclarationSyntax
+                ?? throw new RefactoringException(ErrorCodes.RoslynError, "Failed to update local declaration.");
+            var statement = declaration.Parent as LocalDeclarationStatementSyntax
+                ?? throw new RefactoringException(ErrorCodes.RoslynError, "Failed to update local declaration.");
+            var newDeclaration = declaration.RemoveNode(varToRemove, SyntaxRemoveOptions.KeepNoTrivia)!;
+            newRoot = newRoot.ReplaceNode(statement, statement.WithDeclaration(newDeclaration));
+        }
+
+        var updatedType = newRoot.GetAnnotatedNodes(typeAnn).OfType<TypeDeclarationSyntax>().First();
+        var typeWithField = InsertField(updatedType, plan.Field);
+        if (@params.InitializeInConstructor && plan.Initializer != null)
+            typeWithField = EnsureConstructorInitialization(typeWithField, @params, plan.Initializer);
+
+        return (CompilationUnitSyntax)newRoot.ReplaceNode(updatedType, typeWithField);
+    }
+
+    private static ILocalSymbol? FindPromotableLocal(
+        SyntaxNode node,
+        TextSpan span,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        var declarator = node.AncestorsAndSelf()
+            .OfType<VariableDeclaratorSyntax>()
+            .FirstOrDefault(v => v.Parent?.Parent is LocalDeclarationStatementSyntax && v.Span.Contains(span));
+        if (declarator != null)
+            return semanticModel.GetDeclaredSymbol(declarator, cancellationToken) as ILocalSymbol;
+
+        var localStatement = node.AncestorsAndSelf()
+            .OfType<LocalDeclarationStatementSyntax>()
+            .FirstOrDefault(s => s.Span.Contains(span) && s.Declaration.Variables.Count == 1);
+        if (localStatement != null)
+            return semanticModel.GetDeclaredSymbol(localStatement.Declaration.Variables[0], cancellationToken) as ILocalSymbol;
+
+        IdentifierNameSyntax? identifier = node as IdentifierNameSyntax
+            ?? node.DescendantNodesAndSelf()
+                .OfType<IdentifierNameSyntax>()
+                .FirstOrDefault(id => span.OverlapsWith(id.Span) || id.Span.Contains(span) || span.Contains(id.Span));
+
+        if (identifier == null)
+            return null;
+
+        if (semanticModel.GetSymbolInfo(identifier, cancellationToken).Symbol is ILocalSymbol local)
+        {
+            var syntax = local.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax(cancellationToken);
+            if (syntax is VariableDeclaratorSyntax v && v.Parent?.Parent is LocalDeclarationStatementSyntax)
+                return local;
+        }
+
+        return null;
+    }
+
+    private static IReadOnlyList<IdentifierNameSyntax> FindLocalReferences(
+        SyntaxNode root,
+        SemanticModel semanticModel,
+        ILocalSymbol local,
+        CancellationToken cancellationToken)
+    {
+        return root.DescendantNodes()
+            .OfType<IdentifierNameSyntax>()
+            .Where(id =>
+            {
+                var symbol = semanticModel.GetSymbolInfo(id, cancellationToken).Symbol;
+                return symbol != null && SymbolEqualityComparer.Default.Equals(symbol, local);
+            })
+            .ToList();
+    }
+
+    private static ExpressionSyntax? FindEnclosingExpression(SyntaxNode node, TextSpan span)
+    {
+        ExpressionSyntax? bestMatch = null;
+        var current = node;
+
+        while (current != null)
+        {
+            if (current is ExpressionSyntax expr && current.Span.Contains(span))
+            {
+                if (bestMatch == null || current.Span.Length <= bestMatch.Span.Length)
+                    bestMatch = expr;
+            }
+
+            current = current.Parent;
+        }
+
+        return bestMatch;
+    }
+
+    private static List<SyntaxNode> FindMatchingExpressions(TypeDeclarationSyntax containingType, ExpressionSyntax original)
+    {
+        var normalized = NormalizeExpression(original);
+        return containingType.DescendantNodes()
+            .OfType<ExpressionSyntax>()
+            .Where(expr => expr != original && NormalizeExpression(expr) == normalized)
+            .Cast<SyntaxNode>()
+            .Prepend(original)
+            .ToList();
+    }
+
+    private static string NormalizeExpression(ExpressionSyntax expression) =>
+        expression.NormalizeWhitespace().ToFullString().Trim();
+
+    private static TypeDeclarationSyntax GetContainingTypeOrThrow(SyntaxNode node)
+    {
+        var typeDecl = node.AncestorsAndSelf().OfType<TypeDeclarationSyntax>().FirstOrDefault();
+        if (typeDecl != null)
+            return typeDecl;
+
+        if (node.AncestorsAndSelf().OfType<BaseTypeDeclarationSyntax>().Any())
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidTargetType,
+                "Cannot introduce a field into this type.");
+        }
+
+        throw new RefactoringException(
+            ErrorCodes.TypeNotFound,
+            "Selection must be inside a type declaration.");
+    }
+
+    private static void ValidateContainingType(
+        TypeDeclarationSyntax containingType,
+        bool isStaticField,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        if (containingType is InterfaceDeclarationSyntax)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidTargetType,
+                "Cannot introduce a field into an interface.");
+        }
+
+        var symbol = semanticModel.GetDeclaredSymbol(containingType, cancellationToken) as INamedTypeSymbol;
+        if (symbol == null)
+            throw new RefactoringException(ErrorCodes.RoslynError, "Could not resolve containing type.");
+
+        if (symbol.TypeKind is TypeKind.Enum or TypeKind.Delegate or TypeKind.Interface)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidTargetType,
+                $"Cannot introduce a field into '{symbol.Name}'.");
+        }
+
+        if (symbol.IsStatic && !isStaticField)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidTargetType,
+                "Cannot introduce an instance field into a static type.");
+        }
+    }
+
+    private static void ValidateNameAvailable(
+        TypeDeclarationSyntax containingType,
+        SemanticModel semanticModel,
+        string fieldName,
+        CancellationToken cancellationToken)
+    {
+        var symbol = semanticModel.GetDeclaredSymbol(containingType, cancellationToken) as INamedTypeSymbol;
+        if (symbol?.GetMembers(fieldName).Any() == true)
+        {
+            throw new RefactoringException(
+                ErrorCodes.NameCollision,
+                $"Member '{fieldName}' already exists in type.");
+        }
+
+        var existingField = containingType.Members
+            .OfType<FieldDeclarationSyntax>()
+            .SelectMany(f => f.Declaration.Variables)
+            .FirstOrDefault(v => v.Identifier.Text == fieldName);
+
+        if (existingField != null)
+        {
+            throw new RefactoringException(
+                ErrorCodes.NameCollision,
+                $"Field '{fieldName}' already exists in type.");
+        }
+    }
+
+    private static void ValidateFieldType(ITypeSymbol fieldType)
+    {
+        if (fieldType.SpecialType == SpecialType.System_Void)
+        {
+            throw new RefactoringException(
+                ErrorCodes.ExpressionIsVoid,
+                "Cannot introduce a field from a void expression.");
+        }
+
+        if (fieldType.TypeKind == TypeKind.Error || fieldType.IsAnonymousType)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidTargetType,
+                "Expression type is not a valid field type.");
+        }
+    }
+
+    private static void ValidateExpressionCaptures(
+        ExpressionSyntax expression,
+        SemanticModel semanticModel,
+        ILocalSymbol? excludedLocal,
+        bool isStaticField,
+        CancellationToken cancellationToken)
+    {
+        foreach (var ident in expression.DescendantNodesAndSelf().OfType<IdentifierNameSyntax>())
+        {
+            var symbol = semanticModel.GetSymbolInfo(ident, cancellationToken).Symbol;
+            if (symbol == null)
+                continue;
+
+            if (symbol is ILocalSymbol local &&
+                (excludedLocal == null || !SymbolEqualityComparer.Default.Equals(local, excludedLocal)))
+            {
+                throw new RefactoringException(
+                    ErrorCodes.ExpressionCapturesLocal,
+                    $"Expression captures local variable '{local.Name}'.");
+            }
+
+            if (symbol is IParameterSymbol parameter && parameter.ContainingSymbol is IMethodSymbol)
+            {
+                throw new RefactoringException(
+                    ErrorCodes.ExpressionCapturesLocal,
+                    $"Expression captures parameter '{parameter.Name}'.");
+            }
+
+            if (isStaticField && symbol is ISymbol { IsStatic: false, Kind: not Microsoft.CodeAnalysis.SymbolKind.Namespace and not Microsoft.CodeAnalysis.SymbolKind.NamedType })
+            {
+                throw new RefactoringException(
+                    ErrorCodes.ExpressionNotFieldInitializable,
+                    "A static field initializer cannot reference instance members.");
+            }
+        }
+
+        if (isStaticField && expression.DescendantNodesAndSelf().OfType<ThisExpressionSyntax>().Any())
+        {
+            throw new RefactoringException(
+                ErrorCodes.ExpressionNotFieldInitializable,
+                "A static field initializer cannot reference instance members.");
+        }
+    }
+
+    private static void ValidateInlineInitializer(
+        ExpressionSyntax initializer,
+        SemanticModel semanticModel,
+        bool isStaticField,
+        CancellationToken cancellationToken)
+    {
+        if (ContainsAwait(initializer))
+        {
+            throw new RefactoringException(
+                ErrorCodes.ExpressionNotFieldInitializable,
+                "Expression cannot be used as a field initializer.");
+        }
+
+        ValidateExpressionCaptures(initializer, semanticModel, excludedLocal: null, isStaticField, cancellationToken);
+    }
+
+    private static void ValidateStaticUsage(SyntaxNode node, bool isStaticField)
+    {
+        if (isStaticField)
+            return;
+
+        if (IsInStaticMember(node))
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidTargetType,
+                "Cannot introduce an instance field from a static member.");
+        }
+    }
+
+    private static bool IsInStaticMember(SyntaxNode node)
+    {
+        foreach (var ancestor in node.AncestorsAndSelf())
+        {
+            switch (ancestor)
+            {
+                case MethodDeclarationSyntax method:
+                    return method.Modifiers.Any(SyntaxKind.StaticKeyword);
+                case PropertyDeclarationSyntax property:
+                    return property.Modifiers.Any(SyntaxKind.StaticKeyword);
+                case ConstructorDeclarationSyntax ctor:
+                    return ctor.Modifiers.Any(SyntaxKind.StaticKeyword);
+                case LocalFunctionStatementSyntax localFunction:
+                    return localFunction.Modifiers.Any(SyntaxKind.StaticKeyword);
+                case FieldDeclarationSyntax field:
+                    return field.Modifiers.Any(SyntaxKind.StaticKeyword);
+                case VariableDeclarationSyntax:
+                    continue;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ContainsAwait(SyntaxNode node) =>
+        node.DescendantNodesAndSelf().Any(n => n.IsKind(SyntaxKind.AwaitExpression));
+
+    private static bool IsTypeContext(ExpressionSyntax expression)
+    {
+        return expression.Parent switch
+        {
+            VariableDeclarationSyntax vd when vd.Type == expression => true,
+            ParameterSyntax p when p.Type == expression => true,
+            MethodDeclarationSyntax m when m.ReturnType == expression => true,
+            PropertyDeclarationSyntax p when p.Type == expression => true,
+            TypeArgumentListSyntax => true,
+            QualifiedNameSyntax => true,
+            AliasQualifiedNameSyntax => true,
+            CastExpressionSyntax c when c.Type == expression => true,
+            BinaryExpressionSyntax b when b.IsKind(SyntaxKind.AsExpression) && b.Right == expression => true,
+            TypeConstraintSyntax => true,
+            BaseListSyntax => true,
+            SimpleBaseTypeSyntax => true,
+            ArrayTypeSyntax => true,
+            NullableTypeSyntax => true,
+            ForEachStatementSyntax f when f.Type == expression => true,
+            _ => false
+        };
+    }
+
+    private static FieldDeclarationSyntax CreateFieldDeclaration(
+        IntroduceFieldParams @params,
+        ITypeSymbol type,
+        ExpressionSyntax? initializer)
+    {
+        var modifiers = new List<SyntaxToken>
+        {
+            SyntaxFactory.Token(SyntaxKind.PrivateKeyword).WithTrailingTrivia(SyntaxFactory.Space)
+        };
+
+        if (@params.IsStatic)
+            modifiers.Add(SyntaxFactory.Token(SyntaxKind.StaticKeyword).WithTrailingTrivia(SyntaxFactory.Space));
+
+        if (@params.IsReadonly)
+            modifiers.Add(SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword).WithTrailingTrivia(SyntaxFactory.Space));
+
+        var declarator = SyntaxFactory.VariableDeclarator(@params.FieldName);
+        if (initializer != null)
+        {
+            declarator = declarator.WithInitializer(
+                SyntaxFactory.EqualsValueClause(initializer.WithoutTrivia()));
+        }
+
+        return SyntaxFactory.FieldDeclaration(
+                SyntaxFactory.VariableDeclaration(
+                        SyntaxFactory.ParseTypeName(type.ToDisplayString()).WithTrailingTrivia(SyntaxFactory.Space))
+                    .WithVariables(SyntaxFactory.SingletonSeparatedList(declarator)))
+            .WithModifiers(SyntaxFactory.TokenList(modifiers))
+            .NormalizeWhitespace();
+    }
+
+    private static TypeDeclarationSyntax InsertField(
+        TypeDeclarationSyntax typeDeclaration,
+        FieldDeclarationSyntax field)
+    {
+        var members = typeDeclaration.Members.ToList();
+        var insertIndex = 0;
+        for (var i = 0; i < members.Count; i++)
+        {
+            if (members[i] is FieldDeclarationSyntax)
+                insertIndex = i + 1;
+            else if (insertIndex > 0)
+                break;
+        }
+
+        members.Insert(insertIndex, field
+            .WithLeadingTrivia(SyntaxFactory.CarriageReturnLineFeed)
+            .WithTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed));
+
+        return typeDeclaration.WithMembers(SyntaxFactory.List(members));
+    }
+
+    private static TypeDeclarationSyntax EnsureConstructorInitialization(
+        TypeDeclarationSyntax typeDeclaration,
+        IntroduceFieldParams @params,
+        ExpressionSyntax initializer)
+    {
+        if (!@params.IsStatic && typeDeclaration.ParameterList != null)
+        {
+            var hasInstanceCtor = typeDeclaration.Members
+                .OfType<ConstructorDeclarationSyntax>()
+                .Any(c => !c.Modifiers.Any(SyntaxKind.StaticKeyword));
+            if (!hasInstanceCtor)
+            {
+                throw new RefactoringException(
+                    ErrorCodes.ConstructorNotFound,
+                    "Cannot initialize in a constructor on a type that only has a primary constructor.");
+            }
+        }
+
+        var assignment = CreateAssignment(@params.FieldName, initializer);
+        var constructors = typeDeclaration.Members
+            .OfType<ConstructorDeclarationSyntax>()
+            .Where(c => @params.IsStatic
+                ? c.Modifiers.Any(SyntaxKind.StaticKeyword)
+                : !c.Modifiers.Any(SyntaxKind.StaticKeyword) && !ChainsToThis(c))
+            .ToList();
+
+        if (constructors.Count == 0)
+        {
+            var created = CreateConstructor(typeDeclaration.Identifier.Text, @params.IsStatic, assignment);
+            var members = typeDeclaration.Members.ToList();
+            var insertIndex = 0;
+            for (var i = 0; i < members.Count; i++)
+            {
+                if (members[i] is FieldDeclarationSyntax)
+                    insertIndex = i + 1;
+            }
+
+            members.Insert(insertIndex, created
+                .WithLeadingTrivia(SyntaxFactory.CarriageReturnLineFeed)
+                .WithTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed));
+            return typeDeclaration.WithMembers(SyntaxFactory.List(members));
+        }
+
+        return typeDeclaration.ReplaceNodes(constructors, (original, _) => AddAssignmentToConstructor(original, assignment));
+    }
+
+    private static bool ChainsToThis(ConstructorDeclarationSyntax constructor) =>
+        constructor.Initializer?.ThisOrBaseKeyword.IsKind(SyntaxKind.ThisKeyword) == true;
+
+    private static ConstructorDeclarationSyntax AddAssignmentToConstructor(
+        ConstructorDeclarationSyntax constructor,
+        ExpressionStatementSyntax assignment)
+    {
+        if (constructor.ExpressionBody != null)
+        {
+            var original = SyntaxFactory.ExpressionStatement(constructor.ExpressionBody.Expression);
+            var body = SyntaxFactory.Block(assignment, original);
+            return constructor
+                .WithExpressionBody(null)
+                .WithSemicolonToken(default)
+                .WithBody(body.NormalizeWhitespace());
+        }
+
+        var bodyBlock = constructor.Body ?? SyntaxFactory.Block();
+        return constructor.WithBody(
+            bodyBlock.WithStatements(bodyBlock.Statements.Insert(0, assignment)));
+    }
+
+    private static ConstructorDeclarationSyntax CreateConstructor(
+        string typeName,
+        bool isStatic,
+        ExpressionStatementSyntax assignment)
+    {
+        var modifiers = isStatic
+            ? SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.StaticKeyword).WithTrailingTrivia(SyntaxFactory.Space))
+            : SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.PublicKeyword).WithTrailingTrivia(SyntaxFactory.Space));
+
+        return SyntaxFactory.ConstructorDeclaration(typeName)
+            .WithModifiers(modifiers)
+            .WithParameterList(SyntaxFactory.ParameterList())
+            .WithBody(SyntaxFactory.Block(assignment))
+            .NormalizeWhitespace();
+    }
+
+    private static ExpressionStatementSyntax CreateAssignment(string fieldName, ExpressionSyntax initializer) =>
+        SyntaxFactory.ExpressionStatement(
+                SyntaxFactory.AssignmentExpression(
+                    SyntaxKind.SimpleAssignmentExpression,
+                    SyntaxFactory.IdentifierName(fieldName),
+                    initializer.WithoutTrivia()))
+            .NormalizeWhitespace()
+            .WithTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed);
+
+    private static RefactoringResult CreatePreviewResult(
+        Guid operationId,
+        IntroduceFieldParams @params,
+        FieldPlan plan)
+    {
+        var initNote = @params.InitializeInConstructor
+            ? " initialized in constructor"
+            : string.Empty;
+
+        var pendingChanges = new List<PendingChange>
+        {
+            new()
+            {
+                File = @params.SourceFile,
+                ChangeType = ChangeKind.Modify,
+                Description = $"Introduce field '{@params.FieldName}' of type {plan.FieldType}{initNote}",
+                BeforeSnippet = "// (selected expression or local)",
+                AfterSnippet = plan.Field.NormalizeWhitespace().ToFullString()
+            }
+        };
+
+        return RefactoringResult.PreviewResult(operationId, pendingChanges);
+    }
+
+    private static bool IsValidIdentifier(string name)
+    {
+        if (string.IsNullOrEmpty(name))
+            return false;
+        if (!SyntaxFacts.IsValidIdentifier(name))
+            return false;
+        return !SyntaxFacts.IsKeywordKind(SyntaxFacts.GetKeywordKind(name));
+    }
+
+    private sealed record FieldPlan(
+        string ContainingTypeName,
+        string FieldType,
+        FieldDeclarationSyntax Field,
+        IReadOnlyList<SyntaxNode> Replacements,
+        LocalDeclarationStatementSyntax? DeclarationToRemove,
+        VariableDeclaratorSyntax? DeclaratorToRemove,
+        ExpressionSyntax? Initializer,
+        int ReplacementCount);
+}

--- a/src/RoslynMcp.Core/Refactoring/Extract/IntroduceFieldOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/IntroduceFieldOperation.cs
@@ -279,7 +279,6 @@ public sealed class IntroduceFieldOperation : RefactoringOperationBase<Introduce
         var replaceAnn = new SyntaxAnnotation("introduce-field-replace");
         var removeDeclAnn = new SyntaxAnnotation("introduce-field-remove-decl");
         var removeVarAnn = new SyntaxAnnotation("introduce-field-remove-var");
-        var typeAnn = new SyntaxAnnotation("introduce-field-type");
 
         var annotateTargets = plan.Replacements
             .Concat(plan.DeclarationToRemove != null ? new SyntaxNode[] { plan.DeclarationToRemove } : Array.Empty<SyntaxNode>())
@@ -287,24 +286,19 @@ public sealed class IntroduceFieldOperation : RefactoringOperationBase<Introduce
             .Distinct()
             .ToList();
 
-        var containingType = root.DescendantNodes()
-            .OfType<TypeDeclarationSyntax>()
-            .First(t => t.Identifier.Text == plan.ContainingTypeName);
-        annotateTargets.Add(containingType);
-
-        var annotated = root.ReplaceNodes(annotateTargets, (original, _) =>
-        {
-            var node = original;
-            if (plan.Replacements.Contains(original))
-                node = node.WithAdditionalAnnotations(replaceAnn);
-            if (plan.DeclarationToRemove == original)
-                node = node.WithAdditionalAnnotations(removeDeclAnn);
-            if (plan.DeclaratorToRemove == original)
-                node = node.WithAdditionalAnnotations(removeVarAnn);
-            if (original == containingType)
-                node = node.WithAdditionalAnnotations(typeAnn);
-            return node;
-        });
+        var annotated = annotateTargets.Count == 0
+            ? root
+            : root.ReplaceNodes(annotateTargets, (original, _) =>
+            {
+                var node = original;
+                if (plan.Replacements.Contains(original))
+                    node = node.WithAdditionalAnnotations(replaceAnn);
+                if (plan.DeclarationToRemove == original)
+                    node = node.WithAdditionalAnnotations(removeDeclAnn);
+                if (plan.DeclaratorToRemove == original)
+                    node = node.WithAdditionalAnnotations(removeVarAnn);
+                return node;
+            });
 
         var fieldRef = SyntaxFactory.IdentifierName(@params.FieldName);
         var replacements = annotated.GetAnnotatedNodes(replaceAnn).ToList();
@@ -330,7 +324,9 @@ public sealed class IntroduceFieldOperation : RefactoringOperationBase<Introduce
             newRoot = newRoot.ReplaceNode(statement, statement.WithDeclaration(newDeclaration));
         }
 
-        var updatedType = newRoot.GetAnnotatedNodes(typeAnn).OfType<TypeDeclarationSyntax>().First();
+        var updatedType = newRoot.DescendantNodes()
+            .OfType<TypeDeclarationSyntax>()
+            .First(t => t.Identifier.Text == plan.ContainingTypeName);
         var typeWithField = InsertField(updatedType, plan.Field);
         if (@params.InitializeInConstructor && plan.Initializer != null)
             typeWithField = EnsureConstructorInitialization(typeWithField, @params, plan.Initializer);
@@ -357,9 +353,9 @@ public sealed class IntroduceFieldOperation : RefactoringOperationBase<Introduce
             return semanticModel.GetDeclaredSymbol(localStatement.Declaration.Variables[0], cancellationToken) as ILocalSymbol;
 
         IdentifierNameSyntax? identifier = node as IdentifierNameSyntax
-            ?? node.DescendantNodesAndSelf()
+            ?? node.AncestorsAndSelf()
                 .OfType<IdentifierNameSyntax>()
-                .FirstOrDefault(id => span.OverlapsWith(id.Span) || id.Span.Contains(span) || span.Contains(id.Span));
+                .FirstOrDefault(id => id.Span.Contains(span));
 
         if (identifier == null)
             return null;

--- a/src/RoslynMcp.Core/Refactoring/Extract/IntroduceFieldOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/IntroduceFieldOperation.cs
@@ -187,6 +187,8 @@ public sealed class IntroduceFieldOperation : RefactoringOperationBase<Introduce
                     $"Local variable '{local.Name}' cannot be promoted to a field.");
             }
 
+            RejectUsingLocal(local, declarator);
+
             var declaration = (LocalDeclarationStatementSyntax)declarator.Parent!.Parent!;
             initializer = declarator.Initializer?.Value;
             fieldType = local.Type;
@@ -239,14 +241,15 @@ public sealed class IntroduceFieldOperation : RefactoringOperationBase<Introduce
 
             initializer = expression;
             replacements = @params.ReplaceAll
-                ? FindMatchingExpressions(GetContainingTypeOrThrow(expression), expression)
+                ? FindMatchingExpressions(GetContainingTypeOrThrow(expression), expression, semanticModel, cancellationToken)
                 : new List<SyntaxNode> { expression };
         }
 
-        var containingType = GetContainingTypeOrThrow(local?.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax() ?? expression!);
+        var planAnchor = local?.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax() ?? expression!;
+        var containingType = GetContainingTypeOrThrow(planAnchor);
         ValidateContainingType(containingType, @params.IsStatic, semanticModel, cancellationToken);
         ValidateNameAvailable(containingType, semanticModel, @params.FieldName, cancellationToken);
-        ValidateStaticUsage(local?.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax() ?? expression!, @params.IsStatic);
+        ValidateStaticUsage(planAnchor, @params.IsStatic);
 
         if (!@params.InitializeInConstructor && initializer != null)
             ValidateInlineInitializer(initializer, semanticModel, @params.IsStatic, cancellationToken);
@@ -261,6 +264,7 @@ public sealed class IntroduceFieldOperation : RefactoringOperationBase<Introduce
         var field = CreateFieldDeclaration(@params, fieldType, @params.InitializeInConstructor ? null : initializer);
 
         return new FieldPlan(
+            containingType,
             containingType.Identifier.Text,
             fieldType.ToDisplayString(),
             field,
@@ -268,6 +272,7 @@ public sealed class IntroduceFieldOperation : RefactoringOperationBase<Introduce
             declarationToRemove,
             declaratorToRemove,
             initializer,
+            FindInsertBeforeFieldVariable(@params.IsStatic, planAnchor, replacements),
             replacements.Count + (declarationToRemove != null || declaratorToRemove != null ? 1 : 0));
     }
 
@@ -279,6 +284,7 @@ public sealed class IntroduceFieldOperation : RefactoringOperationBase<Introduce
         var replaceAnn = new SyntaxAnnotation("introduce-field-replace");
         var removeDeclAnn = new SyntaxAnnotation("introduce-field-remove-decl");
         var removeVarAnn = new SyntaxAnnotation("introduce-field-remove-var");
+        var typeAnn = new SyntaxAnnotation("introduce-field-type");
 
         var annotateTargets = plan.Replacements
             .Concat(plan.DeclarationToRemove != null ? new SyntaxNode[] { plan.DeclarationToRemove } : Array.Empty<SyntaxNode>())
@@ -300,7 +306,19 @@ public sealed class IntroduceFieldOperation : RefactoringOperationBase<Introduce
                 return node;
             });
 
-        var fieldRef = SyntaxFactory.IdentifierName(@params.FieldName);
+        var typeSeed = annotated.GetAnnotatedNodes(replaceAnn).FirstOrDefault()
+            ?? annotated.GetAnnotatedNodes(removeDeclAnn).FirstOrDefault()
+            ?? annotated.GetAnnotatedNodes(removeVarAnn).FirstOrDefault();
+        var typeToAnnotate = typeSeed != null
+            ? GetContainingTypeOrThrow(typeSeed)
+            : annotated.GetCurrentNode(plan.ContainingType)
+                ?? throw new RefactoringException(ErrorCodes.RoslynError, "Failed to locate containing type after rewrite.");
+
+        annotated = (CompilationUnitSyntax)annotated.ReplaceNode(
+            typeToAnnotate,
+            typeToAnnotate.WithAdditionalAnnotations(typeAnn));
+
+        var fieldRef = CreateFieldReference(@params.IsStatic, plan.ContainingTypeName, @params.FieldName);
         var replacements = annotated.GetAnnotatedNodes(replaceAnn).ToList();
         SyntaxNode newRoot = replacements.Count == 0
             ? annotated
@@ -324,10 +342,9 @@ public sealed class IntroduceFieldOperation : RefactoringOperationBase<Introduce
             newRoot = newRoot.ReplaceNode(statement, statement.WithDeclaration(newDeclaration));
         }
 
-        var updatedType = newRoot.DescendantNodes()
-            .OfType<TypeDeclarationSyntax>()
-            .First(t => t.Identifier.Text == plan.ContainingTypeName);
-        var typeWithField = InsertField(updatedType, plan.Field);
+        var updatedType = newRoot.GetAnnotatedNodes(typeAnn).OfType<TypeDeclarationSyntax>().FirstOrDefault()
+            ?? throw new RefactoringException(ErrorCodes.RoslynError, "Failed to locate containing type after rewrite.");
+        var typeWithField = InsertField(updatedType, plan.Field, plan.InsertBeforeFieldVariable);
         if (@params.InitializeInConstructor && plan.Initializer != null)
             typeWithField = EnsureConstructorInitialization(typeWithField, @params, plan.Initializer);
 
@@ -344,13 +361,24 @@ public sealed class IntroduceFieldOperation : RefactoringOperationBase<Introduce
             .OfType<VariableDeclaratorSyntax>()
             .FirstOrDefault(v => v.Parent?.Parent is LocalDeclarationStatementSyntax && v.Span.Contains(span));
         if (declarator != null)
-            return semanticModel.GetDeclaredSymbol(declarator, cancellationToken) as ILocalSymbol;
+        {
+            var declared = semanticModel.GetDeclaredSymbol(declarator, cancellationToken) as ILocalSymbol;
+            if (declared != null)
+                RejectUsingLocal(declared, declarator);
+            return declared;
+        }
 
         var localStatement = node.AncestorsAndSelf()
             .OfType<LocalDeclarationStatementSyntax>()
             .FirstOrDefault(s => s.Span.Contains(span) && s.Declaration.Variables.Count == 1);
         if (localStatement != null)
-            return semanticModel.GetDeclaredSymbol(localStatement.Declaration.Variables[0], cancellationToken) as ILocalSymbol;
+        {
+            var variable = localStatement.Declaration.Variables[0];
+            var declared = semanticModel.GetDeclaredSymbol(variable, cancellationToken) as ILocalSymbol;
+            if (declared != null)
+                RejectUsingLocal(declared, variable);
+            return declared;
+        }
 
         IdentifierNameSyntax? identifier = node as IdentifierNameSyntax
             ?? node.AncestorsAndSelf()
@@ -363,8 +391,12 @@ public sealed class IntroduceFieldOperation : RefactoringOperationBase<Introduce
         if (semanticModel.GetSymbolInfo(identifier, cancellationToken).Symbol is ILocalSymbol local)
         {
             var syntax = local.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax(cancellationToken);
-            if (syntax is VariableDeclaratorSyntax v && v.Parent?.Parent is LocalDeclarationStatementSyntax)
-                return local;
+            if (syntax is VariableDeclaratorSyntax v)
+            {
+                RejectUsingLocal(local, v);
+                if (v.Parent?.Parent is LocalDeclarationStatementSyntax)
+                    return local;
+            }
         }
 
         return null;
@@ -405,15 +437,47 @@ public sealed class IntroduceFieldOperation : RefactoringOperationBase<Introduce
         return bestMatch;
     }
 
-    private static List<SyntaxNode> FindMatchingExpressions(TypeDeclarationSyntax containingType, ExpressionSyntax original)
+    private static List<SyntaxNode> FindMatchingExpressions(
+        TypeDeclarationSyntax containingType,
+        ExpressionSyntax original,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
     {
         var normalized = NormalizeExpression(original);
+        var originalBindings = CollectBindings(original, semanticModel, cancellationToken);
         return containingType.DescendantNodes()
             .OfType<ExpressionSyntax>()
-            .Where(expr => expr != original && NormalizeExpression(expr) == normalized)
+            .Where(expr =>
+                expr == original ||
+                (NormalizeExpression(expr) == normalized &&
+                 BindingsEqual(originalBindings, CollectBindings(expr, semanticModel, cancellationToken))))
             .Cast<SyntaxNode>()
-            .Prepend(original)
             .ToList();
+    }
+
+    private static IReadOnlyList<ISymbol?> CollectBindings(
+        ExpressionSyntax expression,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        return expression.DescendantNodesAndSelf()
+            .OfType<IdentifierNameSyntax>()
+            .Select(id => semanticModel.GetSymbolInfo(id, cancellationToken).Symbol)
+            .ToList();
+    }
+
+    private static bool BindingsEqual(IReadOnlyList<ISymbol?> left, IReadOnlyList<ISymbol?> right)
+    {
+        if (left.Count != right.Count)
+            return false;
+
+        for (var i = 0; i < left.Count; i++)
+        {
+            if (!SymbolEqualityComparer.Default.Equals(left[i], right[i]))
+                return false;
+        }
+
+        return true;
     }
 
     private static string NormalizeExpression(ExpressionSyntax expression) =>
@@ -669,9 +733,38 @@ public sealed class IntroduceFieldOperation : RefactoringOperationBase<Introduce
 
     private static TypeDeclarationSyntax InsertField(
         TypeDeclarationSyntax typeDeclaration,
-        FieldDeclarationSyntax field)
+        FieldDeclarationSyntax field,
+        string? insertBeforeFieldVariable)
     {
         var members = typeDeclaration.Members.ToList();
+        var insertIndex = FindFieldInsertIndex(members, insertBeforeFieldVariable);
+
+        members.Insert(insertIndex, field
+            .WithLeadingTrivia(SyntaxFactory.CarriageReturnLineFeed)
+            .WithTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed));
+
+        return typeDeclaration.WithMembers(SyntaxFactory.List(members));
+    }
+
+    private static int FindFieldInsertIndex(IReadOnlyList<MemberDeclarationSyntax> members, string? insertBeforeFieldVariable)
+    {
+        if (insertBeforeFieldVariable != null)
+        {
+            var sourceIndex = -1;
+            for (var i = 0; i < members.Count; i++)
+            {
+                if (members[i] is FieldDeclarationSyntax existing &&
+                    existing.Declaration.Variables.Any(v => v.Identifier.Text == insertBeforeFieldVariable))
+                {
+                    sourceIndex = i;
+                    break;
+                }
+            }
+
+            if (sourceIndex >= 0)
+                return sourceIndex;
+        }
+
         var insertIndex = 0;
         for (var i = 0; i < members.Count; i++)
         {
@@ -681,11 +774,7 @@ public sealed class IntroduceFieldOperation : RefactoringOperationBase<Introduce
                 break;
         }
 
-        members.Insert(insertIndex, field
-            .WithLeadingTrivia(SyntaxFactory.CarriageReturnLineFeed)
-            .WithTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed));
-
-        return typeDeclaration.WithMembers(SyntaxFactory.List(members));
+        return insertIndex;
     }
 
     private static TypeDeclarationSyntax EnsureConstructorInitialization(
@@ -706,7 +795,9 @@ public sealed class IntroduceFieldOperation : RefactoringOperationBase<Introduce
             }
         }
 
-        var assignment = CreateAssignment(@params.FieldName, initializer);
+        var assignment = CreateAssignment(
+            CreateFieldReference(@params.IsStatic, typeDeclaration.Identifier.Text, @params.FieldName),
+            initializer);
         var constructors = typeDeclaration.Members
             .OfType<ConstructorDeclarationSyntax>()
             .Where(c => @params.IsStatic
@@ -772,14 +863,72 @@ public sealed class IntroduceFieldOperation : RefactoringOperationBase<Introduce
             .NormalizeWhitespace();
     }
 
-    private static ExpressionStatementSyntax CreateAssignment(string fieldName, ExpressionSyntax initializer) =>
+    private static ExpressionStatementSyntax CreateAssignment(ExpressionSyntax fieldRef, ExpressionSyntax initializer) =>
         SyntaxFactory.ExpressionStatement(
                 SyntaxFactory.AssignmentExpression(
                     SyntaxKind.SimpleAssignmentExpression,
-                    SyntaxFactory.IdentifierName(fieldName),
+                    fieldRef,
                     initializer.WithoutTrivia()))
             .NormalizeWhitespace()
             .WithTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed);
+
+    private static ExpressionSyntax CreateFieldReference(bool isStatic, string typeName, string fieldName)
+    {
+        var name = SyntaxFactory.IdentifierName(fieldName);
+        if (isStatic)
+        {
+            return SyntaxFactory.MemberAccessExpression(
+                SyntaxKind.SimpleMemberAccessExpression,
+                SyntaxFactory.IdentifierName(typeName),
+                name);
+        }
+
+        return SyntaxFactory.MemberAccessExpression(
+            SyntaxKind.SimpleMemberAccessExpression,
+            SyntaxFactory.ThisExpression(),
+            name);
+    }
+
+    private static void RejectUsingLocal(ILocalSymbol local, VariableDeclaratorSyntax declarator)
+    {
+        if (!IsUsingDeclaration(declarator))
+            return;
+
+        throw new RefactoringException(
+            ErrorCodes.ExpressionNotFieldInitializable,
+            $"Local variable '{local.Name}' is a using declaration and cannot be promoted to a field.");
+    }
+
+    private static bool IsUsingDeclaration(VariableDeclaratorSyntax declarator) =>
+        declarator.Parent?.Parent switch
+        {
+            LocalDeclarationStatementSyntax statement => statement.UsingKeyword != default,
+            UsingStatementSyntax => true,
+            _ => false
+        };
+
+    private static string? FindInsertBeforeFieldVariable(
+        bool isStaticField,
+        SyntaxNode planAnchor,
+        IReadOnlyList<SyntaxNode> replacements)
+    {
+        if (!isStaticField)
+            return null;
+
+        var sourceField = planAnchor.AncestorsAndSelf()
+            .OfType<FieldDeclarationSyntax>()
+            .FirstOrDefault(f => f.Modifiers.Any(SyntaxKind.StaticKeyword));
+
+        sourceField ??= replacements
+            .Select(r => r.Ancestors()
+                .OfType<FieldDeclarationSyntax>()
+                .FirstOrDefault(f => f.Modifiers.Any(SyntaxKind.StaticKeyword)))
+            .Where(f => f != null)
+            .OrderBy(f => f!.SpanStart)
+            .FirstOrDefault();
+
+        return sourceField?.Declaration.Variables.FirstOrDefault()?.Identifier.Text;
+    }
 
     private static RefactoringResult CreatePreviewResult(
         Guid operationId,
@@ -815,6 +964,7 @@ public sealed class IntroduceFieldOperation : RefactoringOperationBase<Introduce
     }
 
     private sealed record FieldPlan(
+        TypeDeclarationSyntax ContainingType,
         string ContainingTypeName,
         string FieldType,
         FieldDeclarationSyntax Field,
@@ -822,5 +972,6 @@ public sealed class IntroduceFieldOperation : RefactoringOperationBase<Introduce
         LocalDeclarationStatementSyntax? DeclarationToRemove,
         VariableDeclaratorSyntax? DeclaratorToRemove,
         ExpressionSyntax? Initializer,
+        string? InsertBeforeFieldVariable,
         int ReplacementCount);
 }

--- a/src/RoslynMcp.Server/McpServerHost.cs
+++ b/src/RoslynMcp.Server/McpServerHost.cs
@@ -52,6 +52,7 @@ public sealed class McpServerHost : IAsyncDisposable
         _toolRegistry.Register(new PullMembersUpTool(workspaceProvider));
         _toolRegistry.Register(new PushMembersDownTool(workspaceProvider));
         _toolRegistry.Register(new UseBaseTypeTool(workspaceProvider));
+        _toolRegistry.Register(new IntroduceFieldTool(workspaceProvider));
 
         // Code Navigation / Query Tools
         _toolRegistry.Register(new FindReferencesTool(workspaceProvider));

--- a/src/RoslynMcp.Server/RoslynMcp.Server.csproj
+++ b/src/RoslynMcp.Server/RoslynMcp.Server.csproj
@@ -18,7 +18,7 @@
     <Version>0.4.0</Version>
     <Authors>Joshua Ramirez</Authors>
     <Company>RedJay</Company>
-    <Description>MCP Server for Roslyn-powered C# refactoring operations. Install as a global tool to use with Claude Code, Claude Desktop, or other MCP clients. Provides 45 tools: 23 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 7 code conversion tools.</Description>
+    <Description>MCP Server for Roslyn-powered C# refactoring operations. Install as a global tool to use with Claude Code, Claude Desktop, or other MCP clients. Provides 46 tools: 24 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 7 code conversion tools.</Description>
     <PackageTags>roslyn;mcp;refactoring;csharp;model-context-protocol;code-analysis;dotnet;ai-tools;claude</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/JoshuaRamirez/RoslynMcpServer</RepositoryUrl>

--- a/src/RoslynMcp.Server/Tools/IntroduceFieldTool.cs
+++ b/src/RoslynMcp.Server/Tools/IntroduceFieldTool.cs
@@ -1,0 +1,186 @@
+using System.Text.Json;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.Refactoring;
+using RoslynMcp.Core.Refactoring.Extract;
+using RoslynMcp.Core.Workspace;
+using RoslynMcp.Server.Transport;
+
+namespace RoslynMcp.Server.Tools;
+
+/// <summary>
+/// MCP tool handler for introduce_field operation.
+/// </summary>
+public sealed class IntroduceFieldTool : IToolHandler
+{
+    private readonly IWorkspaceProvider _workspaceProvider;
+    private readonly JsonSerializerOptions _jsonOptions;
+
+    /// <summary>
+    /// Creates a new introduce field tool.
+    /// </summary>
+    public IntroduceFieldTool(IWorkspaceProvider workspaceProvider)
+    {
+        _workspaceProvider = workspaceProvider;
+        _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = false
+        };
+    }
+
+    /// <inheritdoc />
+    public string Name => "introduce_field";
+
+    /// <inheritdoc />
+    public string Description => "Turn a selected local variable or expression into a class field, optionally initializing it in a constructor.";
+
+    /// <inheritdoc />
+    public object InputSchema => new
+    {
+        type = "object",
+        required = new[] { "solutionPath", "sourceFile", "startLine", "startColumn", "endLine", "endColumn", "fieldName" },
+        properties = new
+        {
+            solutionPath = new
+            {
+                type = "string",
+                description = "Absolute path to the .sln or .csproj file"
+            },
+            sourceFile = new
+            {
+                type = "string",
+                description = "Absolute path to the source file"
+            },
+            startLine = new
+            {
+                type = "integer",
+                description = "Start line of the local variable or expression (1-based)"
+            },
+            startColumn = new
+            {
+                type = "integer",
+                description = "Start column of the local variable or expression (1-based)"
+            },
+            endLine = new
+            {
+                type = "integer",
+                description = "End line of the local variable or expression (1-based)"
+            },
+            endColumn = new
+            {
+                type = "integer",
+                description = "End column of the local variable or expression (1-based)"
+            },
+            fieldName = new
+            {
+                type = "string",
+                description = "Name for the new field"
+            },
+            isReadonly = new
+            {
+                type = "boolean",
+                description = "Create as a readonly field",
+                @default = false
+            },
+            isStatic = new
+            {
+                type = "boolean",
+                description = "Create as a static field",
+                @default = false
+            },
+            initializeInConstructor = new
+            {
+                type = "boolean",
+                description = "Initialize the field in a constructor instead of inline",
+                @default = false
+            },
+            replaceAll = new
+            {
+                type = "boolean",
+                description = "Replace all identical expressions in the containing type",
+                @default = false
+            },
+            preview = new
+            {
+                type = "boolean",
+                description = "Return computed changes without applying",
+                @default = false
+            }
+        },
+        additionalProperties = false
+    };
+
+    /// <inheritdoc />
+    public async Task<ToolResult> ExecuteAsync(JsonElement? arguments, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (arguments == null)
+            {
+                return ToolResult.Error("Arguments required");
+            }
+
+            var args = JsonSerializer.Deserialize<IntroduceFieldArgs>(arguments.Value.GetRawText(), _jsonOptions);
+            if (args == null)
+            {
+                return ToolResult.Error("Failed to parse arguments");
+            }
+
+            using var context = await _workspaceProvider.CreateContextAsync(
+                args.SolutionPath,
+                cancellationToken);
+
+            var operation = new IntroduceFieldOperation(context);
+            var @params = new IntroduceFieldParams
+            {
+                SourceFile = args.SourceFile,
+                StartLine = args.StartLine,
+                StartColumn = args.StartColumn,
+                EndLine = args.EndLine,
+                EndColumn = args.EndColumn,
+                FieldName = args.FieldName,
+                IsReadonly = args.IsReadonly ?? false,
+                IsStatic = args.IsStatic ?? false,
+                InitializeInConstructor = args.InitializeInConstructor ?? false,
+                ReplaceAll = args.ReplaceAll ?? false,
+                Preview = args.Preview ?? false
+            };
+
+            var result = await operation.ExecuteAsync(@params, cancellationToken);
+
+            var json = JsonSerializer.Serialize(result, _jsonOptions);
+            return result.Success ? ToolResult.Success(json) : ToolResult.Error(json);
+        }
+        catch (RefactoringException ex)
+        {
+            var error = ex.ToError();
+            var json = JsonSerializer.Serialize(new { success = false, error }, _jsonOptions);
+            return ToolResult.Error(json);
+        }
+        catch (Exception ex)
+        {
+            var json = JsonSerializer.Serialize(new
+            {
+                success = false,
+                error = new { code = "INTERNAL_ERROR", message = ex.Message }
+            }, _jsonOptions);
+            return ToolResult.Error(json);
+        }
+    }
+
+    private sealed class IntroduceFieldArgs
+    {
+        public string SolutionPath { get; init; } = "";
+        public string SourceFile { get; init; } = "";
+        public int StartLine { get; init; }
+        public int StartColumn { get; init; }
+        public int EndLine { get; init; }
+        public int EndColumn { get; init; }
+        public string FieldName { get; init; } = "";
+        public bool? IsReadonly { get; init; }
+        public bool? IsStatic { get; init; }
+        public bool? InitializeInConstructor { get; init; }
+        public bool? ReplaceAll { get; init; }
+        public bool? Preview { get; init; }
+    }
+}

--- a/tests/RoslynMcp.Cli.Tests/HelpGeneratorTests.cs
+++ b/tests/RoslynMcp.Cli.Tests/HelpGeneratorTests.cs
@@ -15,14 +15,15 @@ public class HelpGeneratorTests
     }
 
     [Fact]
-    public void GenerateGlobalHelp_Lists45Tools()
+    public void GenerateGlobalHelp_Lists46Tools()
     {
         var registry = ToolRegistry.BuildDefault();
         var help = HelpGenerator.GenerateGlobalHelp(registry);
-        Assert.Contains("Total: 45 tools", help);
+        Assert.Contains("Total: 46 tools", help);
         Assert.Contains("pull-members-up", help);
         Assert.Contains("push-members-down", help);
         Assert.Contains("use-base-type", help);
+        Assert.Contains("introduce-field", help);
     }
 
     [Fact]

--- a/tests/RoslynMcp.Cli.Tests/ToolRegistryTests.cs
+++ b/tests/RoslynMcp.Cli.Tests/ToolRegistryTests.cs
@@ -6,11 +6,11 @@ namespace RoslynMcp.Cli.Tests;
 public class ToolRegistryTests
 {
     [Fact]
-    public void BuildDefault_Registers45Tools()
+    public void BuildDefault_Registers46Tools()
     {
         var registry = ToolRegistry.BuildDefault();
         var tools = registry.GetAllTools();
-        Assert.Equal(45, tools.Count);
+        Assert.Equal(46, tools.Count);
     }
 
     [Fact]
@@ -87,6 +87,7 @@ public class ToolRegistryTests
     [InlineData("pull-members-up", "Refactoring")]
     [InlineData("push-members-down", "Refactoring")]
     [InlineData("use-base-type", "Refactoring")]
+    [InlineData("introduce-field", "Refactoring")]
     [InlineData("find-references", "Query")]
     [InlineData("get-diagnostics", "Query")]
     [InlineData("diagnose", "Diagnostic")]
@@ -105,11 +106,11 @@ public class ToolRegistryTests
     }
 
     [Fact]
-    public void RefactoringToolCount_Is32()
+    public void RefactoringToolCount_Is33()
     {
         var registry = ToolRegistry.BuildDefault();
         var count = registry.GetAllTools().Count(t => t.Category == "Refactoring");
-        Assert.Equal(32, count);
+        Assert.Equal(33, count);
     }
 
     [Fact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Extract/IntroduceFieldOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Extract/IntroduceFieldOperationTests.cs
@@ -1,0 +1,726 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+using RoslynMcp.Contracts.Errors;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.Refactoring;
+using RoslynMcp.Core.Refactoring.Extract;
+using RoslynMcp.Core.Workspace;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Refactoring.Extract;
+
+/// <summary>
+/// Operation-level tests for <see cref="IntroduceFieldOperation"/>.
+/// </summary>
+public class IntroduceFieldOperationTests
+{
+    #region Input Validation
+
+    [Fact]
+    public void Validate_MissingSourceFile_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            IntroduceFieldOperation.Validate(new IntroduceFieldParams
+            {
+                SourceFile = "",
+                StartLine = 1,
+                StartColumn = 1,
+                EndLine = 1,
+                EndColumn = 2,
+                FieldName = "_value"
+            }));
+
+        Assert.Equal(ErrorCodes.MissingRequiredParam, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_MissingFieldName_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            IntroduceFieldOperation.Validate(new IntroduceFieldParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                StartLine = 1,
+                StartColumn = 1,
+                EndLine = 1,
+                EndColumn = 2,
+                FieldName = ""
+            }));
+
+        Assert.Equal(ErrorCodes.MissingRequiredParam, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_RelativePath_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            IntroduceFieldOperation.Validate(new IntroduceFieldParams
+            {
+                SourceFile = "Types.cs",
+                StartLine = 1,
+                StartColumn = 1,
+                EndLine = 1,
+                EndColumn = 2,
+                FieldName = "_value"
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidSourcePath, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_InvalidLine_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            IntroduceFieldOperation.Validate(new IntroduceFieldParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                StartLine = 0,
+                StartColumn = 1,
+                EndLine = 1,
+                EndColumn = 2,
+                FieldName = "_value"
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidLineNumber, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_InvalidSelectionRange_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            IntroduceFieldOperation.Validate(new IntroduceFieldParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                StartLine = 2,
+                StartColumn = 1,
+                EndLine = 1,
+                EndColumn = 2,
+                FieldName = "_value"
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidSelectionRange, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_InvalidFieldName_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            IntroduceFieldOperation.Validate(new IntroduceFieldParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                StartLine = 1,
+                StartColumn = 1,
+                EndLine = 1,
+                EndColumn = 2,
+                FieldName = "123bad"
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidSymbolName, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_MissingFile_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            IntroduceFieldOperation.Validate(new IntroduceFieldParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                StartLine = 1,
+                StartColumn = 1,
+                EndLine = 1,
+                EndColumn = 2,
+                FieldName = "_value"
+            }));
+
+        Assert.Equal(ErrorCodes.SourceFileNotFound, ex.ErrorCode);
+    }
+
+    #endregion
+
+    #region P0 Happy Path
+
+    [SkippableFact]
+    public async Task IntroduceField_Literal_CreatesFieldAndReplacesExpression()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public int Get()
+                {
+                    return 42;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new IntroduceFieldOperation(workspace.Context);
+        var span = FindSpan(source, "42");
+
+        var result = await operation.ExecuteAsync(new IntroduceFieldParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = span.StartLine,
+            StartColumn = span.StartColumn,
+            EndLine = span.EndLine,
+            EndColumn = span.EndColumn,
+            FieldName = "_answer"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("private int _answer = 42;", updated);
+        Assert.Contains("return _answer;", updated);
+        Assert.DoesNotContain("return 42;", updated);
+    }
+
+    [SkippableFact]
+    public async Task IntroduceField_Expression_CreatesFieldAndReplacesExpression()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public int Get()
+                {
+                    return 1 + 2;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new IntroduceFieldOperation(workspace.Context);
+        var span = FindSpan(source, "1 + 2");
+
+        var result = await operation.ExecuteAsync(new IntroduceFieldParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = span.StartLine,
+            StartColumn = span.StartColumn,
+            EndLine = span.EndLine,
+            EndColumn = span.EndColumn,
+            FieldName = "_sum"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("private int _sum = 1 + 2;", updated);
+        Assert.Contains("return _sum;", updated);
+    }
+
+    [SkippableFact]
+    public async Task IntroduceField_LocalVariable_PromotesToField()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public int Get()
+                {
+                    int value = 7;
+                    return value;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new IntroduceFieldOperation(workspace.Context);
+        var span = FindSpan(source, "value = 7");
+
+        var result = await operation.ExecuteAsync(new IntroduceFieldParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = span.StartLine,
+            StartColumn = span.StartColumn,
+            EndLine = span.EndLine,
+            EndColumn = span.EndColumn,
+            FieldName = "_value"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("private int _value = 7;", updated);
+        Assert.Contains("return _value;", updated);
+        Assert.DoesNotContain("int value = 7;", updated);
+    }
+
+    [SkippableFact]
+    public async Task IntroduceField_InitializeInConstructor_AddsAssignment()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public int Get()
+                {
+                    return 42;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new IntroduceFieldOperation(workspace.Context);
+        var span = FindSpan(source, "42");
+
+        var result = await operation.ExecuteAsync(new IntroduceFieldParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = span.StartLine,
+            StartColumn = span.StartColumn,
+            EndLine = span.EndLine,
+            EndColumn = span.EndColumn,
+            FieldName = "_answer",
+            InitializeInConstructor = true
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("private int _answer;", updated);
+        Assert.DoesNotContain("private int _answer = 42;", updated);
+        Assert.Contains("public Calculator()", updated);
+        Assert.Contains("_answer = 42;", updated);
+        Assert.Contains("return _answer;", updated);
+    }
+
+    [SkippableFact]
+    public async Task IntroduceField_InitializeInExistingConstructor_PrependsAssignment()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public Calculator()
+                {
+                    Warmup();
+                }
+
+                public int Get()
+                {
+                    return 42;
+                }
+
+                private static void Warmup()
+                {
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new IntroduceFieldOperation(workspace.Context);
+        var span = FindSpan(source, "42");
+
+        var result = await operation.ExecuteAsync(new IntroduceFieldParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = span.StartLine,
+            StartColumn = span.StartColumn,
+            EndLine = span.EndLine,
+            EndColumn = span.EndColumn,
+            FieldName = "_answer",
+            InitializeInConstructor = true
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("_answer = 42;", updated);
+        Assert.Contains("Warmup();", updated);
+        Assert.Equal(1, CountOccurrences(updated, "public Calculator()"));
+    }
+
+    [SkippableFact]
+    public async Task IntroduceField_Preview_DoesNotModifyFile()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public int Get()
+                {
+                    return 42;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+        var operation = new IntroduceFieldOperation(workspace.Context);
+        var span = FindSpan(source, "42");
+
+        var result = await operation.ExecuteAsync(new IntroduceFieldParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = span.StartLine,
+            StartColumn = span.StartColumn,
+            EndLine = span.EndLine,
+            EndColumn = span.EndColumn,
+            FieldName = "_answer",
+            Preview = true
+        });
+
+        Assert.True(result.Success);
+        Assert.True(result.Preview);
+        Assert.NotNull(result.PendingChanges);
+        Assert.Contains(result.PendingChanges, c => c.Description.Contains("_answer"));
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [SkippableFact]
+    public async Task IntroduceField_Readonly_AddsModifier()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public int Get()
+                {
+                    return 42;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new IntroduceFieldOperation(workspace.Context);
+        var span = FindSpan(source, "42");
+
+        var result = await operation.ExecuteAsync(new IntroduceFieldParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = span.StartLine,
+            StartColumn = span.StartColumn,
+            EndLine = span.EndLine,
+            EndColumn = span.EndColumn,
+            FieldName = "_answer",
+            IsReadonly = true
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("private readonly int _answer = 42;", updated);
+    }
+
+    #endregion
+
+    #region P0 Rejects
+
+    [SkippableFact]
+    public async Task IntroduceField_NoExpression_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public int Get()
+                {
+                    return 42;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new IntroduceFieldOperation(workspace.Context);
+        var span = FindSpan(source, "return");
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new IntroduceFieldParams
+            {
+                SourceFile = workspace.SourcePath,
+                StartLine = span.StartLine,
+                StartColumn = span.StartColumn,
+                EndLine = span.EndLine,
+                EndColumn = span.EndColumn,
+                FieldName = "_answer"
+            }));
+
+        Assert.Equal(ErrorCodes.ExpressionNotFound, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void IntroduceField_UneditableDocument_Throws()
+    {
+        var workspace = new AdhocWorkspace();
+        var project = workspace.AddProject("P", LanguageNames.CSharp);
+        var document = workspace.AddDocument(project.Id, "Generated.cs", SourceText.From("class C {}"));
+
+        var ex = Assert.Throws<RefactoringException>(() =>
+            IntroduceFieldOperation.ValidateDocumentIsEditable(document, workspace));
+
+        Assert.Equal(ErrorCodes.DocumentNotEditable, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task IntroduceField_InterfaceTarget_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public interface ICalculator
+            {
+                int Get()
+                {
+                    return 42;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new IntroduceFieldOperation(workspace.Context);
+        var span = FindSpan(source, "42");
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new IntroduceFieldParams
+            {
+                SourceFile = workspace.SourcePath,
+                StartLine = span.StartLine,
+                StartColumn = span.StartColumn,
+                EndLine = span.EndLine,
+                EndColumn = span.EndColumn,
+                FieldName = "_answer"
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidTargetType, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task IntroduceField_NameExists_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                private int _answer = 1;
+
+                public int Get()
+                {
+                    return 42;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new IntroduceFieldOperation(workspace.Context);
+        var span = FindSpan(source, "42");
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new IntroduceFieldParams
+            {
+                SourceFile = workspace.SourcePath,
+                StartLine = span.StartLine,
+                StartColumn = span.StartColumn,
+                EndLine = span.EndLine,
+                EndColumn = span.EndColumn,
+                FieldName = "_answer"
+            }));
+
+        Assert.Equal(ErrorCodes.NameCollision, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task IntroduceField_ExpressionUsesLocal_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public int Get()
+                {
+                    int offset = 3;
+                    return offset + 2;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new IntroduceFieldOperation(workspace.Context);
+        var span = FindSpan(source, "offset + 2");
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new IntroduceFieldParams
+            {
+                SourceFile = workspace.SourcePath,
+                StartLine = span.StartLine,
+                StartColumn = span.StartColumn,
+                EndLine = span.EndLine,
+                EndColumn = span.EndColumn,
+                FieldName = "_sum"
+            }));
+
+        Assert.Equal(ErrorCodes.ExpressionCapturesLocal, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task IntroduceField_InstanceFieldFromStaticMember_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public static int Get()
+                {
+                    return 42;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new IntroduceFieldOperation(workspace.Context);
+        var span = FindSpan(source, "42");
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new IntroduceFieldParams
+            {
+                SourceFile = workspace.SourcePath,
+                StartLine = span.StartLine,
+                StartColumn = span.StartColumn,
+                EndLine = span.EndLine,
+                EndColumn = span.EndColumn,
+                FieldName = "_answer"
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidTargetType, ex.ErrorCode);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static string AbsoluteTestPath() =>
+        OperatingSystem.IsWindows() ? @"C:\test\file.cs" : "/test/file.cs";
+
+    private static string NormalizeNewlines(string text) =>
+        text.Replace("\r\n", "\n");
+
+    private static int CountOccurrences(string text, string value)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = text.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += value.Length;
+        }
+
+        return count;
+    }
+
+    private static (int StartLine, int StartColumn, int EndLine, int EndColumn) FindSpan(string source, string snippet)
+    {
+        var index = source.IndexOf(snippet, StringComparison.Ordinal);
+        if (index < 0)
+            throw new InvalidOperationException($"Snippet not found: {snippet}");
+
+        return (GetLineColumn(source, index).Line, GetLineColumn(source, index).Column,
+            GetLineColumn(source, index + snippet.Length).Line, GetLineColumn(source, index + snippet.Length).Column);
+    }
+
+    private static (int Line, int Column) GetLineColumn(string source, int index)
+    {
+        var line = 1;
+        var column = 1;
+        for (var i = 0; i < index; i++)
+        {
+            if (source[i] == '\n')
+            {
+                line++;
+                column = 1;
+            }
+            else
+            {
+                column++;
+            }
+        }
+
+        return (line, column);
+    }
+
+    private sealed class TempWorkspace : IAsyncDisposable
+    {
+        public required string DirectoryPath { get; init; }
+        public required string ProjectPath { get; init; }
+        public required string SourcePath { get; init; }
+        public required WorkspaceContext Context { get; init; }
+
+        public static async Task<TempWorkspace> CreateAsync(string source, string fileName = "Types.cs")
+        {
+            Skip.IfNot(ModuleInitializer.MsBuildAvailable, ModuleInitializer.MsBuildError ?? "MSBuild not available");
+
+            var directory = Path.Combine(Path.GetTempPath(), "RoslynMcpIntroduceField_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(directory);
+
+            var projectPath = Path.Combine(directory, "TestApp.csproj");
+            var sourcePath = Path.Combine(directory, fileName);
+
+            await File.WriteAllTextAsync(projectPath, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net9.0</TargetFramework>
+                    <Nullable>enable</Nullable>
+                  </PropertyGroup>
+                </Project>
+                """);
+            await File.WriteAllTextAsync(sourcePath, source);
+
+            try
+            {
+                var provider = new MSBuildWorkspaceProvider();
+                var context = await provider.CreateContextAsync(projectPath);
+                if (context.GetDocumentByPath(sourcePath) == null)
+                {
+                    context.Dispose();
+                    throw new InvalidOperationException($"Workspace loaded but did not include {sourcePath}.");
+                }
+
+                return new TempWorkspace
+                {
+                    DirectoryPath = directory,
+                    ProjectPath = projectPath,
+                    SourcePath = sourcePath,
+                    Context = context
+                };
+            }
+            catch (Exception ex) when (ex is not SkipException)
+            {
+                try
+                {
+                    Directory.Delete(directory, recursive: true);
+                }
+                catch
+                {
+                    // ignore cleanup failures
+                }
+
+                Skip.If(true, $"Workspace load failed: {ex.Message}");
+                throw;
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            Context.Dispose();
+            await Task.Run(() =>
+            {
+                try
+                {
+                    Directory.Delete(DirectoryPath, recursive: true);
+                }
+                catch
+                {
+                    // ignore locked temp files
+                }
+            });
+        }
+    }
+
+    #endregion
+}

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Extract/IntroduceFieldOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Extract/IntroduceFieldOperationTests.cs
@@ -172,7 +172,7 @@ public class IntroduceFieldOperationTests
         Assert.True(result.Success);
         var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
         Assert.Contains("private int _answer = 42;", updated);
-        Assert.Contains("return _answer;", updated);
+        Assert.Contains("return this._answer;", updated);
         Assert.DoesNotContain("return 42;", updated);
     }
 
@@ -208,7 +208,7 @@ public class IntroduceFieldOperationTests
         Assert.True(result.Success);
         var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
         Assert.Contains("private int _sum = 1 + 2;", updated);
-        Assert.Contains("return _sum;", updated);
+        Assert.Contains("return this._sum;", updated);
     }
 
     [SkippableFact]
@@ -244,7 +244,7 @@ public class IntroduceFieldOperationTests
         Assert.True(result.Success);
         var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
         Assert.Contains("private int _value = 7;", updated);
-        Assert.Contains("return _value;", updated);
+        Assert.Contains("return this._value;", updated);
         Assert.DoesNotContain("int value = 7;", updated);
     }
 
@@ -283,8 +283,8 @@ public class IntroduceFieldOperationTests
         Assert.Contains("private int _answer;", updated);
         Assert.DoesNotContain("private int _answer = 42;", updated);
         Assert.Contains("public Calculator()", updated);
-        Assert.Contains("_answer = 42;", updated);
-        Assert.Contains("return _answer;", updated);
+        Assert.Contains("this._answer = 42;", updated);
+        Assert.Contains("return this._answer;", updated);
     }
 
     [SkippableFact]
@@ -328,7 +328,7 @@ public class IntroduceFieldOperationTests
 
         Assert.True(result.Success);
         var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
-        Assert.Contains("_answer = 42;", updated);
+        Assert.Contains("this._answer = 42;", updated);
         Assert.Contains("Warmup();", updated);
         Assert.Equal(1, CountOccurrences(updated, "public Calculator()"));
     }
@@ -589,6 +589,372 @@ public class IntroduceFieldOperationTests
             }));
 
         Assert.Equal(ErrorCodes.InvalidTargetType, ex.ErrorCode);
+    }
+
+    #endregion
+
+    #region Review follow-up regressions
+
+    [SkippableFact]
+    public async Task IntroduceField_ReplaceAll_DoesNotRewriteDifferentBindings()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public int Value { get; set; }
+
+                public int First()
+                {
+                    return Value + 1;
+                }
+
+                public int Second()
+                {
+                    int Value = 10;
+                    return Value + 1;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new IntroduceFieldOperation(workspace.Context);
+        var span = FindSpan(source, "Value + 1");
+
+        var result = await operation.ExecuteAsync(new IntroduceFieldParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = span.StartLine,
+            StartColumn = span.StartColumn,
+            EndLine = span.EndLine,
+            EndColumn = span.EndColumn,
+            FieldName = "_next",
+            ReplaceAll = true
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("private int _next = Value + 1;", updated);
+        Assert.Contains("return this._next;", updated);
+        Assert.Contains("int Value = 10;", updated);
+        Assert.Contains("return Value + 1;", updated);
+        Assert.Equal(1, CountOccurrences(updated, "return this._next;"));
+        Assert.Equal(1, CountOccurrences(updated, "return Value + 1;"));
+    }
+
+    [SkippableFact]
+    public async Task IntroduceField_ReplaceAll_RewritesSameBindings()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public int Value { get; set; }
+
+                public int First()
+                {
+                    return Value + 1;
+                }
+
+                public int Second()
+                {
+                    return Value + 1;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new IntroduceFieldOperation(workspace.Context);
+        var span = FindSpan(source, "Value + 1");
+
+        var result = await operation.ExecuteAsync(new IntroduceFieldParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = span.StartLine,
+            StartColumn = span.StartColumn,
+            EndLine = span.EndLine,
+            EndColumn = span.EndColumn,
+            FieldName = "_next",
+            ReplaceAll = true
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("private int _next = Value + 1;", updated);
+        Assert.Equal(2, CountOccurrences(updated, "return this._next;"));
+        Assert.DoesNotContain("return Value + 1;", updated);
+    }
+
+    [SkippableFact]
+    public async Task IntroduceField_ShadowingParameter_UsesThisQualifiedReference()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public int Get()
+                {
+                    int value = 7;
+                    return Apply(x =>
+                    {
+                        int _value = x;
+                        return value + _value;
+                    });
+                }
+
+                private static int Apply(System.Func<int, int> fn)
+                {
+                    return fn(1);
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new IntroduceFieldOperation(workspace.Context);
+        var span = FindSpan(source, "value = 7");
+
+        var result = await operation.ExecuteAsync(new IntroduceFieldParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = span.StartLine,
+            StartColumn = span.StartColumn,
+            EndLine = span.EndLine,
+            EndColumn = span.EndColumn,
+            FieldName = "_value"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("private int _value = 7;", updated);
+        Assert.Contains("return this._value + _value;", updated);
+        Assert.DoesNotContain("return value + _value;", updated);
+        Assert.DoesNotContain("int value = 7;", updated);
+    }
+
+    [SkippableFact]
+    public async Task IntroduceField_StaticField_UsesTypeQualifiedReference()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public static int Get()
+                {
+                    return 42;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new IntroduceFieldOperation(workspace.Context);
+        var span = FindSpan(source, "42");
+
+        var result = await operation.ExecuteAsync(new IntroduceFieldParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = span.StartLine,
+            StartColumn = span.StartColumn,
+            EndLine = span.EndLine,
+            EndColumn = span.EndColumn,
+            FieldName = "_answer",
+            IsStatic = true
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("private static int _answer = 42;", updated);
+        Assert.Contains("return Calculator._answer;", updated);
+        Assert.DoesNotContain("return 42;", updated);
+    }
+
+    [SkippableFact]
+    public async Task IntroduceField_UsingLocal_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public sealed class Resource : System.IDisposable
+            {
+                public int Value => 1;
+                public void Dispose()
+                {
+                }
+            }
+
+            public class Calculator
+            {
+                public int Get()
+                {
+                    using var resource = new Resource();
+                    return resource.Value;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new IntroduceFieldOperation(workspace.Context);
+        var span = FindSpan(source, "resource = new Resource()");
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new IntroduceFieldParams
+            {
+                SourceFile = workspace.SourcePath,
+                StartLine = span.StartLine,
+                StartColumn = span.StartColumn,
+                EndLine = span.EndLine,
+                EndColumn = span.EndColumn,
+                FieldName = "_resource"
+            }));
+
+        Assert.Equal(ErrorCodes.ExpressionNotFieldInitializable, ex.ErrorCode);
+        var unchanged = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("using var resource = new Resource();", unchanged);
+        Assert.DoesNotContain("private Resource _resource", unchanged);
+    }
+
+    [SkippableFact]
+    public async Task IntroduceField_AwaitUsingLocal_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public sealed class Resource : System.IAsyncDisposable
+            {
+                public int Value => 1;
+                public System.Threading.Tasks.ValueTask DisposeAsync()
+                {
+                    return System.Threading.Tasks.ValueTask.CompletedTask;
+                }
+            }
+
+            public class Calculator
+            {
+                public async System.Threading.Tasks.Task<int> Get()
+                {
+                    await using var resource = new Resource();
+                    return resource.Value;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new IntroduceFieldOperation(workspace.Context);
+        var span = FindSpan(source, "resource = new Resource()");
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new IntroduceFieldParams
+            {
+                SourceFile = workspace.SourcePath,
+                StartLine = span.StartLine,
+                StartColumn = span.StartColumn,
+                EndLine = span.EndLine,
+                EndColumn = span.EndColumn,
+                FieldName = "_resource"
+            }));
+
+        Assert.Equal(ErrorCodes.ExpressionNotFieldInitializable, ex.ErrorCode);
+        var unchanged = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("await using var resource = new Resource();", unchanged);
+    }
+
+    [SkippableFact]
+    public async Task IntroduceField_StaticInitializer_InsertsNewFieldBeforeSource()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                private static int A = Compute();
+
+                private static int Compute()
+                {
+                    return 1;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new IntroduceFieldOperation(workspace.Context);
+        var span = FindSpan(source, "Compute()");
+
+        var result = await operation.ExecuteAsync(new IntroduceFieldParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = span.StartLine,
+            StartColumn = span.StartColumn,
+            EndLine = span.EndLine,
+            EndColumn = span.EndColumn,
+            FieldName = "B",
+            IsStatic = true
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("private static int B = Compute();", updated);
+        Assert.Contains("private static int A = Calculator.B;", updated);
+        var bIndex = updated.IndexOf("private static int B = Compute();", StringComparison.Ordinal);
+        var aIndex = updated.IndexOf("private static int A = Calculator.B;", StringComparison.Ordinal);
+        Assert.True(bIndex >= 0 && aIndex > bIndex, "New static field B must be declared before A.");
+    }
+
+    [SkippableFact]
+    public async Task IntroduceField_DuplicateTypeName_UpdatesSelectedTypeOnly()
+    {
+        const string source = """
+            namespace TestApp
+            {
+                public class Calculator
+                {
+                    public int Get()
+                    {
+                        return 42;
+                    }
+                }
+            }
+
+            namespace Other
+            {
+                public class Calculator
+                {
+                    public int Get()
+                    {
+                        return 99;
+                    }
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new IntroduceFieldOperation(workspace.Context);
+        var span = FindSpan(source, "99");
+
+        var result = await operation.ExecuteAsync(new IntroduceFieldParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = span.StartLine,
+            StartColumn = span.StartColumn,
+            EndLine = span.EndLine,
+            EndColumn = span.EndColumn,
+            FieldName = "_answer"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Equal(1, CountOccurrences(updated, "private int _answer = 99;"));
+        Assert.Contains("return this._answer;", updated);
+        Assert.Contains("return 42;", updated);
+        Assert.DoesNotContain("return 99;", updated);
+
+        var testAppIndex = updated.IndexOf("namespace TestApp", StringComparison.Ordinal);
+        var otherIndex = updated.IndexOf("namespace Other", StringComparison.Ordinal);
+        var fieldIndex = updated.IndexOf("private int _answer = 99;", StringComparison.Ordinal);
+        Assert.True(testAppIndex >= 0 && otherIndex > testAppIndex);
+        Assert.True(fieldIndex > otherIndex, "Field must be inserted into Other.Calculator, not TestApp.Calculator.");
     }
 
     #endregion

--- a/tests/RoslynMcp.Server.Tests/Tools/IntroduceFieldToolTests.cs
+++ b/tests/RoslynMcp.Server.Tests/Tools/IntroduceFieldToolTests.cs
@@ -1,0 +1,147 @@
+using System.Text.Json;
+using RoslynMcp.Server.Tests.TestHelpers;
+using RoslynMcp.Server.Tools;
+using RoslynMcp.Server.Transport;
+using Xunit;
+
+namespace RoslynMcp.Server.Tests.Tools;
+
+/// <summary>
+/// Unit tests for IntroduceFieldTool.
+/// Tests tool definition and argument validation.
+/// </summary>
+public class IntroduceFieldToolTests
+{
+    private readonly IntroduceFieldTool _tool;
+
+    public IntroduceFieldToolTests()
+    {
+        _tool = new IntroduceFieldTool(new ThrowingWorkspaceProvider());
+    }
+
+    #region GetDefinition Tests
+
+    [Fact]
+    public void GetDefinition_ReturnsCorrectName()
+    {
+        Assert.Equal("introduce_field", _tool.Name);
+    }
+
+    [Fact]
+    public void GetDefinition_ReturnsNonEmptyDescription()
+    {
+        Assert.NotNull(_tool.Description);
+        Assert.NotEmpty(_tool.Description);
+    }
+
+    [Fact]
+    public void GetDefinition_ReturnsCorrectSchema()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.Equal("object", root.GetProperty("type").GetString());
+        Assert.True(root.TryGetProperty("properties", out _));
+        Assert.True(root.TryGetProperty("required", out _));
+    }
+
+    [Fact]
+    public void GetDefinition_HasRequiredFields()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var required = doc.RootElement.GetProperty("required");
+
+        var requiredFields = new List<string>();
+        foreach (var item in required.EnumerateArray())
+        {
+            requiredFields.Add(item.GetString()!);
+        }
+
+        Assert.Contains("solutionPath", requiredFields);
+        Assert.Contains("sourceFile", requiredFields);
+        Assert.Contains("startLine", requiredFields);
+        Assert.Contains("startColumn", requiredFields);
+        Assert.Contains("endLine", requiredFields);
+        Assert.Contains("endColumn", requiredFields);
+        Assert.Contains("fieldName", requiredFields);
+    }
+
+    [Fact]
+    public void GetDefinition_HasProperties_ForAllParameters()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var properties = doc.RootElement.GetProperty("properties");
+
+        Assert.True(properties.TryGetProperty("solutionPath", out _));
+        Assert.True(properties.TryGetProperty("sourceFile", out _));
+        Assert.True(properties.TryGetProperty("startLine", out _));
+        Assert.True(properties.TryGetProperty("startColumn", out _));
+        Assert.True(properties.TryGetProperty("endLine", out _));
+        Assert.True(properties.TryGetProperty("endColumn", out _));
+        Assert.True(properties.TryGetProperty("fieldName", out _));
+        Assert.True(properties.TryGetProperty("isReadonly", out _));
+        Assert.True(properties.TryGetProperty("isStatic", out _));
+        Assert.True(properties.TryGetProperty("initializeInConstructor", out _));
+        Assert.True(properties.TryGetProperty("replaceAll", out _));
+        Assert.True(properties.TryGetProperty("preview", out _));
+    }
+
+    #endregion
+
+    #region ExecuteAsync Argument Validation Tests
+
+    [Fact]
+    public async Task ExecuteAsync_NullArguments_ReturnsError()
+    {
+        var result = await _tool.ExecuteAsync(null);
+
+        Assert.True(result.IsError);
+        Assert.Contains("Arguments required", GetResultText(result));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EmptyArguments_ReturnsError()
+    {
+        var args = JsonDocument.Parse("{}").RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MissingRequiredField_ReturnsError()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "solutionPath": "C:/test/test.sln",
+                "sourceFile": "C:/test/Test.cs",
+                "startLine": 10,
+                "startColumn": 5,
+                "endLine": 10,
+                "endColumn": 20
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static string GetResultText(ToolResult result)
+    {
+        return result.Content.FirstOrDefault()?.Text ?? string.Empty;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds `introduce_field` / `IntroduceFieldOperation`: turn a selected local variable or expression into a class field, replace the original with a field reference, and optionally initialize the field in a constructor.

This is the next Phase 2 increment after `use_base_type` (PR #37 / issue #36), following Arch §10 (lowest remaining risk) and the existing `extract_*` / `introduce_parameter` / `use_base_type` patterns.

## Related Issues

Closes #38

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Bug fix (review follow-up correctness holes)
- [x] Test additions or updates
- [x] Documentation update

## What landed

- Field declaration created; selected expression or local replaced with a field reference
- Optional constructor initialization (`initializeInConstructor`)
- Preview mode (no disk writes)
- Rejects: no expression, uneditable documents, invalid target type (interface / instance field from static member), name collision, local capture
- MCP + CLI wiring (`introduce_field` / `introduce-field`)
- Tool-count updates (45 → 46)

## Review follow-up (Verify.R2)

Addresses the five Copilot/Codex TAKEs on this PR:

1. **replaceAll semantic match** — `FindMatchingExpressions` now requires the same identifier bindings (`SymbolEqualityComparer`), not only normalized text. Identical `Value + 1` in another method is left alone when `Value` is a different local/member.
2. **Qualify field references** — instance replacements emit `this.field`; static replacements emit `Type.field`. Constructor assignment LHS uses the same qualification so a shadowing parameter/local cannot steal the binding.
3. **Reject using / await using locals** — `FindPromotableLocal` rejects `using var` / `await using` with `ExpressionNotFieldInitializable`. The declaration is left in place; no disposal-on-field.
4. **Static field insert order** — when the rewritten expression is a static field initializer, the new static field is inserted *before* that source field so `A = B` cannot run before `B = Compute()`.
5. **Containing-type lookup** — `ApplyPlan` annotates the type from the plan nodes (`GetContainingTypeOrThrow`) and replaces that annotated node. No `First` by type name.

## Testing

- [x] New tests added for happy path + rejects + the five review regressions
- [x] All existing tests pass
- [x] Format / quality / warnings-as-errors pass locally

**Test Configuration**:
- OS: Linux
- .NET Version: 9.0.317

**Local results** (head `052c2d4`):
- `IntroduceFieldOperationTests`: 28 passed (20 prior + 8 review regressions)
- Full suite: Core 396 + Server 369 + CLI 95 = 860 passed, 0 failed
- `dotnet format --verify-no-changes`: passed
- `TreatWarningsAsErrors` + `EnforceCodeStyleInBuild`: 0 warnings

## Checklist

- [x] Code follows existing extract/introduce/use_base_type patterns
- [x] XML documentation for public APIs
- [x] README / CHANGELOG / tool-count updates
- [x] Tests for happy path + P0 rejects + review follow-up regressions
- [x] Format / quality / build tests pass locally
- [x] Preview, P0 rejects, MCP/CLI wiring kept; Dependabot left alone
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e423423-d4da-46d3-91d5-93ee5a720ee7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e423423-d4da-46d3-91d5-93ee5a720ee7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

