### PR TITLE
Add safe_delete refactoring

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "roslyn-mcp",
   "version": "0.4.1",
-  "description": "Roslyn-powered C# refactoring MCP server — 46 tools for code navigation, analysis, generation, and refactoring across entire .NET solutions",
+  "description": "Roslyn-powered C# refactoring MCP server — 47 tools for code navigation, analysis, generation, and refactoring across entire .NET solutions",
   "author": {
     "name": "Joshua Ramirez"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - `push_members_down` — move selected members from a base type down onto derived types, with optional named targets, preview mode, and rejects for missing derived types, conflicts, interface-incompatible members, and uneditable targets
 - `use_base_type` — replace derived-type references with a compatible base type or interface, rewriting only usages whose members exist on that base, with preview mode and rejects for missing bases, uneditable documents, and no eligible references
 - `introduce_field` — turn a selected local variable or expression into a class field, optionally initializing it in a constructor, with preview mode and rejects for missing expressions, uneditable documents, and invalid target types
+- `safe_delete` — delete a selected symbol only when it has no remaining references, with preview mode and rejects that include usage locations, missing symbols, and uneditable documents
 
 ## [0.4.0] - 2026-02-23
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Let AI assistants like Claude safely refactor your C# codebase using the same Roslyn compiler platform that powers Visual Studio.
 
-Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that exposes **46 Roslyn-powered tools** to AI assistants and other MCP clients. It combines 24 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 7 code conversion tools -- giving your AI deep code intelligence, comprehensive refactoring, and modern C# syntax transformations with full solution-wide reference tracking and preview support.
+Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that exposes **47 Roslyn-powered tools** to AI assistants and other MCP clients. It combines 25 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 7 code conversion tools -- giving your AI deep code intelligence, comprehensive refactoring, and modern C# syntax transformations with full solution-wide reference tracking and preview support.
 
 ---
 
@@ -30,7 +30,7 @@ Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotoc
 
 ## Why RoslynMcpServer?
 
-- **46 tools** -- refactoring, navigation, analysis, generation, and conversion tools, the most comprehensive Roslyn MCP server available
+- **47 tools** -- refactoring, navigation, analysis, generation, and conversion tools, the most comprehensive Roslyn MCP server available
 - **Preview mode on every operation** -- see exactly what will change before applying
 - **Atomic file writes with rollback** -- if any file write fails, all changes are reverted
 - **Solution-wide reference updates** -- renames and moves propagate across your entire solution
@@ -102,7 +102,7 @@ Claude will use the `rename_symbol` tool to rename the class and update every re
 
 ## Standalone CLI
 
-All 46 tools are also available as a standalone CLI for use in scripts, CI/CD pipelines, and terminals without an AI assistant.
+All 47 tools are also available as a standalone CLI for use in scripts, CI/CD pipelines, and terminals without an AI assistant.
 
 ### Install
 
@@ -205,6 +205,7 @@ All tools accept a `solutionPath` parameter (absolute path to a `.sln`, `.slnx`,
 | `push_members_down` | Move selected members from a base type down onto derived types. | `sourceFile`, `typeName`, `members`, `targetDerivedTypes`, `leaveAbstract` |
 | `use_base_type` | Replace derived-type references with a compatible base type or interface. | `sourceFile`, `typeName`, `targetBaseType` |
 | `introduce_field` | Turn a selected local variable or expression into a class field, optionally initializing it in a constructor. | `sourceFile`, `startLine`, `startColumn`, `endLine`, `endColumn`, `fieldName`, `isReadonly`, `isStatic`, `initializeInConstructor`, `replaceAll` |
+| `safe_delete` | Delete a selected symbol only when it has no remaining references. If usages exist, reject with their locations. | `sourceFile`, `startLine`, `startColumn`, `endLine`, `endColumn`, `symbolName` |
 
 ### Inline
 

--- a/src/RoslynMcp.Cli/ToolRegistry.cs
+++ b/src/RoslynMcp.Cli/ToolRegistry.cs
@@ -47,7 +47,7 @@ public sealed class ToolEntry
 }
 
 /// <summary>
-/// Maps tool names to execution delegates for all 46 Roslyn tools.
+/// Maps tool names to execution delegates for all 47 Roslyn tools.
 /// </summary>
 public sealed class ToolRegistry
 {
@@ -139,7 +139,7 @@ public sealed class ToolRegistry
         _tools.Values.OrderBy(t => t.Category).ThenBy(t => t.Name).ToList();
 
     /// <summary>
-    /// Build the default registry with all 46 tools registered.
+    /// Build the default registry with all 47 tools registered.
     /// </summary>
     public static ToolRegistry BuildDefault()
     {
@@ -166,6 +166,8 @@ public sealed class ToolRegistry
             "use-base-type", "Replace derived-type references with a compatible base type or interface");
         r.RegisterRefactoring<IntroduceFieldOperation, IntroduceFieldParams>(
             "introduce-field", "Turn a selected local variable or expression into a class field");
+        r.RegisterRefactoring<SafeDeleteOperation, SafeDeleteParams>(
+            "safe-delete", "Delete a selected symbol only when it has no remaining references");
 
         // ── Refactoring: Rename (1) ───────────────────────────────────
         r.RegisterRefactoring<RenameSymbolOperation, RenameSymbolParams>(

--- a/src/RoslynMcp.Contracts/Enums/RefactoringKind.cs
+++ b/src/RoslynMcp.Contracts/Enums/RefactoringKind.cs
@@ -44,6 +44,9 @@ public enum RefactoringKind
     /// <summary>Promote a local variable or expression to a class field.</summary>
     IntroduceField,
 
+    /// <summary>Delete a symbol only when it has no remaining references.</summary>
+    SafeDelete,
+
     /// <summary>Extract expression to variable.</summary>
     ExtractVariable,
 

--- a/src/RoslynMcp.Contracts/Errors/ErrorCodes.cs
+++ b/src/RoslynMcp.Contracts/Errors/ErrorCodes.cs
@@ -361,6 +361,13 @@ public static class ErrorCodes
     /// <summary>Expression captures local variable or parameter state.</summary>
     public const string ExpressionCapturesLocal = "3118";
 
+    // --------------------------------------------
+    // Safe Delete Errors (3119)
+    // --------------------------------------------
+
+    /// <summary>Cannot safely delete the symbol because remaining references exist.</summary>
+    public const string MemberHasUsages = "3119";
+
     // ============================================
     // System Errors (4xxx)
     // ============================================

--- a/src/RoslynMcp.Contracts/Models/SafeDeleteParams.cs
+++ b/src/RoslynMcp.Contracts/Models/SafeDeleteParams.cs
@@ -1,0 +1,42 @@
+namespace RoslynMcp.Contracts.Models;
+
+/// <summary>
+/// Parameters for the safe_delete tool.
+/// </summary>
+public sealed class SafeDeleteParams
+{
+    /// <summary>
+    /// Absolute path to the source file.
+    /// </summary>
+    public required string SourceFile { get; init; }
+
+    /// <summary>
+    /// Start line of the selected symbol (1-based).
+    /// </summary>
+    public required int StartLine { get; init; }
+
+    /// <summary>
+    /// Start column of the selected symbol (1-based).
+    /// </summary>
+    public required int StartColumn { get; init; }
+
+    /// <summary>
+    /// End line of the selected symbol (1-based).
+    /// </summary>
+    public required int EndLine { get; init; }
+
+    /// <summary>
+    /// End column of the selected symbol (1-based).
+    /// </summary>
+    public required int EndColumn { get; init; }
+
+    /// <summary>
+    /// Optional symbol name used to confirm the selection.
+    /// </summary>
+    public string? SymbolName { get; init; }
+
+    /// <summary>
+    /// Return computed changes without applying. Default: false.
+    /// </summary>
+    public bool Preview { get; init; }
+}

--- a/src/RoslynMcp.Core/Refactoring/Extract/SafeDeleteOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/SafeDeleteOperation.cs
@@ -1,0 +1,471 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Text;
+using RoslynMcp.Contracts.Enums;
+using RoslynMcp.Contracts.Errors;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.FileSystem;
+using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Resolution;
+using RoslynMcp.Core.Workspace;
+
+namespace RoslynMcp.Core.Refactoring.Extract;
+
+/// <summary>
+/// Deletes a selected symbol only when it has no remaining references.
+/// Remaining usages are reported as an error with locations; no force-delete
+/// or reference cleanup is performed.
+/// </summary>
+public sealed class SafeDeleteOperation : RefactoringOperationBase<SafeDeleteParams>
+{
+    /// <summary>
+    /// Creates a new safe-delete operation.
+    /// </summary>
+    public SafeDeleteOperation(WorkspaceContext context) : base(context)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override void ValidateParams(SafeDeleteParams @params) => Validate(@params);
+
+    /// <summary>
+    /// Validates safe-delete parameters. Internal so tests can exercise
+    /// input rules without loading a workspace.
+    /// </summary>
+    internal static void Validate(SafeDeleteParams @params)
+    {
+        if (string.IsNullOrWhiteSpace(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "sourceFile is required.");
+
+        if (!PathResolver.IsAbsolutePath(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.InvalidSourcePath, "sourceFile must be an absolute path.");
+
+        if (!PathResolver.IsValidCSharpFilePath(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.InvalidSourcePath, "sourceFile must be a .cs file.");
+
+        if (@params.StartLine < 1)
+            throw new RefactoringException(ErrorCodes.InvalidLineNumber, "startLine must be >= 1.");
+
+        if (@params.StartColumn < 1)
+            throw new RefactoringException(ErrorCodes.InvalidColumnNumber, "startColumn must be >= 1.");
+
+        if (@params.EndLine < 1)
+            throw new RefactoringException(ErrorCodes.InvalidLineNumber, "endLine must be >= 1.");
+
+        if (@params.EndColumn < 1)
+            throw new RefactoringException(ErrorCodes.InvalidColumnNumber, "endColumn must be >= 1.");
+
+        if (@params.EndLine < @params.StartLine ||
+            (@params.EndLine == @params.StartLine && @params.EndColumn < @params.StartColumn))
+            throw new RefactoringException(ErrorCodes.InvalidSelectionRange, "End must be after start.");
+
+        if (!File.Exists(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.SourceFileNotFound, $"Source file not found: {@params.SourceFile}");
+    }
+
+    /// <summary>
+    /// Rejects documents that cannot receive source edits.
+    /// </summary>
+    internal static void ValidateDocumentIsEditable(Document document, Microsoft.CodeAnalysis.Workspace workspace)
+    {
+        if (document is SourceGeneratedDocument)
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable (source-generated).");
+        }
+
+        if (string.IsNullOrWhiteSpace(document.FilePath) || !File.Exists(document.FilePath))
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable.");
+        }
+
+        if (!workspace.CanApplyChange(ApplyChangesKind.ChangeDocument))
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable (workspace cannot apply changes).");
+        }
+    }
+
+    /// <inheritdoc />
+    protected override async Task<RefactoringResult> ExecuteCoreAsync(
+        Guid operationId,
+        SafeDeleteParams @params,
+        CancellationToken cancellationToken)
+    {
+        var document = GetDocumentOrThrow(@params.SourceFile);
+        ValidateDocumentIsEditable(document, Context.Workspace);
+
+        var root = await document.GetSyntaxRootAsync(cancellationToken);
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken);
+        if (root == null || semanticModel == null)
+            throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse file.");
+
+        var sourceText = await document.GetTextAsync(cancellationToken);
+        var span = GetSelectionSpan(sourceText, @params);
+        var symbol = await ResolveSelectedSymbolAsync(
+            document, root, semanticModel, span, @params, cancellationToken);
+
+        symbol = NormalizeDeletableSymbol(symbol);
+        ValidateSymbolCanBeDeleted(symbol);
+
+        var declarationDocuments = await GetDeclarationDocumentsAsync(symbol, cancellationToken);
+        foreach (var declarationDocument in declarationDocuments)
+            ValidateDocumentIsEditable(declarationDocument, Context.Workspace);
+
+        var usages = await FindUsagesAsync(symbol, cancellationToken);
+        if (!CanSafelyDelete(usages))
+            throw CreateHasUsagesException(symbol, usages);
+
+        var plan = await BuildPlanAsync(symbol, cancellationToken);
+        if (@params.Preview)
+            return CreatePreviewResult(operationId, plan);
+
+        var newSolution = await ApplyPlanAsync(Context.Solution, plan, cancellationToken);
+        var commitResult = await CommitChangesAsync(newSolution, cancellationToken);
+
+        return RefactoringResult.Succeeded(
+            operationId,
+            new FileChanges
+            {
+                FilesModified = commitResult.FilesModified,
+                FilesCreated = commitResult.FilesCreated,
+                FilesDeleted = commitResult.FilesDeleted
+            },
+            new Contracts.Models.SymbolInfo
+            {
+                Name = symbol.Name,
+                FullyQualifiedName = symbol.ToDisplayString(),
+                Kind = SymbolKindMapper.Map(symbol)
+            },
+            0,
+            0);
+    }
+
+    internal static TextSpan GetSelectionSpan(SourceText sourceText, SafeDeleteParams @params)
+    {
+        if (@params.StartLine > sourceText.Lines.Count || @params.EndLine > sourceText.Lines.Count)
+            throw new RefactoringException(ErrorCodes.InvalidLineNumber, "Selection is outside the file.");
+
+        var startLine = sourceText.Lines[@params.StartLine - 1];
+        var endLine = sourceText.Lines[@params.EndLine - 1];
+        if (@params.StartColumn - 1 > startLine.Span.Length || @params.EndColumn - 1 > endLine.SpanIncludingLineBreak.Length)
+            throw new RefactoringException(ErrorCodes.InvalidColumnNumber, "Selection column is outside the line.");
+
+        var startPosition = startLine.Start + @params.StartColumn - 1;
+        var endPosition = endLine.Start + @params.EndColumn - 1;
+        if (endPosition < startPosition)
+            throw new RefactoringException(ErrorCodes.InvalidSelectionRange, "End must be after start.");
+
+        return TextSpan.FromBounds(startPosition, endPosition);
+    }
+
+    private async Task<ISymbol> ResolveSelectedSymbolAsync(
+        Document document,
+        SyntaxNode root,
+        SemanticModel semanticModel,
+        TextSpan span,
+        SafeDeleteParams @params,
+        CancellationToken cancellationToken)
+    {
+        var node = root.FindNode(span, getInnermostNodeForTie: true);
+        for (var current = node; current != null; current = current.Parent)
+        {
+            var declared = semanticModel.GetDeclaredSymbol(current, cancellationToken);
+            if (declared != null && SelectionCoversDeclaration(current, span))
+                return ConfirmSymbolName(declared, @params.SymbolName);
+        }
+
+        var symbolInfo = semanticModel.GetSymbolInfo(node, cancellationToken);
+        if (symbolInfo.Symbol != null)
+            return ConfirmSymbolName(symbolInfo.Symbol, @params.SymbolName);
+
+        var resolver = Context.CreateGeneralSymbolResolver();
+        try
+        {
+            var resolved = await resolver.ResolveAtPositionAsync(
+                document, @params.StartLine, @params.StartColumn, cancellationToken);
+            return ConfirmSymbolName(resolved.Symbol, @params.SymbolName);
+        }
+        catch (RefactoringException ex) when (ex.ErrorCode == ErrorCodes.SymbolNotFound)
+        {
+            throw new RefactoringException(
+                ErrorCodes.SymbolNotFound,
+                "No symbol found at the specified selection.");
+        }
+    }
+
+    private static ISymbol ConfirmSymbolName(ISymbol symbol, string? expectedName)
+    {
+        if (!string.IsNullOrWhiteSpace(expectedName) && symbol.Name != expectedName)
+        {
+            throw new RefactoringException(
+                ErrorCodes.SymbolNotFound,
+                $"No symbol named '{expectedName}' found at the specified selection.");
+        }
+
+        return symbol;
+    }
+
+    private static bool SelectionCoversDeclaration(SyntaxNode declaration, TextSpan span)
+    {
+        return declaration.Span.Contains(span) || span.Contains(declaration.Span) || declaration.Span.OverlapsWith(span);
+    }
+
+    private static ISymbol NormalizeDeletableSymbol(ISymbol symbol)
+    {
+        symbol = symbol.OriginalDefinition;
+
+        if (symbol is IMethodSymbol { AssociatedSymbol: { } associated } &&
+            associated.Kind is Microsoft.CodeAnalysis.SymbolKind.Property or Microsoft.CodeAnalysis.SymbolKind.Event)
+        {
+            return associated.OriginalDefinition;
+        }
+
+        return symbol;
+    }
+
+    private static void ValidateSymbolCanBeDeleted(ISymbol symbol)
+    {
+        if (symbol.Kind is Microsoft.CodeAnalysis.SymbolKind.Namespace
+            or Microsoft.CodeAnalysis.SymbolKind.NetModule
+            or Microsoft.CodeAnalysis.SymbolKind.Assembly)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidSymbolKind,
+                $"Symbol '{symbol.Name}' cannot be safe-deleted.");
+        }
+
+        if (symbol is IParameterSymbol or ITypeParameterSymbol)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidSymbolKind,
+                $"Symbol '{symbol.Name}' cannot be safe-deleted without changing a signature.");
+        }
+
+        if (!symbol.Locations.Any(location => location.IsInSource))
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Symbol '{symbol.Name}' is not in an editable document.");
+        }
+    }
+
+    private async Task<IReadOnlyList<Document>> GetDeclarationDocumentsAsync(
+        ISymbol symbol,
+        CancellationToken cancellationToken)
+    {
+        var documents = new List<Document>();
+        foreach (var reference in symbol.DeclaringSyntaxReferences)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var syntax = await reference.GetSyntaxAsync(cancellationToken);
+            var document = Context.Solution.GetDocument(syntax.SyntaxTree);
+            if (document == null)
+            {
+                throw new RefactoringException(
+                    ErrorCodes.DocumentNotEditable,
+                    $"Declaration of '{symbol.Name}' is not in an editable document.");
+            }
+
+            documents.Add(document);
+        }
+
+        if (documents.Count == 0)
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Symbol '{symbol.Name}' is not in an editable document.");
+        }
+
+        return documents;
+    }
+
+    private async Task<IReadOnlyList<UsageLocation>> FindUsagesAsync(
+        ISymbol symbol,
+        CancellationToken cancellationToken)
+    {
+        var references = await SymbolFinder.FindReferencesAsync(
+            symbol, Context.Solution, cancellationToken);
+        var usages = new List<UsageLocation>();
+
+        foreach (var referencedSymbol in references)
+        {
+            foreach (var location in referencedSymbol.Locations)
+            {
+                if (location.Document == null || !location.Location.IsInSource)
+                    continue;
+
+                if (IsDefinitionLocation(referencedSymbol.Definition, location.Location))
+                    continue;
+
+                var lineSpan = location.Location.GetLineSpan();
+                usages.Add(new UsageLocation(
+                    location.Document.FilePath ?? lineSpan.Path,
+                    lineSpan.StartLinePosition.Line + 1,
+                    lineSpan.StartLinePosition.Character + 1,
+                    GetSnippet(location.Location)));
+            }
+        }
+
+        return usages;
+    }
+
+    private static bool CanSafelyDelete(IReadOnlyList<UsageLocation> usages) => usages.Count == 0;
+
+    private static bool IsDefinitionLocation(ISymbol symbol, Location location)
+    {
+        return symbol.Locations.Any(definition =>
+            definition.IsInSource &&
+            definition.SourceTree == location.SourceTree &&
+            definition.SourceSpan == location.SourceSpan);
+    }
+
+    private static string? GetSnippet(Location location)
+    {
+        if (location.SourceTree == null)
+            return null;
+
+        var text = location.SourceTree.GetText();
+        var line = location.GetLineSpan().StartLinePosition.Line;
+        if (line < 0 || line >= text.Lines.Count)
+            return null;
+
+        return text.Lines[line].ToString().Trim();
+    }
+
+    private static RefactoringException CreateHasUsagesException(
+        ISymbol symbol,
+        IReadOnlyList<UsageLocation> usages)
+    {
+        var locations = usages
+            .Select(usage => new Dictionary<string, object>
+            {
+                ["file"] = usage.File,
+                ["line"] = usage.Line,
+                ["column"] = usage.Column,
+                ["snippet"] = usage.Snippet ?? string.Empty
+            })
+            .ToList();
+
+        return new RefactoringException(
+            ErrorCodes.MemberHasUsages,
+            $"Cannot safely delete '{symbol.Name}' because it has {usages.Count} remaining reference(s).",
+            new Dictionary<string, object>
+            {
+                ["symbolName"] = symbol.Name,
+                ["usageCount"] = usages.Count,
+                ["locations"] = locations
+            },
+            ["Remove or update the remaining references, then retry."]);
+    }
+
+    private static async Task<DeletePlan> BuildPlanAsync(ISymbol symbol, CancellationToken cancellationToken)
+    {
+        var removals = new List<NodeRemoval>();
+        foreach (var reference in symbol.DeclaringSyntaxReferences)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var syntax = await reference.GetSyntaxAsync(cancellationToken);
+            var removable = GetRemovableNode(syntax);
+            removals.Add(new NodeRemoval(removable.SyntaxTree, removable.Span, removable.ToFullString().Trim()));
+        }
+
+        if (removals.Count == 0)
+        {
+            throw new RefactoringException(
+                ErrorCodes.RoslynError,
+                $"Could not locate a declaration to delete for '{symbol.Name}'.");
+        }
+
+        return new DeletePlan(symbol.Name, symbol.ToDisplayString(), SymbolKindMapper.Map(symbol), removals);
+    }
+
+    private static SyntaxNode GetRemovableNode(SyntaxNode declaration)
+    {
+        if (declaration is VariableDeclaratorSyntax declarator)
+        {
+            if (declarator.Parent is VariableDeclarationSyntax { Variables.Count: 1 } variableDeclaration)
+            {
+                if (variableDeclaration.Parent is FieldDeclarationSyntax or EventFieldDeclarationSyntax
+                    or LocalDeclarationStatementSyntax)
+                {
+                    return variableDeclaration.Parent;
+                }
+            }
+
+            return declarator;
+        }
+
+        if (declaration is MemberDeclarationSyntax member)
+            return member;
+
+        if (declaration is LocalFunctionStatementSyntax localFunction)
+            return localFunction;
+
+        return declaration.FirstAncestorOrSelf<MemberDeclarationSyntax>()
+            ?? declaration.FirstAncestorOrSelf<LocalDeclarationStatementSyntax>()
+            ?? declaration;
+    }
+
+    private static async Task<Solution> ApplyPlanAsync(
+        Solution solution,
+        DeletePlan plan,
+        CancellationToken cancellationToken)
+    {
+        foreach (var group in plan.Removals.GroupBy(removal => removal.SyntaxTree))
+        {
+            var document = solution.GetDocument(group.Key)
+                ?? throw new RefactoringException(
+                    ErrorCodes.DocumentNotEditable,
+                    "A declaration document is no longer in the workspace.");
+
+            var root = await document.GetSyntaxRootAsync(cancellationToken)
+                ?? throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse file.");
+
+            var nodes = group
+                .Select(removal => root.DescendantNodesAndSelf()
+                    .FirstOrDefault(node => node.Span == removal.Span)
+                    ?? GetRemovableNode(root.FindNode(removal.Span, getInnermostNodeForTie: true)))
+                .Distinct()
+                .ToList();
+
+            var newRoot = root.RemoveNodes(nodes, SyntaxRemoveOptions.KeepNoTrivia)
+                ?? throw new RefactoringException(ErrorCodes.RoslynError, "Deleting the symbol produced an empty document root.");
+
+            solution = document.WithSyntaxRoot(newRoot).Project.Solution;
+        }
+
+        return solution;
+    }
+
+    private static RefactoringResult CreatePreviewResult(Guid operationId, DeletePlan plan)
+    {
+        var pendingChanges = plan.Removals
+            .Select(removal => new PendingChange
+            {
+                File = removal.SyntaxTree.FilePath ?? string.Empty,
+                ChangeType = ChangeKind.Modify,
+                Description = $"Delete unused {plan.Kind.ToString().ToLowerInvariant()} '{plan.Name}'",
+                BeforeSnippet = removal.Text,
+                AfterSnippet = "// (removed)"
+            })
+            .ToList();
+
+        return RefactoringResult.PreviewResult(operationId, pendingChanges);
+    }
+
+    private sealed record UsageLocation(string File, int Line, int Column, string? Snippet);
+
+    private sealed record NodeRemoval(SyntaxTree SyntaxTree, TextSpan Span, string Text);
+
+    private sealed record DeletePlan(
+        string Name,
+        string FullyQualifiedName,
+        Contracts.Enums.SymbolKind Kind,
+        IReadOnlyList<NodeRemoval> Removals);
+}

--- a/src/RoslynMcp.Core/Refactoring/Extract/SafeDeleteOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/SafeDeleteOperation.cs
@@ -216,10 +216,8 @@ public sealed class SafeDeleteOperation : RefactoringOperationBase<SafeDeletePar
     private static bool IdentifierOverlaps(SyntaxNode node, TextSpan span)
     {
         var identifier = GetDeclarationIdentifier(node);
-        if (identifier != null)
-            return identifier.Value.Span.OverlapsWith(span) || span.OverlapsWith(identifier.Value.Span);
-
-        return node is MemberDeclarationSyntax && node.Span.OverlapsWith(span);
+        return identifier != null &&
+            (identifier.Value.Span.OverlapsWith(span) || span.OverlapsWith(identifier.Value.Span));
     }
 
     private static SyntaxToken? GetDeclarationIdentifier(SyntaxNode node) => node switch
@@ -236,6 +234,10 @@ public sealed class SafeDeleteOperation : RefactoringOperationBase<SafeDeletePar
         LocalFunctionStatementSyntax localFunction => localFunction.Identifier,
         ConstructorDeclarationSyntax constructor => constructor.Identifier,
         DestructorDeclarationSyntax destructor => destructor.Identifier,
+        CatchDeclarationSyntax catchDeclaration => catchDeclaration.Identifier,
+        ForEachStatementSyntax forEach => forEach.Identifier,
+        SingleVariableDesignationSyntax designation => designation.Identifier,
+        LabeledStatementSyntax labeled => labeled.Identifier,
         _ => null
     };
 
@@ -335,7 +337,93 @@ public sealed class SafeDeleteOperation : RefactoringOperationBase<SafeDeletePar
             }
         }
 
+        usages.AddRange(FindContractObligations(symbol));
         return usages;
+    }
+
+    private static IReadOnlyList<UsageLocation> FindContractObligations(ISymbol symbol)
+    {
+        var obligations = new List<UsageLocation>();
+
+        switch (symbol)
+        {
+            case IMethodSymbol method:
+                AddOverrideObligation(obligations, method.OverriddenMethod, method.IsOverride);
+                AddExplicitImplementations(obligations, method.ExplicitInterfaceImplementations);
+                AddImplicitInterfaceImplementations(obligations, method);
+                break;
+            case IPropertySymbol property:
+                AddOverrideObligation(obligations, property.OverriddenProperty, property.IsOverride);
+                AddExplicitImplementations(obligations, property.ExplicitInterfaceImplementations);
+                AddImplicitInterfaceImplementations(obligations, property);
+                break;
+            case IEventSymbol @event:
+                AddOverrideObligation(obligations, @event.OverriddenEvent, @event.IsOverride);
+                AddExplicitImplementations(obligations, @event.ExplicitInterfaceImplementations);
+                AddImplicitInterfaceImplementations(obligations, @event);
+                break;
+        }
+
+        return obligations;
+    }
+
+    private static void AddOverrideObligation(List<UsageLocation> usages, ISymbol? overridden, bool isOverride)
+    {
+        if (!isOverride || overridden == null)
+            return;
+
+        usages.Add(ToContractUsage(overridden, "overrides"));
+    }
+
+    private static void AddExplicitImplementations(List<UsageLocation> usages, IEnumerable<ISymbol> implementations)
+    {
+        foreach (var implemented in implementations)
+            usages.Add(ToContractUsage(implemented, "implements"));
+    }
+
+    private static void AddImplicitInterfaceImplementations(List<UsageLocation> usages, ISymbol symbol)
+    {
+        if (symbol.ContainingType == null)
+            return;
+
+        foreach (var iface in symbol.ContainingType.AllInterfaces)
+        {
+            foreach (var member in iface.GetMembers(symbol.Name))
+            {
+                var implementation = symbol.ContainingType.FindImplementationForInterfaceMember(member);
+                if (implementation == null)
+                    continue;
+
+                if (!SymbolEqualityComparer.Default.Equals(implementation, symbol) &&
+                    !SymbolEqualityComparer.Default.Equals(implementation.OriginalDefinition, symbol.OriginalDefinition))
+                {
+                    continue;
+                }
+
+                usages.Add(ToContractUsage(member, "implements"));
+            }
+        }
+    }
+
+    private static UsageLocation ToContractUsage(ISymbol contractMember, string relation)
+    {
+        var location = contractMember.Locations.FirstOrDefault(candidate => candidate.IsInSource);
+        var display = contractMember.ToDisplayString();
+        if (location == null)
+        {
+            return new UsageLocation(
+                contractMember.ContainingType?.ToDisplayString() ?? display,
+                0,
+                0,
+                $"{relation} {display}");
+        }
+
+        var lineSpan = location.GetLineSpan();
+        return new UsageLocation(
+            lineSpan.Path,
+            lineSpan.StartLinePosition.Line + 1,
+            lineSpan.StartLinePosition.Character + 1,
+            $"{relation} {display}");
     }
 
     private static bool CanSafelyDelete(IReadOnlyList<UsageLocation> usages) => usages.Count == 0;
@@ -410,18 +498,14 @@ public sealed class SafeDeleteOperation : RefactoringOperationBase<SafeDeletePar
 
     private static SyntaxNode GetRemovableNode(SyntaxNode declaration)
     {
-        if (declaration is VariableDeclaratorSyntax declarator)
+        if (declaration is VariableDeclaratorSyntax declarator &&
+            declarator.Parent is VariableDeclarationSyntax variableDeclaration &&
+            variableDeclaration.Parent is FieldDeclarationSyntax or EventFieldDeclarationSyntax
+                or LocalDeclarationStatementSyntax)
         {
-            if (declarator.Parent is VariableDeclarationSyntax { Variables.Count: 1 } variableDeclaration)
-            {
-                if (variableDeclaration.Parent is FieldDeclarationSyntax or EventFieldDeclarationSyntax
-                    or LocalDeclarationStatementSyntax)
-                {
-                    return variableDeclaration.Parent;
-                }
-            }
-
-            return declarator;
+            return variableDeclaration.Variables.Count == 1
+                ? variableDeclaration.Parent
+                : declarator;
         }
 
         if (declaration is MemberDeclarationSyntax member)
@@ -430,9 +514,10 @@ public sealed class SafeDeleteOperation : RefactoringOperationBase<SafeDeletePar
         if (declaration is LocalFunctionStatementSyntax localFunction)
             return localFunction;
 
-        return declaration.FirstAncestorOrSelf<MemberDeclarationSyntax>()
-            ?? declaration.FirstAncestorOrSelf<LocalDeclarationStatementSyntax>()
-            ?? declaration;
+        var name = GetDeclarationIdentifier(declaration)?.Text ?? declaration.Kind().ToString();
+        throw new RefactoringException(
+            ErrorCodes.InvalidSymbolKind,
+            $"Declaration '{name}' is not a form that can be safely deleted.");
     }
 
     private static async Task<Solution> ApplyPlanAsync(

--- a/src/RoslynMcp.Core/Refactoring/Extract/SafeDeleteOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/SafeDeleteOperation.cs
@@ -1,4 +1,5 @@
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Text;
@@ -107,8 +108,8 @@ public sealed class SafeDeleteOperation : RefactoringOperationBase<SafeDeletePar
 
         var sourceText = await document.GetTextAsync(cancellationToken);
         var span = GetSelectionSpan(sourceText, @params);
-        var symbol = await ResolveSelectedSymbolAsync(
-            document, root, semanticModel, span, @params, cancellationToken);
+        var symbol = ResolveSelectedSymbol(
+            root, semanticModel, span, @params, cancellationToken);
 
         symbol = NormalizeDeletableSymbol(symbol);
         ValidateSymbolCanBeDeleted(symbol);
@@ -164,39 +165,40 @@ public sealed class SafeDeleteOperation : RefactoringOperationBase<SafeDeletePar
         return TextSpan.FromBounds(startPosition, endPosition);
     }
 
-    private async Task<ISymbol> ResolveSelectedSymbolAsync(
-        Document document,
+    private static ISymbol ResolveSelectedSymbol(
         SyntaxNode root,
         SemanticModel semanticModel,
         TextSpan span,
         SafeDeleteParams @params,
         CancellationToken cancellationToken)
     {
+        var token = root.FindToken(span.Start);
+        if (token.Span.OverlapsWith(span) || span.OverlapsWith(token.Span))
+        {
+            var tokenNode = token.Parent;
+            if (tokenNode != null)
+            {
+                var declaredOnToken = semanticModel.GetDeclaredSymbol(tokenNode, cancellationToken);
+                if (declaredOnToken != null && IdentifierOverlaps(tokenNode, span))
+                    return ConfirmSymbolName(declaredOnToken, @params.SymbolName);
+
+                if (token.IsKind(SyntaxKind.IdentifierToken))
+                {
+                    var tokenSymbol = semanticModel.GetSymbolInfo(tokenNode, cancellationToken).Symbol;
+                    if (tokenSymbol != null)
+                        return ConfirmSymbolName(tokenSymbol, @params.SymbolName);
+                }
+            }
+        }
+
         var node = root.FindNode(span, getInnermostNodeForTie: true);
-        for (var current = node; current != null; current = current.Parent)
-        {
-            var declared = semanticModel.GetDeclaredSymbol(current, cancellationToken);
-            if (declared != null && SelectionCoversDeclaration(current, span))
-                return ConfirmSymbolName(declared, @params.SymbolName);
-        }
+        var declared = semanticModel.GetDeclaredSymbol(node, cancellationToken);
+        if (declared != null && IdentifierOverlaps(node, span))
+            return ConfirmSymbolName(declared, @params.SymbolName);
 
-        var symbolInfo = semanticModel.GetSymbolInfo(node, cancellationToken);
-        if (symbolInfo.Symbol != null)
-            return ConfirmSymbolName(symbolInfo.Symbol, @params.SymbolName);
-
-        var resolver = Context.CreateGeneralSymbolResolver();
-        try
-        {
-            var resolved = await resolver.ResolveAtPositionAsync(
-                document, @params.StartLine, @params.StartColumn, cancellationToken);
-            return ConfirmSymbolName(resolved.Symbol, @params.SymbolName);
-        }
-        catch (RefactoringException ex) when (ex.ErrorCode == ErrorCodes.SymbolNotFound)
-        {
-            throw new RefactoringException(
-                ErrorCodes.SymbolNotFound,
-                "No symbol found at the specified selection.");
-        }
+        throw new RefactoringException(
+            ErrorCodes.SymbolNotFound,
+            "No symbol found at the specified selection.");
     }
 
     private static ISymbol ConfirmSymbolName(ISymbol symbol, string? expectedName)
@@ -211,10 +213,31 @@ public sealed class SafeDeleteOperation : RefactoringOperationBase<SafeDeletePar
         return symbol;
     }
 
-    private static bool SelectionCoversDeclaration(SyntaxNode declaration, TextSpan span)
+    private static bool IdentifierOverlaps(SyntaxNode node, TextSpan span)
     {
-        return declaration.Span.Contains(span) || span.Contains(declaration.Span) || declaration.Span.OverlapsWith(span);
+        var identifier = GetDeclarationIdentifier(node);
+        if (identifier != null)
+            return identifier.Value.Span.OverlapsWith(span) || span.OverlapsWith(identifier.Value.Span);
+
+        return node is MemberDeclarationSyntax && node.Span.OverlapsWith(span);
     }
+
+    private static SyntaxToken? GetDeclarationIdentifier(SyntaxNode node) => node switch
+    {
+        MethodDeclarationSyntax method => method.Identifier,
+        PropertyDeclarationSyntax property => property.Identifier,
+        EventDeclarationSyntax @event => @event.Identifier,
+        VariableDeclaratorSyntax variable => variable.Identifier,
+        TypeDeclarationSyntax type => type.Identifier,
+        EnumDeclarationSyntax @enum => @enum.Identifier,
+        DelegateDeclarationSyntax @delegate => @delegate.Identifier,
+        EnumMemberDeclarationSyntax member => member.Identifier,
+        ParameterSyntax parameter => parameter.Identifier,
+        LocalFunctionStatementSyntax localFunction => localFunction.Identifier,
+        ConstructorDeclarationSyntax constructor => constructor.Identifier,
+        DestructorDeclarationSyntax destructor => destructor.Identifier,
+        _ => null
+    };
 
     private static ISymbol NormalizeDeletableSymbol(ISymbol symbol)
     {

--- a/src/RoslynMcp.Server/McpServerHost.cs
+++ b/src/RoslynMcp.Server/McpServerHost.cs
@@ -53,6 +53,7 @@ public sealed class McpServerHost : IAsyncDisposable
         _toolRegistry.Register(new PushMembersDownTool(workspaceProvider));
         _toolRegistry.Register(new UseBaseTypeTool(workspaceProvider));
         _toolRegistry.Register(new IntroduceFieldTool(workspaceProvider));
+        _toolRegistry.Register(new SafeDeleteTool(workspaceProvider));
 
         // Code Navigation / Query Tools
         _toolRegistry.Register(new FindReferencesTool(workspaceProvider));

--- a/src/RoslynMcp.Server/RoslynMcp.Server.csproj
+++ b/src/RoslynMcp.Server/RoslynMcp.Server.csproj
@@ -18,7 +18,7 @@
     <Version>0.4.0</Version>
     <Authors>Joshua Ramirez</Authors>
     <Company>RedJay</Company>
-    <Description>MCP Server for Roslyn-powered C# refactoring operations. Install as a global tool to use with Claude Code, Claude Desktop, or other MCP clients. Provides 46 tools: 24 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 7 code conversion tools.</Description>
+    <Description>MCP Server for Roslyn-powered C# refactoring operations. Install as a global tool to use with Claude Code, Claude Desktop, or other MCP clients. Provides 47 tools: 25 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 7 code conversion tools.</Description>
     <PackageTags>roslyn;mcp;refactoring;csharp;model-context-protocol;code-analysis;dotnet;ai-tools;claude</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/JoshuaRamirez/RoslynMcpServer</RepositoryUrl>

--- a/src/RoslynMcp.Server/Tools/SafeDeleteTool.cs
+++ b/src/RoslynMcp.Server/Tools/SafeDeleteTool.cs
@@ -1,0 +1,154 @@
+using System.Text.Json;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.Refactoring;
+using RoslynMcp.Core.Refactoring.Extract;
+using RoslynMcp.Core.Workspace;
+using RoslynMcp.Server.Transport;
+
+namespace RoslynMcp.Server.Tools;
+
+/// <summary>
+/// MCP tool handler for safe_delete operation.
+/// </summary>
+public sealed class SafeDeleteTool : IToolHandler
+{
+    private readonly IWorkspaceProvider _workspaceProvider;
+    private readonly JsonSerializerOptions _jsonOptions;
+
+    /// <summary>
+    /// Creates a new safe-delete tool.
+    /// </summary>
+    public SafeDeleteTool(IWorkspaceProvider workspaceProvider)
+    {
+        _workspaceProvider = workspaceProvider;
+        _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = false
+        };
+    }
+
+    /// <inheritdoc />
+    public string Name => "safe_delete";
+
+    /// <inheritdoc />
+    public string Description => "Delete a selected symbol only when it has no remaining references. If usages exist, reject with their locations.";
+
+    /// <inheritdoc />
+    public object InputSchema => new
+    {
+        type = "object",
+        required = new[] { "solutionPath", "sourceFile", "startLine", "startColumn", "endLine", "endColumn" },
+        properties = new
+        {
+            solutionPath = new
+            {
+                type = "string",
+                description = "Absolute path to the .sln or .csproj file"
+            },
+            sourceFile = new
+            {
+                type = "string",
+                description = "Absolute path to the source file"
+            },
+            startLine = new
+            {
+                type = "integer",
+                description = "Start line of the selected symbol (1-based)"
+            },
+            startColumn = new
+            {
+                type = "integer",
+                description = "Start column of the selected symbol (1-based)"
+            },
+            endLine = new
+            {
+                type = "integer",
+                description = "End line of the selected symbol (1-based)"
+            },
+            endColumn = new
+            {
+                type = "integer",
+                description = "End column of the selected symbol (1-based)"
+            },
+            symbolName = new
+            {
+                type = "string",
+                description = "Optional symbol name used to confirm the selection"
+            },
+            preview = new
+            {
+                type = "boolean",
+                description = "Return computed changes without applying",
+                @default = false
+            }
+        },
+        additionalProperties = false
+    };
+
+    /// <inheritdoc />
+    public async Task<ToolResult> ExecuteAsync(JsonElement? arguments, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (arguments == null)
+            {
+                return ToolResult.Error("Arguments required");
+            }
+
+            var args = JsonSerializer.Deserialize<SafeDeleteArgs>(arguments.Value.GetRawText(), _jsonOptions);
+            if (args == null)
+            {
+                return ToolResult.Error("Failed to parse arguments");
+            }
+
+            using var context = await _workspaceProvider.CreateContextAsync(
+                args.SolutionPath,
+                cancellationToken);
+
+            var operation = new SafeDeleteOperation(context);
+            var @params = new SafeDeleteParams
+            {
+                SourceFile = args.SourceFile,
+                StartLine = args.StartLine,
+                StartColumn = args.StartColumn,
+                EndLine = args.EndLine,
+                EndColumn = args.EndColumn,
+                SymbolName = args.SymbolName,
+                Preview = args.Preview ?? false
+            };
+
+            var result = await operation.ExecuteAsync(@params, cancellationToken);
+
+            var json = JsonSerializer.Serialize(result, _jsonOptions);
+            return result.Success ? ToolResult.Success(json) : ToolResult.Error(json);
+        }
+        catch (RefactoringException ex)
+        {
+            var error = ex.ToError();
+            var json = JsonSerializer.Serialize(new { success = false, error }, _jsonOptions);
+            return ToolResult.Error(json);
+        }
+        catch (Exception ex)
+        {
+            var json = JsonSerializer.Serialize(new
+            {
+                success = false,
+                error = new { code = "INTERNAL_ERROR", message = ex.Message }
+            }, _jsonOptions);
+            return ToolResult.Error(json);
+        }
+    }
+
+    private sealed class SafeDeleteArgs
+    {
+        public string SolutionPath { get; init; } = "";
+        public string SourceFile { get; init; } = "";
+        public int StartLine { get; init; }
+        public int StartColumn { get; init; }
+        public int EndLine { get; init; }
+        public int EndColumn { get; init; }
+        public string? SymbolName { get; init; }
+        public bool? Preview { get; init; }
+    }
+}

--- a/tests/RoslynMcp.Cli.Tests/HelpGeneratorTests.cs
+++ b/tests/RoslynMcp.Cli.Tests/HelpGeneratorTests.cs
@@ -15,15 +15,16 @@ public class HelpGeneratorTests
     }
 
     [Fact]
-    public void GenerateGlobalHelp_Lists46Tools()
+    public void GenerateGlobalHelp_Lists47Tools()
     {
         var registry = ToolRegistry.BuildDefault();
         var help = HelpGenerator.GenerateGlobalHelp(registry);
-        Assert.Contains("Total: 46 tools", help);
+        Assert.Contains("Total: 47 tools", help);
         Assert.Contains("pull-members-up", help);
         Assert.Contains("push-members-down", help);
         Assert.Contains("use-base-type", help);
         Assert.Contains("introduce-field", help);
+        Assert.Contains("safe-delete", help);
     }
 
     [Fact]

--- a/tests/RoslynMcp.Cli.Tests/ToolRegistryTests.cs
+++ b/tests/RoslynMcp.Cli.Tests/ToolRegistryTests.cs
@@ -6,11 +6,11 @@ namespace RoslynMcp.Cli.Tests;
 public class ToolRegistryTests
 {
     [Fact]
-    public void BuildDefault_Registers46Tools()
+    public void BuildDefault_Registers47Tools()
     {
         var registry = ToolRegistry.BuildDefault();
         var tools = registry.GetAllTools();
-        Assert.Equal(46, tools.Count);
+        Assert.Equal(47, tools.Count);
     }
 
     [Fact]
@@ -88,6 +88,7 @@ public class ToolRegistryTests
     [InlineData("push-members-down", "Refactoring")]
     [InlineData("use-base-type", "Refactoring")]
     [InlineData("introduce-field", "Refactoring")]
+    [InlineData("safe-delete", "Refactoring")]
     [InlineData("find-references", "Query")]
     [InlineData("get-diagnostics", "Query")]
     [InlineData("diagnose", "Diagnostic")]
@@ -106,11 +107,11 @@ public class ToolRegistryTests
     }
 
     [Fact]
-    public void RefactoringToolCount_Is33()
+    public void RefactoringToolCount_Is34()
     {
         var registry = ToolRegistry.BuildDefault();
         var count = registry.GetAllTools().Count(t => t.Category == "Refactoring");
-        Assert.Equal(33, count);
+        Assert.Equal(34, count);
     }
 
     [Fact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Extract/SafeDeleteOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Extract/SafeDeleteOperationTests.cs
@@ -1,0 +1,442 @@
+using System.Collections;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using RoslynMcp.Contracts.Errors;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.Refactoring;
+using RoslynMcp.Core.Refactoring.Extract;
+using RoslynMcp.Core.Workspace;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Refactoring.Extract;
+
+/// <summary>
+/// Operation-level tests for <see cref="SafeDeleteOperation"/>.
+/// </summary>
+public class SafeDeleteOperationTests
+{
+    #region Input Validation
+
+    [Fact]
+    public void Validate_MissingSourceFile_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            SafeDeleteOperation.Validate(new SafeDeleteParams
+            {
+                SourceFile = "",
+                StartLine = 1,
+                StartColumn = 1,
+                EndLine = 1,
+                EndColumn = 2
+            }));
+
+        Assert.Equal(ErrorCodes.MissingRequiredParam, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_RelativePath_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            SafeDeleteOperation.Validate(new SafeDeleteParams
+            {
+                SourceFile = "Types.cs",
+                StartLine = 1,
+                StartColumn = 1,
+                EndLine = 1,
+                EndColumn = 2
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidSourcePath, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_InvalidLine_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            SafeDeleteOperation.Validate(new SafeDeleteParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                StartLine = 0,
+                StartColumn = 1,
+                EndLine = 1,
+                EndColumn = 2
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidLineNumber, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_InvalidSelectionRange_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            SafeDeleteOperation.Validate(new SafeDeleteParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                StartLine = 2,
+                StartColumn = 1,
+                EndLine = 1,
+                EndColumn = 2
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidSelectionRange, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_MissingFile_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            SafeDeleteOperation.Validate(new SafeDeleteParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                StartLine = 1,
+                StartColumn = 1,
+                EndLine = 1,
+                EndColumn = 2
+            }));
+
+        Assert.Equal(ErrorCodes.SourceFileNotFound, ex.ErrorCode);
+    }
+
+    #endregion
+
+    #region P0 Happy Path
+
+    [SkippableFact]
+    public async Task SafeDelete_UnusedField_RemovesDeclaration()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                private int _unused;
+
+                public int Get()
+                {
+                    return 42;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new SafeDeleteOperation(workspace.Context);
+        var span = FindSpan(source, "_unused");
+
+        var result = await operation.ExecuteAsync(new SafeDeleteParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = span.StartLine,
+            StartColumn = span.StartColumn,
+            EndLine = span.EndLine,
+            EndColumn = span.EndColumn,
+            SymbolName = "_unused"
+        });
+
+        Assert.True(result.Success);
+        Assert.False(result.Preview);
+        Assert.NotNull(result.Symbol);
+        Assert.Equal("_unused", result.Symbol.Name);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.DoesNotContain("_unused", updated);
+        Assert.Contains("return 42;", updated);
+    }
+
+    [SkippableFact]
+    public async Task SafeDelete_UnusedMethod_RemovesDeclaration()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public int Get()
+                {
+                    return 42;
+                }
+
+                private void UnusedHelper()
+                {
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new SafeDeleteOperation(workspace.Context);
+        var span = FindSpan(source, "UnusedHelper");
+
+        var result = await operation.ExecuteAsync(new SafeDeleteParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = span.StartLine,
+            StartColumn = span.StartColumn,
+            EndLine = span.EndLine,
+            EndColumn = span.EndColumn
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.DoesNotContain("UnusedHelper", updated);
+        Assert.Contains("public int Get()", updated);
+    }
+
+    #endregion
+
+    #region P0 Preview
+
+    [SkippableFact]
+    public async Task SafeDelete_Preview_DoesNotModifyFile()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                private int _unused;
+
+                public int Get()
+                {
+                    return 42;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+        var operation = new SafeDeleteOperation(workspace.Context);
+        var span = FindSpan(source, "_unused");
+
+        var result = await operation.ExecuteAsync(new SafeDeleteParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = span.StartLine,
+            StartColumn = span.StartColumn,
+            EndLine = span.EndLine,
+            EndColumn = span.EndColumn,
+            Preview = true
+        });
+
+        Assert.True(result.Success);
+        Assert.True(result.Preview);
+        Assert.NotNull(result.PendingChanges);
+        Assert.Contains(result.PendingChanges, change => change.Description.Contains("_unused"));
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    #endregion
+
+    #region P0 Rejects
+
+    [SkippableFact]
+    public async Task SafeDelete_InUseField_ThrowsWithLocations()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                private int _used;
+
+                public int Get()
+                {
+                    return _used;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new SafeDeleteOperation(workspace.Context);
+        var span = FindSpan(source, "_used");
+        var usage = FindSpan(source, "return _used;");
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new SafeDeleteParams
+            {
+                SourceFile = workspace.SourcePath,
+                StartLine = span.StartLine,
+                StartColumn = span.StartColumn,
+                EndLine = span.EndLine,
+                EndColumn = span.EndColumn,
+                SymbolName = "_used"
+            }));
+
+        Assert.Equal(ErrorCodes.MemberHasUsages, ex.ErrorCode);
+        Assert.NotNull(ex.Details);
+        Assert.True(ex.Details.ContainsKey("locations"));
+        Assert.Equal(1, Convert.ToInt32(ex.Details["usageCount"]));
+
+        var locations = Assert.IsAssignableFrom<IEnumerable>(ex.Details["locations"]);
+        var locationMaps = locations.Cast<Dictionary<string, object>>().ToList();
+        Assert.NotEmpty(locationMaps);
+        Assert.Contains(locationMaps, location =>
+            Convert.ToInt32(location["line"]) == usage.StartLine &&
+            location["snippet"] is string snippet &&
+            snippet.Contains("_used"));
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [SkippableFact]
+    public async Task SafeDelete_NoSymbol_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public int Get()
+                {
+                    return 42;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new SafeDeleteOperation(workspace.Context);
+        var span = FindSpan(source, "return");
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new SafeDeleteParams
+            {
+                SourceFile = workspace.SourcePath,
+                StartLine = span.StartLine,
+                StartColumn = span.StartColumn,
+                EndLine = span.EndLine,
+                EndColumn = span.EndColumn
+            }));
+
+        Assert.Equal(ErrorCodes.SymbolNotFound, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void SafeDelete_UneditableDocument_Throws()
+    {
+        var workspace = new AdhocWorkspace();
+        var project = workspace.AddProject("P", LanguageNames.CSharp);
+        var document = workspace.AddDocument(project.Id, "Generated.cs", SourceText.From("class C {}"));
+
+        var ex = Assert.Throws<RefactoringException>(() =>
+            SafeDeleteOperation.ValidateDocumentIsEditable(document, workspace));
+
+        Assert.Equal(ErrorCodes.DocumentNotEditable, ex.ErrorCode);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static string AbsoluteTestPath() =>
+        Path.Combine(Path.GetTempPath(), "RoslynMcpSafeDeleteMissing.cs");
+
+    private static string NormalizeNewlines(string text) =>
+        text.Replace("\r\n", "\n", StringComparison.Ordinal);
+
+    private static (int StartLine, int StartColumn, int EndLine, int EndColumn) FindSpan(string source, string snippet)
+    {
+        var index = source.IndexOf(snippet, StringComparison.Ordinal);
+        if (index < 0)
+            throw new InvalidOperationException($"Snippet not found: {snippet}");
+
+        return (GetLineColumn(source, index).Line, GetLineColumn(source, index).Column,
+            GetLineColumn(source, index + snippet.Length).Line, GetLineColumn(source, index + snippet.Length).Column);
+    }
+
+    private static (int Line, int Column) GetLineColumn(string source, int index)
+    {
+        var line = 1;
+        var column = 1;
+        for (var i = 0; i < index; i++)
+        {
+            if (source[i] == '\n')
+            {
+                line++;
+                column = 1;
+            }
+            else
+            {
+                column++;
+            }
+        }
+
+        return (line, column);
+    }
+
+    private sealed class TempWorkspace : IAsyncDisposable
+    {
+        public required string DirectoryPath { get; init; }
+        public required string ProjectPath { get; init; }
+        public required string SourcePath { get; init; }
+        public required WorkspaceContext Context { get; init; }
+
+        public static async Task<TempWorkspace> CreateAsync(string source, string fileName = "Types.cs")
+        {
+            Skip.IfNot(ModuleInitializer.MsBuildAvailable, ModuleInitializer.MsBuildError ?? "MSBuild not available");
+
+            var directory = Path.Combine(Path.GetTempPath(), "RoslynMcpSafeDelete_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(directory);
+
+            var projectPath = Path.Combine(directory, "TestApp.csproj");
+            var sourcePath = Path.Combine(directory, fileName);
+
+            await File.WriteAllTextAsync(projectPath, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net9.0</TargetFramework>
+                    <Nullable>enable</Nullable>
+                  </PropertyGroup>
+                </Project>
+                """);
+            await File.WriteAllTextAsync(sourcePath, source);
+
+            try
+            {
+                var provider = new MSBuildWorkspaceProvider();
+                var context = await provider.CreateContextAsync(projectPath);
+                if (context.GetDocumentByPath(sourcePath) == null)
+                {
+                    context.Dispose();
+                    throw new InvalidOperationException($"Workspace loaded but did not include {sourcePath}.");
+                }
+
+                return new TempWorkspace
+                {
+                    DirectoryPath = directory,
+                    ProjectPath = projectPath,
+                    SourcePath = sourcePath,
+                    Context = context
+                };
+            }
+            catch (Exception ex) when (ex is not SkipException)
+            {
+                try
+                {
+                    Directory.Delete(directory, recursive: true);
+                }
+                catch
+                {
+                    // ignore cleanup failures
+                }
+
+                Skip.If(true, $"Workspace load failed: {ex.Message}");
+                throw;
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            Context.Dispose();
+            await Task.Run(() =>
+            {
+                try
+                {
+                    Directory.Delete(DirectoryPath, recursive: true);
+                }
+                catch
+                {
+                    // ignore locked temp files
+                }
+            });
+        }
+    }
+
+    #endregion
+}

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Extract/SafeDeleteOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Extract/SafeDeleteOperationTests.cs
@@ -307,6 +307,127 @@ public class SafeDeleteOperationTests
         Assert.Equal(ErrorCodes.SymbolNotFound, ex.ErrorCode);
     }
 
+    [SkippableFact]
+    public async Task SafeDelete_BodyText_ThrowsSymbolNotFound()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public int Get()
+                {
+                    return 42;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new SafeDeleteOperation(workspace.Context);
+        var span = FindSpan(source, "42");
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new SafeDeleteParams
+            {
+                SourceFile = workspace.SourcePath,
+                StartLine = span.StartLine,
+                StartColumn = span.StartColumn,
+                EndLine = span.EndLine,
+                EndColumn = span.EndColumn
+            }));
+
+        Assert.Equal(ErrorCodes.SymbolNotFound, ex.ErrorCode);
+        var updated = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Contains("public int Get()", updated);
+    }
+
+    [SkippableFact]
+    public async Task SafeDelete_ForeachVariable_ThrowsWithoutDeletingMethod()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public void Walk(int[] items)
+                {
+                    foreach (var unusedItem in items)
+                    {
+                    }
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new SafeDeleteOperation(workspace.Context);
+        var span = FindSpan(source, "unusedItem");
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new SafeDeleteParams
+            {
+                SourceFile = workspace.SourcePath,
+                StartLine = span.StartLine,
+                StartColumn = span.StartColumn,
+                EndLine = span.EndLine,
+                EndColumn = span.EndColumn,
+                SymbolName = "unusedItem"
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidSymbolKind, ex.ErrorCode);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("public void Walk(int[] items)", before);
+    }
+
+    [SkippableFact]
+    public async Task SafeDelete_UnusedInterfaceImplementation_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public interface ICalculator
+            {
+                int Get();
+            }
+
+            public class Calculator : ICalculator
+            {
+                public int Get()
+                {
+                    return 42;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new SafeDeleteOperation(workspace.Context);
+        var span = FindSpan(source, "public int Get()");
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new SafeDeleteParams
+            {
+                SourceFile = workspace.SourcePath,
+                StartLine = span.StartLine,
+                StartColumn = span.StartColumn + "public int ".Length,
+                EndLine = span.EndLine,
+                EndColumn = span.StartColumn + "public int Get".Length,
+                SymbolName = "Get"
+            }));
+
+        Assert.Equal(ErrorCodes.MemberHasUsages, ex.ErrorCode);
+        Assert.NotNull(ex.Details);
+        Assert.True(Convert.ToInt32(ex.Details["usageCount"]) >= 1);
+        var locations = Assert.IsAssignableFrom<IEnumerable>(ex.Details["locations"]);
+        var locationMaps = locations.Cast<Dictionary<string, object>>().ToList();
+        Assert.Contains(locationMaps, location =>
+            location["snippet"] is string snippet &&
+            snippet.Contains("implements", StringComparison.Ordinal) &&
+            snippet.Contains("Get", StringComparison.Ordinal));
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("public int Get()", before);
+    }
+
     [Fact]
     public void SafeDelete_UneditableDocument_Throws()
     {

--- a/tests/RoslynMcp.Server.Tests/Tools/SafeDeleteToolTests.cs
+++ b/tests/RoslynMcp.Server.Tests/Tools/SafeDeleteToolTests.cs
@@ -1,0 +1,140 @@
+using System.Text.Json;
+using RoslynMcp.Server.Tests.TestHelpers;
+using RoslynMcp.Server.Tools;
+using RoslynMcp.Server.Transport;
+using Xunit;
+
+namespace RoslynMcp.Server.Tests.Tools;
+
+/// <summary>
+/// Unit tests for SafeDeleteTool.
+/// Tests tool definition and argument validation.
+/// </summary>
+public class SafeDeleteToolTests
+{
+    private readonly SafeDeleteTool _tool;
+
+    public SafeDeleteToolTests()
+    {
+        _tool = new SafeDeleteTool(new ThrowingWorkspaceProvider());
+    }
+
+    #region GetDefinition Tests
+
+    [Fact]
+    public void GetDefinition_ReturnsCorrectName()
+    {
+        Assert.Equal("safe_delete", _tool.Name);
+    }
+
+    [Fact]
+    public void GetDefinition_ReturnsNonEmptyDescription()
+    {
+        Assert.NotNull(_tool.Description);
+        Assert.NotEmpty(_tool.Description);
+    }
+
+    [Fact]
+    public void GetDefinition_ReturnsCorrectSchema()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.Equal("object", root.GetProperty("type").GetString());
+        Assert.True(root.TryGetProperty("properties", out _));
+        Assert.True(root.TryGetProperty("required", out _));
+    }
+
+    [Fact]
+    public void GetDefinition_HasRequiredFields()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var required = doc.RootElement.GetProperty("required");
+
+        var requiredFields = new List<string>();
+        foreach (var item in required.EnumerateArray())
+        {
+            requiredFields.Add(item.GetString()!);
+        }
+
+        Assert.Contains("solutionPath", requiredFields);
+        Assert.Contains("sourceFile", requiredFields);
+        Assert.Contains("startLine", requiredFields);
+        Assert.Contains("startColumn", requiredFields);
+        Assert.Contains("endLine", requiredFields);
+        Assert.Contains("endColumn", requiredFields);
+    }
+
+    [Fact]
+    public void GetDefinition_HasProperties_ForAllParameters()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var properties = doc.RootElement.GetProperty("properties");
+
+        Assert.True(properties.TryGetProperty("solutionPath", out _));
+        Assert.True(properties.TryGetProperty("sourceFile", out _));
+        Assert.True(properties.TryGetProperty("startLine", out _));
+        Assert.True(properties.TryGetProperty("startColumn", out _));
+        Assert.True(properties.TryGetProperty("endLine", out _));
+        Assert.True(properties.TryGetProperty("endColumn", out _));
+        Assert.True(properties.TryGetProperty("symbolName", out _));
+        Assert.True(properties.TryGetProperty("preview", out _));
+    }
+
+    #endregion
+
+    #region ExecuteAsync Argument Validation Tests
+
+    [Fact]
+    public async Task ExecuteAsync_NullArguments_ReturnsError()
+    {
+        var result = await _tool.ExecuteAsync(null);
+
+        Assert.True(result.IsError);
+        Assert.Contains("Arguments required", GetResultText(result));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EmptyArguments_ReturnsError()
+    {
+        var args = JsonDocument.Parse("{}").RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MissingRequiredField_ReturnsError()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "solutionPath": "C:/test/test.sln",
+                "sourceFile": "C:/test/Test.cs",
+                "startLine": 10,
+                "startColumn": 5
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static string GetResultText(ToolResult result)
+    {
+        return result.Content.FirstOrDefault()?.Text ?? string.Empty;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds `safe_delete` / `SafeDeleteOperation`: delete a selected symbol only when it has no remaining references. If usages exist, the operation rejects with those locations and does not modify files.

This is the next Phase 2 simple increment after `introduce_field` (PR #39 / issue #38), following Arch-Hierarchy-Additional-Operations.md §5.4 and §10 and the existing `introduce_field` / `extract_*` / `introduce_parameter` patterns.

Force-delete and reference cleanup are intentionally not implemented.

## Related Issues

Closes #40

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Test additions or updates
- [x] Documentation update

## What landed

- Unused symbol is removed (field and method happy paths)
- In-use reject with file/line/column/snippet locations (no disk writes)
- Preview mode (no disk writes)
- Rejects: no symbol, uneditable documents, plus input validation
- MCP + CLI wiring (`safe_delete` / `safe-delete`)
- Tool-count updates (46 → 47)

## Review follow-up

Addresses the three judged TAKEs on `SafeDeleteOperation`:

1. **Identifier-only selection** — `IdentifierOverlaps` no longer treats a whole `MemberDeclarationSyntax` span as selected. `return` and method-body text keep throwing `SymbolNotFound`.
2. **Unsupported locals** — catch / foreach / pattern / label declarations are rejected with `InvalidSymbolKind` instead of walking up to (and deleting) the containing method.
3. **Interface / override obligations** — zero `FindReferences` hits is not enough. Implicit and explicit interface implementations and overrides are reported as remaining usages (`MemberHasUsages`). Unused interface implementations are rejected.

## Testing

- [x] New tests added for happy path + in-use reject + preview + P0 rejects
- [x] Review-follow-up tests for identifier-only selection, unsupported foreach locals, and unused interface implementations
- [x] All existing tests pass
- [x] Format check passed locally

**Test Configuration**:
- OS: Linux
- .NET Version: 9.0.317

**Local results** (head `66b01fa`):
- `SafeDeleteOperationTests`: 14 passed
- Full suite: Core 410 + Server 377 + CLI 96 = 883 passed, 0 failed
- `dotnet format --verify-no-changes`: passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0bc00108-dfa3-432a-a919-6b90ddd92100?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0bc00108-dfa3-432a-a919-6b90ddd92100&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

