### PR TITLE
Add make_static refactoring

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "roslyn-mcp",
   "version": "0.4.1",
-  "description": "Roslyn-powered C# refactoring MCP server — 47 tools for code navigation, analysis, generation, and refactoring across entire .NET solutions",
+  "description": "Roslyn-powered C# refactoring MCP server — 48 tools for code navigation, analysis, generation, and refactoring across entire .NET solutions",
   "author": {
     "name": "Joshua Ramirez"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - `use_base_type` — replace derived-type references with a compatible base type or interface, rewriting only usages whose members exist on that base, with preview mode and rejects for missing bases, uneditable documents, and no eligible references
 - `introduce_field` — turn a selected local variable or expression into a class field, optionally initializing it in a constructor, with preview mode and rejects for missing expressions, uneditable documents, and invalid target types
 - `safe_delete` — delete a selected symbol only when it has no remaining references, with preview mode and rejects that include usage locations, missing symbols, and uneditable documents
+- `make_static` — add the static modifier to a selected instance method that does not use instance state, update call sites and method-group conversions to the containing type name, with preview mode and rejects for instance-member access, already-static methods, and uneditable documents
 
 ## [0.4.0] - 2026-02-23
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Let AI assistants like Claude safely refactor your C# codebase using the same Roslyn compiler platform that powers Visual Studio.
 
-Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that exposes **47 Roslyn-powered tools** to AI assistants and other MCP clients. It combines 25 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 7 code conversion tools -- giving your AI deep code intelligence, comprehensive refactoring, and modern C# syntax transformations with full solution-wide reference tracking and preview support.
+Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that exposes **48 Roslyn-powered tools** to AI assistants and other MCP clients. It combines 26 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 7 code conversion tools -- giving your AI deep code intelligence, comprehensive refactoring, and modern C# syntax transformations with full solution-wide reference tracking and preview support.
 
 ---
 
@@ -30,7 +30,7 @@ Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotoc
 
 ## Why RoslynMcpServer?
 
-- **47 tools** -- refactoring, navigation, analysis, generation, and conversion tools, the most comprehensive Roslyn MCP server available
+- **48 tools** -- refactoring, navigation, analysis, generation, and conversion tools, the most comprehensive Roslyn MCP server available
 - **Preview mode on every operation** -- see exactly what will change before applying
 - **Atomic file writes with rollback** -- if any file write fails, all changes are reverted
 - **Solution-wide reference updates** -- renames and moves propagate across your entire solution
@@ -102,7 +102,7 @@ Claude will use the `rename_symbol` tool to rename the class and update every re
 
 ## Standalone CLI
 
-All 47 tools are also available as a standalone CLI for use in scripts, CI/CD pipelines, and terminals without an AI assistant.
+All 48 tools are also available as a standalone CLI for use in scripts, CI/CD pipelines, and terminals without an AI assistant.
 
 ### Install
 
@@ -206,6 +206,7 @@ All tools accept a `solutionPath` parameter (absolute path to a `.sln`, `.slnx`,
 | `use_base_type` | Replace derived-type references with a compatible base type or interface. | `sourceFile`, `typeName`, `targetBaseType` |
 | `introduce_field` | Turn a selected local variable or expression into a class field, optionally initializing it in a constructor. | `sourceFile`, `startLine`, `startColumn`, `endLine`, `endColumn`, `fieldName`, `isReadonly`, `isStatic`, `initializeInConstructor`, `replaceAll` |
 | `safe_delete` | Delete a selected symbol only when it has no remaining references. If usages exist, reject with their locations. | `sourceFile`, `startLine`, `startColumn`, `endLine`, `endColumn`, `symbolName` |
+| `make_static` | Make a selected instance method static when it does not use instance state. Adds the static modifier and updates call sites and method-group conversions to the containing type name. | `sourceFile`, `startLine`, `startColumn`, `endLine`, `endColumn`, `symbolName` |
 
 ### Inline
 

--- a/src/RoslynMcp.Cli/ToolRegistry.cs
+++ b/src/RoslynMcp.Cli/ToolRegistry.cs
@@ -47,7 +47,7 @@ public sealed class ToolEntry
 }
 
 /// <summary>
-/// Maps tool names to execution delegates for all 47 Roslyn tools.
+/// Maps tool names to execution delegates for all 48 Roslyn tools.
 /// </summary>
 public sealed class ToolRegistry
 {
@@ -139,7 +139,7 @@ public sealed class ToolRegistry
         _tools.Values.OrderBy(t => t.Category).ThenBy(t => t.Name).ToList();
 
     /// <summary>
-    /// Build the default registry with all 47 tools registered.
+    /// Build the default registry with all 48 tools registered.
     /// </summary>
     public static ToolRegistry BuildDefault()
     {
@@ -168,6 +168,8 @@ public sealed class ToolRegistry
             "introduce-field", "Turn a selected local variable or expression into a class field");
         r.RegisterRefactoring<SafeDeleteOperation, SafeDeleteParams>(
             "safe-delete", "Delete a selected symbol only when it has no remaining references");
+        r.RegisterRefactoring<MakeStaticOperation, MakeStaticParams>(
+            "make-static", "Make a selected instance method static when it does not use instance state");
 
         // ── Refactoring: Rename (1) ───────────────────────────────────
         r.RegisterRefactoring<RenameSymbolOperation, RenameSymbolParams>(

--- a/src/RoslynMcp.Contracts/Enums/RefactoringKind.cs
+++ b/src/RoslynMcp.Contracts/Enums/RefactoringKind.cs
@@ -47,6 +47,9 @@ public enum RefactoringKind
     /// <summary>Delete a symbol only when it has no remaining references.</summary>
     SafeDelete,
 
+    /// <summary>Add the static modifier to an instance method that does not use instance state.</summary>
+    MakeStatic,
+
     /// <summary>Extract expression to variable.</summary>
     ExtractVariable,
 

--- a/src/RoslynMcp.Contracts/Errors/ErrorCodes.cs
+++ b/src/RoslynMcp.Contracts/Errors/ErrorCodes.cs
@@ -368,6 +368,16 @@ public static class ErrorCodes
     /// <summary>Cannot safely delete the symbol because remaining references exist.</summary>
     public const string MemberHasUsages = "3119";
 
+    // --------------------------------------------
+    // Make Static Errors (3120-3121)
+    // --------------------------------------------
+
+    /// <summary>Cannot make static because the method uses instance members.</summary>
+    public const string UsesInstanceMembers = "3120";
+
+    /// <summary>Member is already static.</summary>
+    public const string AlreadyStatic = "3121";
+
     // ============================================
     // System Errors (4xxx)
     // ============================================

--- a/src/RoslynMcp.Contracts/Models/MakeStaticParams.cs
+++ b/src/RoslynMcp.Contracts/Models/MakeStaticParams.cs
@@ -1,0 +1,42 @@
+namespace RoslynMcp.Contracts.Models;
+
+/// <summary>
+/// Parameters for the make_static tool.
+/// </summary>
+public sealed class MakeStaticParams
+{
+    /// <summary>
+    /// Absolute path to the source file.
+    /// </summary>
+    public required string SourceFile { get; init; }
+
+    /// <summary>
+    /// Start line of the selected method (1-based).
+    /// </summary>
+    public required int StartLine { get; init; }
+
+    /// <summary>
+    /// Start column of the selected method (1-based).
+    /// </summary>
+    public required int StartColumn { get; init; }
+
+    /// <summary>
+    /// End line of the selected method (1-based).
+    /// </summary>
+    public required int EndLine { get; init; }
+
+    /// <summary>
+    /// End column of the selected method (1-based).
+    /// </summary>
+    public required int EndColumn { get; init; }
+
+    /// <summary>
+    /// Optional method name used to confirm the selection.
+    /// </summary>
+    public string? SymbolName { get; init; }
+
+    /// <summary>
+    /// Return computed changes without applying. Default: false.
+    /// </summary>
+    public bool Preview { get; init; }
+}

--- a/src/RoslynMcp.Core/Refactoring/Extract/MakeStaticOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/MakeStaticOperation.cs
@@ -279,6 +279,13 @@ public sealed class MakeStaticOperation : RefactoringOperationBase<MakeStaticPar
                 $"Method '{method.Name}' cannot be made static because it is virtual, override, or abstract.");
         }
 
+        if (method.IsExtern)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidSymbolKind,
+                $"Method '{method.Name}' cannot be made static because it is extern.");
+        }
+
         if (method.ContainingType == null)
         {
             throw new RefactoringException(
@@ -618,6 +625,9 @@ public sealed class MakeStaticOperation : RefactoringOperationBase<MakeStaticPar
                 if (nameNode == null)
                     continue;
 
+                if (IsConditionalAccessCallSite(nameNode))
+                    throw CreateConditionalAccessException(method);
+
                 var target = GetRewriteTarget(nameNode);
                 if (target == null)
                     continue;
@@ -651,16 +661,27 @@ public sealed class MakeStaticOperation : RefactoringOperationBase<MakeStaticPar
                 .FirstOrDefault(name => name.Span.Contains(span) || span.Contains(name.Span));
     }
 
+    private static bool IsConditionalAccessCallSite(SimpleNameSyntax name) =>
+        name.Parent is MemberBindingExpressionSyntax ||
+        name.Ancestors().OfType<ConditionalAccessExpressionSyntax>().Any(conditional =>
+            GetConditionalBindingName(conditional) == name);
+
+    private static RefactoringException CreateConditionalAccessException(IMethodSymbol method)
+    {
+        return new RefactoringException(
+            ErrorCodes.InvalidSelection,
+            $"Cannot make '{method.Name}' static because a call site uses null-conditional access (?.) and rewriting it would drop short-circuiting.",
+            new Dictionary<string, object>
+            {
+                ["symbolName"] = method.Name
+            },
+            ["Update or remove null-conditional call sites (invocations and method groups), then retry."]);
+    }
+
     private static SyntaxNode? GetRewriteTarget(SimpleNameSyntax name)
     {
         if (name.Parent is MemberAccessExpressionSyntax memberAccess && memberAccess.Name == name)
             return memberAccess;
-
-        if (name.Parent is MemberBindingExpressionSyntax)
-        {
-            return name.Ancestors().OfType<ConditionalAccessExpressionSyntax>().FirstOrDefault()
-                ?? name.Parent;
-        }
 
         return null;
     }
@@ -725,8 +746,7 @@ public sealed class MakeStaticOperation : RefactoringOperationBase<MakeStaticPar
                 .ToHashSet();
 
             var rewriteTargets = root.DescendantNodes()
-                .Where(node => callSiteSpans.Contains(node.Span) &&
-                    (node is MemberAccessExpressionSyntax || node is ConditionalAccessExpressionSyntax))
+                .Where(node => callSiteSpans.Contains(node.Span) && node is MemberAccessExpressionSyntax)
                 .ToList();
             var methods = root.DescendantNodes()
                 .OfType<MethodDeclarationSyntax>()
@@ -783,23 +803,11 @@ public sealed class MakeStaticOperation : RefactoringOperationBase<MakeStaticPar
 
     private static SyntaxNode RewriteCallSite(SyntaxNode original, SemanticModel model, string methodName)
     {
-        SimpleNameSyntax? name = original switch
-        {
-            MemberAccessExpressionSyntax memberAccess => memberAccess.Name,
-            ConditionalAccessExpressionSyntax conditional => GetConditionalBindingName(conditional),
-            _ => null
-        };
-
-        if (name == null)
+        if (original is not MemberAccessExpressionSyntax memberAccess)
             return original;
 
-        ExpressionSyntax? receiver = original switch
-        {
-            MemberAccessExpressionSyntax memberAccess => memberAccess.Expression,
-            ConditionalAccessExpressionSyntax conditional => conditional.Expression,
-            _ => null
-        };
-
+        var name = memberAccess.Name;
+        var receiver = memberAccess.Expression;
         var symbol = model.GetSymbolInfo(name).Symbol;
         var containingType = (symbol as IMethodSymbol)?.ContainingType;
         if (containingType == null)
@@ -809,16 +817,6 @@ public sealed class MakeStaticOperation : RefactoringOperationBase<MakeStaticPar
                     SyntaxKind.SimpleMemberAccessExpression,
                     fallback,
                     (SimpleNameSyntax)name.WithoutTrivia())
-                .WithTriviaFrom(original);
-        }
-
-        if (original is ConditionalAccessExpressionSyntax conditionalAccess &&
-            conditionalAccess.WhenNotNull is InvocationExpressionSyntax invocation)
-        {
-            var staticAccess = CreateStaticMemberAccess(
-                containingType, name, model, original.SpanStart, receiver);
-            return invocation
-                .WithExpression(staticAccess)
                 .WithTriviaFrom(original);
         }
 

--- a/src/RoslynMcp.Core/Refactoring/Extract/MakeStaticOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/MakeStaticOperation.cs
@@ -1,0 +1,916 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Text;
+using RoslynMcp.Contracts.Enums;
+using RoslynMcp.Contracts.Errors;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.FileSystem;
+using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Resolution;
+using RoslynMcp.Core.Workspace;
+
+namespace RoslynMcp.Core.Refactoring.Extract;
+
+/// <summary>
+/// Adds the <c>static</c> modifier to a selected instance method that does not
+/// use instance state, and updates call sites and method-group conversions to
+/// use the containing type name instead of an instance.
+/// </summary>
+public sealed class MakeStaticOperation : RefactoringOperationBase<MakeStaticParams>
+{
+    /// <summary>
+    /// Creates a new make-static operation.
+    /// </summary>
+    public MakeStaticOperation(WorkspaceContext context) : base(context)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override void ValidateParams(MakeStaticParams @params) => Validate(@params);
+
+    /// <summary>
+    /// Validates make-static parameters. Internal so tests can exercise
+    /// input rules without loading a workspace.
+    /// </summary>
+    internal static void Validate(MakeStaticParams @params)
+    {
+        if (string.IsNullOrWhiteSpace(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "sourceFile is required.");
+
+        if (!PathResolver.IsAbsolutePath(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.InvalidSourcePath, "sourceFile must be an absolute path.");
+
+        if (!PathResolver.IsValidCSharpFilePath(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.InvalidSourcePath, "sourceFile must be a .cs file.");
+
+        if (@params.StartLine < 1)
+            throw new RefactoringException(ErrorCodes.InvalidLineNumber, "startLine must be >= 1.");
+
+        if (@params.StartColumn < 1)
+            throw new RefactoringException(ErrorCodes.InvalidColumnNumber, "startColumn must be >= 1.");
+
+        if (@params.EndLine < 1)
+            throw new RefactoringException(ErrorCodes.InvalidLineNumber, "endLine must be >= 1.");
+
+        if (@params.EndColumn < 1)
+            throw new RefactoringException(ErrorCodes.InvalidColumnNumber, "endColumn must be >= 1.");
+
+        if (@params.EndLine < @params.StartLine ||
+            (@params.EndLine == @params.StartLine && @params.EndColumn < @params.StartColumn))
+            throw new RefactoringException(ErrorCodes.InvalidSelectionRange, "End must be after start.");
+
+        if (!File.Exists(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.SourceFileNotFound, $"Source file not found: {@params.SourceFile}");
+    }
+
+    /// <summary>
+    /// Rejects documents that cannot receive source edits.
+    /// </summary>
+    internal static void ValidateDocumentIsEditable(Document document, Microsoft.CodeAnalysis.Workspace workspace)
+    {
+        if (document is SourceGeneratedDocument)
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable (source-generated).");
+        }
+
+        if (string.IsNullOrWhiteSpace(document.FilePath) || !File.Exists(document.FilePath))
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable.");
+        }
+
+        if (!workspace.CanApplyChange(ApplyChangesKind.ChangeDocument))
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable (workspace cannot apply changes).");
+        }
+    }
+
+    /// <inheritdoc />
+    protected override async Task<RefactoringResult> ExecuteCoreAsync(
+        Guid operationId,
+        MakeStaticParams @params,
+        CancellationToken cancellationToken)
+    {
+        var document = GetDocumentOrThrow(@params.SourceFile);
+        ValidateDocumentIsEditable(document, Context.Workspace);
+
+        var root = await document.GetSyntaxRootAsync(cancellationToken);
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken);
+        if (root == null || semanticModel == null)
+            throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse file.");
+
+        var sourceText = await document.GetTextAsync(cancellationToken);
+        var span = GetSelectionSpan(sourceText, @params);
+        var symbol = ResolveSelectedSymbol(root, semanticModel, span, @params, cancellationToken);
+        var method = NormalizeMethodSymbol(symbol);
+        ValidateMethodCanBeMadeStatic(method);
+
+        var declarationDocuments = await GetDeclarationDocumentsAsync(method, cancellationToken);
+        foreach (var declarationDocument in declarationDocuments)
+            ValidateDocumentIsEditable(declarationDocument, Context.Workspace);
+
+        var instanceMembers = await GetInstanceMemberReferencesAsync(method, cancellationToken);
+        if (!CanMakeStatic(instanceMembers))
+            throw CreateUsesInstanceMembersException(method, instanceMembers);
+
+        var plan = await BuildPlanAsync(method, cancellationToken);
+        if (@params.Preview)
+            return CreatePreviewResult(operationId, plan);
+
+        var newSolution = await ApplyPlanAsync(Context.Solution, plan, cancellationToken);
+        var commitResult = await CommitChangesAsync(newSolution, cancellationToken);
+
+        return RefactoringResult.Succeeded(
+            operationId,
+            new FileChanges
+            {
+                FilesModified = commitResult.FilesModified,
+                FilesCreated = commitResult.FilesCreated,
+                FilesDeleted = commitResult.FilesDeleted
+            },
+            new Contracts.Models.SymbolInfo
+            {
+                Name = method.Name,
+                FullyQualifiedName = method.ToDisplayString(),
+                Kind = SymbolKindMapper.Map(method)
+            },
+            plan.CallSites.Count,
+            0);
+    }
+
+    internal static TextSpan GetSelectionSpan(SourceText sourceText, MakeStaticParams @params)
+    {
+        if (@params.StartLine > sourceText.Lines.Count || @params.EndLine > sourceText.Lines.Count)
+            throw new RefactoringException(ErrorCodes.InvalidLineNumber, "Selection is outside the file.");
+
+        var startLine = sourceText.Lines[@params.StartLine - 1];
+        var endLine = sourceText.Lines[@params.EndLine - 1];
+        if (@params.StartColumn - 1 > startLine.Span.Length || @params.EndColumn - 1 > endLine.SpanIncludingLineBreak.Length)
+            throw new RefactoringException(ErrorCodes.InvalidColumnNumber, "Selection column is outside the line.");
+
+        var startPosition = startLine.Start + @params.StartColumn - 1;
+        var endPosition = endLine.Start + @params.EndColumn - 1;
+        if (endPosition < startPosition)
+            throw new RefactoringException(ErrorCodes.InvalidSelectionRange, "End must be after start.");
+
+        return TextSpan.FromBounds(startPosition, endPosition);
+    }
+
+    private static ISymbol ResolveSelectedSymbol(
+        SyntaxNode root,
+        SemanticModel semanticModel,
+        TextSpan span,
+        MakeStaticParams @params,
+        CancellationToken cancellationToken)
+    {
+        var token = root.FindToken(span.Start);
+        if (token.Span.OverlapsWith(span) || span.OverlapsWith(token.Span))
+        {
+            var tokenNode = token.Parent;
+            if (tokenNode != null)
+            {
+                var declaredOnToken = semanticModel.GetDeclaredSymbol(tokenNode, cancellationToken);
+                if (declaredOnToken != null && IdentifierOverlaps(tokenNode, span))
+                    return ConfirmSymbolName(declaredOnToken, @params.SymbolName);
+
+                if (token.IsKind(SyntaxKind.IdentifierToken))
+                {
+                    var tokenSymbol = semanticModel.GetSymbolInfo(tokenNode, cancellationToken).Symbol;
+                    if (tokenSymbol != null)
+                        return ConfirmSymbolName(tokenSymbol, @params.SymbolName);
+                }
+            }
+        }
+
+        var node = root.FindNode(span, getInnermostNodeForTie: true);
+        var declared = semanticModel.GetDeclaredSymbol(node, cancellationToken);
+        if (declared != null && IdentifierOverlaps(node, span))
+            return ConfirmSymbolName(declared, @params.SymbolName);
+
+        throw new RefactoringException(
+            ErrorCodes.SymbolNotFound,
+            "No symbol found at the specified selection.");
+    }
+
+    private static ISymbol ConfirmSymbolName(ISymbol symbol, string? expectedName)
+    {
+        if (!string.IsNullOrWhiteSpace(expectedName) && symbol.Name != expectedName)
+        {
+            throw new RefactoringException(
+                ErrorCodes.SymbolNotFound,
+                $"No symbol named '{expectedName}' found at the specified selection.");
+        }
+
+        return symbol;
+    }
+
+    private static bool IdentifierOverlaps(SyntaxNode node, TextSpan span)
+    {
+        var identifier = GetDeclarationIdentifier(node);
+        return identifier != null &&
+            (identifier.Value.Span.OverlapsWith(span) || span.OverlapsWith(identifier.Value.Span));
+    }
+
+    private static SyntaxToken? GetDeclarationIdentifier(SyntaxNode node) => node switch
+    {
+        MethodDeclarationSyntax method => method.Identifier,
+        LocalFunctionStatementSyntax localFunction => localFunction.Identifier,
+        ConstructorDeclarationSyntax constructor => constructor.Identifier,
+        DestructorDeclarationSyntax destructor => destructor.Identifier,
+        OperatorDeclarationSyntax @operator => @operator.OperatorToken,
+        ConversionOperatorDeclarationSyntax conversion => conversion.Type.GetLastToken(),
+        PropertyDeclarationSyntax property => property.Identifier,
+        EventDeclarationSyntax @event => @event.Identifier,
+        VariableDeclaratorSyntax variable => variable.Identifier,
+        TypeDeclarationSyntax type => type.Identifier,
+        ParameterSyntax parameter => parameter.Identifier,
+        _ => null
+    };
+
+    private static IMethodSymbol NormalizeMethodSymbol(ISymbol symbol)
+    {
+        symbol = symbol.OriginalDefinition;
+
+        if (symbol is IMethodSymbol { AssociatedSymbol: { } associated } &&
+            associated.Kind is Microsoft.CodeAnalysis.SymbolKind.Property or Microsoft.CodeAnalysis.SymbolKind.Event)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidSymbolKind,
+                $"Symbol '{associated.Name}' is not a method.");
+        }
+
+        if (symbol is not IMethodSymbol method)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidSymbolKind,
+                $"Symbol '{symbol.Name}' is not a method.");
+        }
+
+        return method;
+    }
+
+    private static void ValidateMethodCanBeMadeStatic(IMethodSymbol method)
+    {
+        if (method.MethodKind != MethodKind.Ordinary)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidSymbolKind,
+                $"Symbol '{method.Name}' is not an ordinary method that can be made static.");
+        }
+
+        if (method.IsStatic)
+        {
+            throw new RefactoringException(
+                ErrorCodes.AlreadyStatic,
+                $"Method '{method.Name}' is already static.");
+        }
+
+        if (method.IsAbstract || method.IsOverride || HasVirtualModifier(method))
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidSymbolKind,
+                $"Method '{method.Name}' cannot be made static because it is virtual, override, or abstract.");
+        }
+
+        if (method.ContainingType == null)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidSymbolKind,
+                $"Method '{method.Name}' has no containing type.");
+        }
+
+        if (method.ContainingType.TypeKind == TypeKind.Interface)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidSymbolKind,
+                $"Method '{method.Name}' is an interface member and cannot be made static.");
+        }
+
+        if (ImplementsInterface(method))
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidSymbolKind,
+                $"Method '{method.Name}' implements an interface and cannot be made static.");
+        }
+
+        if (!method.Locations.Any(location => location.IsInSource))
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Method '{method.Name}' is not in an editable document.");
+        }
+    }
+
+    private static bool HasVirtualModifier(IMethodSymbol method)
+    {
+        foreach (var reference in method.DeclaringSyntaxReferences)
+        {
+            if (reference.GetSyntax() is MethodDeclarationSyntax declaration &&
+                declaration.Modifiers.Any(SyntaxKind.VirtualKeyword))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ImplementsInterface(IMethodSymbol method)
+    {
+        if (method.ExplicitInterfaceImplementations.Length > 0)
+            return true;
+
+        if (method.ContainingType == null)
+            return false;
+
+        foreach (var iface in method.ContainingType.AllInterfaces)
+        {
+            foreach (var member in iface.GetMembers(method.Name))
+            {
+                var implementation = method.ContainingType.FindImplementationForInterfaceMember(member);
+                if (implementation == null)
+                    continue;
+
+                if (SymbolEqualityComparer.Default.Equals(implementation, method) ||
+                    SymbolEqualityComparer.Default.Equals(implementation.OriginalDefinition, method.OriginalDefinition))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private async Task<IReadOnlyList<Document>> GetDeclarationDocumentsAsync(
+        IMethodSymbol method,
+        CancellationToken cancellationToken)
+    {
+        var documents = new List<Document>();
+        foreach (var reference in method.DeclaringSyntaxReferences)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var syntax = await reference.GetSyntaxAsync(cancellationToken);
+            var document = Context.Solution.GetDocument(syntax.SyntaxTree);
+            if (document == null)
+            {
+                throw new RefactoringException(
+                    ErrorCodes.DocumentNotEditable,
+                    $"Declaration of '{method.Name}' is not in an editable document.");
+            }
+
+            documents.Add(document);
+        }
+
+        if (documents.Count == 0)
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Method '{method.Name}' is not in an editable document.");
+        }
+
+        return documents;
+    }
+
+    internal static bool CanMakeStatic(IReadOnlyList<ISymbol> instanceMembers) => instanceMembers.Count == 0;
+
+    private async Task<IReadOnlyList<ISymbol>> GetInstanceMemberReferencesAsync(
+        IMethodSymbol method,
+        CancellationToken cancellationToken)
+    {
+        var members = new List<ISymbol>();
+        foreach (var reference in method.DeclaringSyntaxReferences)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var syntax = await reference.GetSyntaxAsync(cancellationToken);
+            var document = Context.Solution.GetDocument(syntax.SyntaxTree);
+            if (document == null)
+                continue;
+
+            var model = await document.GetSemanticModelAsync(cancellationToken);
+            if (model == null)
+                continue;
+
+            members.AddRange(GetInstanceMemberReferences(method, model, syntax, cancellationToken));
+        }
+
+        return members
+            .Distinct<ISymbol>(SymbolEqualityComparer.Default)
+            .ToList();
+    }
+
+    internal static IReadOnlyList<ISymbol> GetInstanceMemberReferences(
+        IMethodSymbol method,
+        SemanticModel model,
+        SyntaxNode methodSyntax,
+        CancellationToken cancellationToken)
+    {
+        var body = GetMethodBody(methodSyntax);
+        if (body == null)
+            return Array.Empty<ISymbol>();
+
+        var results = new List<ISymbol>();
+        foreach (var node in body.DescendantNodesAndSelf())
+        {
+            if (IsInNameof(node))
+                continue;
+
+            if (node is ThisExpressionSyntax or BaseExpressionSyntax)
+            {
+                if (!IsReceiverOfTargetMethod(node, method, model, cancellationToken))
+                    results.Add(method.ContainingType);
+                continue;
+            }
+
+            if (node is not SimpleNameSyntax name)
+                continue;
+
+            var symbol = model.GetSymbolInfo(name, cancellationToken).Symbol;
+            if (symbol == null || symbol.IsStatic)
+                continue;
+
+            if (SymbolEqualityComparer.Default.Equals(symbol.OriginalDefinition, method.OriginalDefinition))
+                continue;
+
+            if (!IsInstanceStateSymbol(symbol))
+                continue;
+
+            if (IsMemberAccessName(name))
+            {
+                var receiver = GetReceiver(name);
+                if (receiver is ThisExpressionSyntax or BaseExpressionSyntax)
+                    results.Add(symbol);
+                continue;
+            }
+
+            results.Add(symbol);
+        }
+
+        return results;
+    }
+
+    private static SyntaxNode? GetMethodBody(SyntaxNode methodSyntax) => methodSyntax switch
+    {
+        MethodDeclarationSyntax method => (SyntaxNode?)method.Body ?? method.ExpressionBody,
+        LocalFunctionStatementSyntax local => (SyntaxNode?)local.Body ?? local.ExpressionBody,
+        _ => methodSyntax
+    };
+
+    private static bool IsInNameof(SyntaxNode node)
+    {
+        foreach (var ancestor in node.AncestorsAndSelf().OfType<InvocationExpressionSyntax>())
+        {
+            if (ancestor.Expression is IdentifierNameSyntax identifier &&
+                identifier.Identifier.Text == "nameof")
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsInstanceStateSymbol(ISymbol symbol)
+    {
+        if (symbol is IParameterSymbol parameter &&
+            parameter.ContainingSymbol is IMethodSymbol { MethodKind: MethodKind.Constructor })
+        {
+            return true;
+        }
+
+        return symbol.Kind is Microsoft.CodeAnalysis.SymbolKind.Field
+            or Microsoft.CodeAnalysis.SymbolKind.Property
+            or Microsoft.CodeAnalysis.SymbolKind.Event
+            or Microsoft.CodeAnalysis.SymbolKind.Method;
+    }
+
+    private static bool IsMemberAccessName(SimpleNameSyntax name) =>
+        name.Parent is MemberAccessExpressionSyntax memberAccess && memberAccess.Name == name ||
+        name.Parent is MemberBindingExpressionSyntax memberBinding && memberBinding.Name == name;
+
+    private static ExpressionSyntax? GetReceiver(SimpleNameSyntax name) => name.Parent switch
+    {
+        MemberAccessExpressionSyntax memberAccess when memberAccess.Name == name => memberAccess.Expression,
+        MemberBindingExpressionSyntax memberBinding when memberBinding.Name == name =>
+            memberBinding.Ancestors().OfType<ConditionalAccessExpressionSyntax>().FirstOrDefault()?.Expression,
+        _ => null
+    };
+
+    private static bool IsReceiverOfTargetMethod(
+        SyntaxNode receiver,
+        IMethodSymbol method,
+        SemanticModel model,
+        CancellationToken cancellationToken)
+    {
+        SimpleNameSyntax? name = receiver.Parent switch
+        {
+            MemberAccessExpressionSyntax memberAccess when memberAccess.Expression == receiver => memberAccess.Name,
+            ConditionalAccessExpressionSyntax conditional when conditional.Expression == receiver =>
+                GetConditionalBindingName(conditional),
+            _ => null
+        };
+
+        if (name == null)
+            return false;
+
+        return model.GetSymbolInfo(name, cancellationToken).Symbol is IMethodSymbol referenced &&
+            SymbolEqualityComparer.Default.Equals(referenced.OriginalDefinition, method.OriginalDefinition);
+    }
+
+    private static SimpleNameSyntax? GetConditionalBindingName(ConditionalAccessExpressionSyntax conditional) =>
+        conditional.WhenNotNull switch
+        {
+            MemberBindingExpressionSyntax binding => binding.Name,
+            InvocationExpressionSyntax invocation when invocation.Expression is MemberBindingExpressionSyntax binding =>
+                binding.Name,
+            _ => null
+        };
+
+    private static RefactoringException CreateUsesInstanceMembersException(
+        IMethodSymbol method,
+        IReadOnlyList<ISymbol> instanceMembers)
+    {
+        var names = instanceMembers
+            .Select(member => member.ToDisplayString())
+            .Distinct()
+            .ToList();
+
+        return new RefactoringException(
+            ErrorCodes.UsesInstanceMembers,
+            $"Cannot make '{method.Name}' static because it uses instance members.",
+            new Dictionary<string, object>
+            {
+                ["symbolName"] = method.Name,
+                ["members"] = names
+            },
+            ["Remove instance member access (including implicit this) or keep the method as an instance method."]);
+    }
+
+    private async Task<StaticPlan> BuildPlanAsync(IMethodSymbol method, CancellationToken cancellationToken)
+    {
+        var declarations = new List<DeclarationEdit>();
+        foreach (var reference in method.DeclaringSyntaxReferences)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var syntax = await reference.GetSyntaxAsync(cancellationToken);
+            if (syntax is not MethodDeclarationSyntax declaration)
+            {
+                throw new RefactoringException(
+                    ErrorCodes.InvalidSymbolKind,
+                    $"Declaration '{method.Name}' is not a method that can be made static.");
+            }
+
+            declarations.Add(new DeclarationEdit(
+                declaration.SyntaxTree,
+                declaration.Span,
+                GetSignatureSnippet(declaration),
+                GetSignatureSnippet(AddStaticModifier(declaration))));
+        }
+
+        if (declarations.Count == 0)
+        {
+            throw new RefactoringException(
+                ErrorCodes.RoslynError,
+                $"Could not locate a declaration to make static for '{method.Name}'.");
+        }
+
+        var callSites = await FindCallSiteEditsAsync(method, cancellationToken);
+        return new StaticPlan(
+            method.Name,
+            method.ToDisplayString(),
+            SymbolKindMapper.Map(method),
+            declarations,
+            callSites);
+    }
+
+    private async Task<IReadOnlyList<CallSiteEdit>> FindCallSiteEditsAsync(
+        IMethodSymbol method,
+        CancellationToken cancellationToken)
+    {
+        var references = await SymbolFinder.FindReferencesAsync(method, Context.Solution, cancellationToken);
+        var edits = new List<CallSiteEdit>();
+
+        foreach (var referencedSymbol in references)
+        {
+            foreach (var location in referencedSymbol.Locations)
+            {
+                if (location.Document == null || !location.Location.IsInSource)
+                    continue;
+
+                if (IsDefinitionLocation(referencedSymbol.Definition, location.Location))
+                    continue;
+
+                ValidateDocumentIsEditable(location.Document, Context.Workspace);
+
+                var root = await location.Document.GetSyntaxRootAsync(cancellationToken);
+                var model = await location.Document.GetSemanticModelAsync(cancellationToken);
+                if (root == null || model == null)
+                    continue;
+
+                var nameNode = FindReferencedName(root, location.Location.SourceSpan);
+                if (nameNode == null)
+                    continue;
+
+                var target = GetRewriteTarget(nameNode);
+                if (target == null)
+                    continue;
+
+                var receiver = GetReceiver(nameNode);
+                var replacement = CreateStaticMemberAccess(
+                    method.ContainingType,
+                    nameNode,
+                    model,
+                    target.SpanStart,
+                    receiver);
+                var replacementWithTrivia = replacement.WithTriviaFrom(target);
+
+                edits.Add(new CallSiteEdit(
+                    location.Document.FilePath ?? string.Empty,
+                    target.SyntaxTree,
+                    target.Span,
+                    target.ToString(),
+                    replacementWithTrivia.ToString()));
+            }
+        }
+
+        return edits;
+    }
+
+    private static SimpleNameSyntax? FindReferencedName(SyntaxNode root, TextSpan span)
+    {
+        var node = root.FindNode(span, getInnermostNodeForTie: true);
+        return node as SimpleNameSyntax
+            ?? node.AncestorsAndSelf().OfType<SimpleNameSyntax>()
+                .FirstOrDefault(name => name.Span.Contains(span) || span.Contains(name.Span));
+    }
+
+    private static SyntaxNode? GetRewriteTarget(SimpleNameSyntax name)
+    {
+        if (name.Parent is MemberAccessExpressionSyntax memberAccess && memberAccess.Name == name)
+            return memberAccess;
+
+        if (name.Parent is MemberBindingExpressionSyntax)
+        {
+            return name.Ancestors().OfType<ConditionalAccessExpressionSyntax>().FirstOrDefault()
+                ?? name.Parent;
+        }
+
+        return null;
+    }
+
+    private static ExpressionSyntax CreateStaticMemberAccess(
+        INamedTypeSymbol containingType,
+        SimpleNameSyntax name,
+        SemanticModel model,
+        int position,
+        ExpressionSyntax? receiver)
+    {
+        var type = containingType;
+        if (receiver != null &&
+            model.GetTypeInfo(receiver).Type is INamedTypeSymbol receiverType &&
+            SymbolEqualityComparer.Default.Equals(receiverType.OriginalDefinition, containingType.OriginalDefinition))
+        {
+            type = receiverType;
+        }
+
+        var typeName = type.ToMinimalDisplayString(model, position);
+        var typeSyntax = SyntaxFactory.ParseName(typeName);
+        return SyntaxFactory.MemberAccessExpression(
+            SyntaxKind.SimpleMemberAccessExpression,
+            typeSyntax,
+            (SimpleNameSyntax)name.WithoutTrivia());
+    }
+
+    private static bool IsDefinitionLocation(ISymbol symbol, Location location)
+    {
+        return symbol.Locations.Any(definition =>
+            definition.IsInSource &&
+            definition.SourceTree == location.SourceTree &&
+            definition.SourceSpan == location.SourceSpan);
+    }
+
+    private static async Task<Solution> ApplyPlanAsync(
+        Solution solution,
+        StaticPlan plan,
+        CancellationToken cancellationToken)
+    {
+        var trees = plan.Declarations.Select(declaration => declaration.SyntaxTree)
+            .Concat(plan.CallSites.Select(callSite => callSite.SyntaxTree))
+            .Distinct();
+
+        foreach (var tree in trees)
+        {
+            var document = solution.GetDocument(tree)
+                ?? throw new RefactoringException(
+                    ErrorCodes.DocumentNotEditable,
+                    "A declaration or call-site document is no longer in the workspace.");
+
+            var root = await document.GetSyntaxRootAsync(cancellationToken)
+                ?? throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse file.");
+
+            var callSiteSpans = plan.CallSites
+                .Where(callSite => callSite.SyntaxTree == tree)
+                .Select(callSite => callSite.Span)
+                .ToHashSet();
+            var declarationSpans = plan.Declarations
+                .Where(declaration => declaration.SyntaxTree == tree)
+                .Select(declaration => declaration.Span)
+                .ToHashSet();
+
+            var rewriteTargets = root.DescendantNodes()
+                .Where(node => callSiteSpans.Contains(node.Span) &&
+                    (node is MemberAccessExpressionSyntax || node is ConditionalAccessExpressionSyntax))
+                .ToList();
+            var methods = root.DescendantNodes()
+                .OfType<MethodDeclarationSyntax>()
+                .Where(method => declarationSpans.Contains(method.Span))
+                .ToList();
+
+            SemanticModel? model = null;
+            if (rewriteTargets.Count > 0)
+            {
+                model = await document.GetSemanticModelAsync(cancellationToken)
+                    ?? throw new RefactoringException(ErrorCodes.RoslynError, "Could not get semantic model.");
+            }
+
+            var replacements = rewriteTargets.ToDictionary(
+                target => target.Span,
+                target => RewriteCallSite(target, model!, plan.Name));
+
+            var methodAnn = new SyntaxAnnotation("make-static-method");
+            var rewriteAnn = new SyntaxAnnotation("make-static-call");
+            var methodSet = methods.Cast<SyntaxNode>().ToHashSet();
+            var rewriteSet = rewriteTargets.ToHashSet();
+            var annotateTargets = methodSet.Concat(rewriteSet).ToList();
+            if (annotateTargets.Count > 0)
+            {
+                root = root.ReplaceNodes(annotateTargets, (original, _) =>
+                {
+                    var node = original;
+                    if (methodSet.Contains(original))
+                        node = node.WithAdditionalAnnotations(methodAnn);
+                    if (rewriteSet.Contains(original))
+                        node = node.WithAdditionalAnnotations(rewriteAnn);
+                    return node;
+                });
+            }
+
+            var annotatedRewrites = root.GetAnnotatedNodes(rewriteAnn).ToList();
+            if (annotatedRewrites.Count > 0)
+            {
+                root = root.ReplaceNodes(annotatedRewrites, (original, _) =>
+                    replacements.TryGetValue(original.Span, out var replacement)
+                        ? replacement
+                        : original);
+            }
+
+            var annotatedMethods = root.GetAnnotatedNodes(methodAnn).OfType<MethodDeclarationSyntax>().ToList();
+            if (annotatedMethods.Count > 0)
+                root = root.ReplaceNodes(annotatedMethods, (original, _) => AddStaticModifier(original));
+
+            solution = document.WithSyntaxRoot(root).Project.Solution;
+        }
+
+        return solution;
+    }
+
+    private static SyntaxNode RewriteCallSite(SyntaxNode original, SemanticModel model, string methodName)
+    {
+        SimpleNameSyntax? name = original switch
+        {
+            MemberAccessExpressionSyntax memberAccess => memberAccess.Name,
+            ConditionalAccessExpressionSyntax conditional => GetConditionalBindingName(conditional),
+            _ => null
+        };
+
+        if (name == null)
+            return original;
+
+        ExpressionSyntax? receiver = original switch
+        {
+            MemberAccessExpressionSyntax memberAccess => memberAccess.Expression,
+            ConditionalAccessExpressionSyntax conditional => conditional.Expression,
+            _ => null
+        };
+
+        var symbol = model.GetSymbolInfo(name).Symbol;
+        var containingType = (symbol as IMethodSymbol)?.ContainingType;
+        if (containingType == null)
+        {
+            var fallback = SyntaxFactory.ParseName(methodName);
+            return SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    fallback,
+                    (SimpleNameSyntax)name.WithoutTrivia())
+                .WithTriviaFrom(original);
+        }
+
+        if (original is ConditionalAccessExpressionSyntax conditionalAccess &&
+            conditionalAccess.WhenNotNull is InvocationExpressionSyntax invocation)
+        {
+            var staticAccess = CreateStaticMemberAccess(
+                containingType, name, model, original.SpanStart, receiver);
+            return invocation
+                .WithExpression(staticAccess)
+                .WithTriviaFrom(original);
+        }
+
+        return CreateStaticMemberAccess(containingType, name, model, original.SpanStart, receiver)
+            .WithTriviaFrom(original);
+    }
+
+    internal static MethodDeclarationSyntax AddStaticModifier(MethodDeclarationSyntax method)
+    {
+        if (method.Modifiers.Any(SyntaxKind.StaticKeyword))
+            return method;
+
+        var staticToken = SyntaxFactory.Token(SyntaxKind.StaticKeyword)
+            .WithTrailingTrivia(SyntaxFactory.Space);
+        var modifiers = method.Modifiers;
+        var insertIndex = 0;
+        for (var i = 0; i < modifiers.Count; i++)
+        {
+            if (modifiers[i].IsKind(SyntaxKind.PublicKeyword) ||
+                modifiers[i].IsKind(SyntaxKind.PrivateKeyword) ||
+                modifiers[i].IsKind(SyntaxKind.ProtectedKeyword) ||
+                modifiers[i].IsKind(SyntaxKind.InternalKeyword))
+            {
+                insertIndex = i + 1;
+            }
+        }
+
+        if (insertIndex == 0 && modifiers.Count > 0)
+        {
+            var first = modifiers[0];
+            staticToken = staticToken.WithLeadingTrivia(first.LeadingTrivia);
+            modifiers = modifiers.Replace(first, first.WithLeadingTrivia(SyntaxFactory.TriviaList()));
+            return method.WithModifiers(modifiers.Insert(0, staticToken));
+        }
+
+        if (insertIndex == 0)
+            return method.WithModifiers(SyntaxFactory.TokenList(staticToken));
+
+        return method.WithModifiers(modifiers.Insert(insertIndex, staticToken));
+    }
+
+    private static string GetSignatureSnippet(MethodDeclarationSyntax method)
+    {
+        var returnType = method.ReturnType.ToString();
+        var modifiers = string.Join(" ", method.Modifiers.Select(token => token.Text));
+        var signature = $"{modifiers} {returnType} {method.Identifier}{method.TypeParameterList}{method.ParameterList}";
+        return signature.Trim();
+    }
+
+    private static RefactoringResult CreatePreviewResult(Guid operationId, StaticPlan plan)
+    {
+        var pendingChanges = new List<PendingChange>();
+        foreach (var declaration in plan.Declarations)
+        {
+            pendingChanges.Add(new PendingChange
+            {
+                File = declaration.SyntaxTree.FilePath ?? string.Empty,
+                ChangeType = ChangeKind.Modify,
+                Description = $"Add static modifier to '{plan.Name}'",
+                BeforeSnippet = declaration.Before,
+                AfterSnippet = declaration.After
+            });
+        }
+
+        foreach (var callSite in plan.CallSites)
+        {
+            pendingChanges.Add(new PendingChange
+            {
+                File = callSite.File,
+                ChangeType = ChangeKind.Modify,
+                Description = $"Update call site of '{plan.Name}' to use the type name",
+                BeforeSnippet = callSite.Before,
+                AfterSnippet = callSite.After
+            });
+        }
+
+        return RefactoringResult.PreviewResult(operationId, pendingChanges);
+    }
+
+    private sealed record DeclarationEdit(SyntaxTree SyntaxTree, TextSpan Span, string Before, string After);
+
+    private sealed record CallSiteEdit(
+        string File,
+        SyntaxTree SyntaxTree,
+        TextSpan Span,
+        string Before,
+        string After);
+
+    private sealed record StaticPlan(
+        string Name,
+        string FullyQualifiedName,
+        Contracts.Enums.SymbolKind Kind,
+        IReadOnlyList<DeclarationEdit> Declarations,
+        IReadOnlyList<CallSiteEdit> CallSites);
+}

--- a/src/RoslynMcp.Server/McpServerHost.cs
+++ b/src/RoslynMcp.Server/McpServerHost.cs
@@ -54,6 +54,7 @@ public sealed class McpServerHost : IAsyncDisposable
         _toolRegistry.Register(new UseBaseTypeTool(workspaceProvider));
         _toolRegistry.Register(new IntroduceFieldTool(workspaceProvider));
         _toolRegistry.Register(new SafeDeleteTool(workspaceProvider));
+        _toolRegistry.Register(new MakeStaticTool(workspaceProvider));
 
         // Code Navigation / Query Tools
         _toolRegistry.Register(new FindReferencesTool(workspaceProvider));

--- a/src/RoslynMcp.Server/RoslynMcp.Server.csproj
+++ b/src/RoslynMcp.Server/RoslynMcp.Server.csproj
@@ -18,7 +18,7 @@
     <Version>0.4.0</Version>
     <Authors>Joshua Ramirez</Authors>
     <Company>RedJay</Company>
-    <Description>MCP Server for Roslyn-powered C# refactoring operations. Install as a global tool to use with Claude Code, Claude Desktop, or other MCP clients. Provides 47 tools: 25 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 7 code conversion tools.</Description>
+    <Description>MCP Server for Roslyn-powered C# refactoring operations. Install as a global tool to use with Claude Code, Claude Desktop, or other MCP clients. Provides 48 tools: 26 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 7 code conversion tools.</Description>
     <PackageTags>roslyn;mcp;refactoring;csharp;model-context-protocol;code-analysis;dotnet;ai-tools;claude</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/JoshuaRamirez/RoslynMcpServer</RepositoryUrl>

--- a/src/RoslynMcp.Server/Tools/MakeStaticTool.cs
+++ b/src/RoslynMcp.Server/Tools/MakeStaticTool.cs
@@ -1,0 +1,154 @@
+using System.Text.Json;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.Refactoring;
+using RoslynMcp.Core.Refactoring.Extract;
+using RoslynMcp.Core.Workspace;
+using RoslynMcp.Server.Transport;
+
+namespace RoslynMcp.Server.Tools;
+
+/// <summary>
+/// MCP tool handler for make_static operation.
+/// </summary>
+public sealed class MakeStaticTool : IToolHandler
+{
+    private readonly IWorkspaceProvider _workspaceProvider;
+    private readonly JsonSerializerOptions _jsonOptions;
+
+    /// <summary>
+    /// Creates a new make-static tool.
+    /// </summary>
+    public MakeStaticTool(IWorkspaceProvider workspaceProvider)
+    {
+        _workspaceProvider = workspaceProvider;
+        _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = false
+        };
+    }
+
+    /// <inheritdoc />
+    public string Name => "make_static";
+
+    /// <inheritdoc />
+    public string Description => "Make a selected instance method static when it does not use instance state. Adds the static modifier and updates call sites and method-group conversions to the containing type name.";
+
+    /// <inheritdoc />
+    public object InputSchema => new
+    {
+        type = "object",
+        required = new[] { "solutionPath", "sourceFile", "startLine", "startColumn", "endLine", "endColumn" },
+        properties = new
+        {
+            solutionPath = new
+            {
+                type = "string",
+                description = "Absolute path to the .sln or .csproj file"
+            },
+            sourceFile = new
+            {
+                type = "string",
+                description = "Absolute path to the source file"
+            },
+            startLine = new
+            {
+                type = "integer",
+                description = "Start line of the selected method (1-based)"
+            },
+            startColumn = new
+            {
+                type = "integer",
+                description = "Start column of the selected method (1-based)"
+            },
+            endLine = new
+            {
+                type = "integer",
+                description = "End line of the selected method (1-based)"
+            },
+            endColumn = new
+            {
+                type = "integer",
+                description = "End column of the selected method (1-based)"
+            },
+            symbolName = new
+            {
+                type = "string",
+                description = "Optional method name used to confirm the selection"
+            },
+            preview = new
+            {
+                type = "boolean",
+                description = "Return computed changes without applying",
+                @default = false
+            }
+        },
+        additionalProperties = false
+    };
+
+    /// <inheritdoc />
+    public async Task<ToolResult> ExecuteAsync(JsonElement? arguments, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (arguments == null)
+            {
+                return ToolResult.Error("Arguments required");
+            }
+
+            var args = JsonSerializer.Deserialize<MakeStaticArgs>(arguments.Value.GetRawText(), _jsonOptions);
+            if (args == null)
+            {
+                return ToolResult.Error("Failed to parse arguments");
+            }
+
+            using var context = await _workspaceProvider.CreateContextAsync(
+                args.SolutionPath,
+                cancellationToken);
+
+            var operation = new MakeStaticOperation(context);
+            var @params = new MakeStaticParams
+            {
+                SourceFile = args.SourceFile,
+                StartLine = args.StartLine,
+                StartColumn = args.StartColumn,
+                EndLine = args.EndLine,
+                EndColumn = args.EndColumn,
+                SymbolName = args.SymbolName,
+                Preview = args.Preview ?? false
+            };
+
+            var result = await operation.ExecuteAsync(@params, cancellationToken);
+
+            var json = JsonSerializer.Serialize(result, _jsonOptions);
+            return result.Success ? ToolResult.Success(json) : ToolResult.Error(json);
+        }
+        catch (RefactoringException ex)
+        {
+            var error = ex.ToError();
+            var json = JsonSerializer.Serialize(new { success = false, error }, _jsonOptions);
+            return ToolResult.Error(json);
+        }
+        catch (Exception ex)
+        {
+            var json = JsonSerializer.Serialize(new
+            {
+                success = false,
+                error = new { code = "INTERNAL_ERROR", message = ex.Message }
+            }, _jsonOptions);
+            return ToolResult.Error(json);
+        }
+    }
+
+    private sealed class MakeStaticArgs
+    {
+        public string SolutionPath { get; init; } = "";
+        public string SourceFile { get; init; } = "";
+        public int StartLine { get; init; }
+        public int StartColumn { get; init; }
+        public int EndLine { get; init; }
+        public int EndColumn { get; init; }
+        public string? SymbolName { get; init; }
+        public bool? Preview { get; init; }
+    }
+}

--- a/tests/RoslynMcp.Cli.Tests/HelpGeneratorTests.cs
+++ b/tests/RoslynMcp.Cli.Tests/HelpGeneratorTests.cs
@@ -15,16 +15,17 @@ public class HelpGeneratorTests
     }
 
     [Fact]
-    public void GenerateGlobalHelp_Lists47Tools()
+    public void GenerateGlobalHelp_Lists48Tools()
     {
         var registry = ToolRegistry.BuildDefault();
         var help = HelpGenerator.GenerateGlobalHelp(registry);
-        Assert.Contains("Total: 47 tools", help);
+        Assert.Contains("Total: 48 tools", help);
         Assert.Contains("pull-members-up", help);
         Assert.Contains("push-members-down", help);
         Assert.Contains("use-base-type", help);
         Assert.Contains("introduce-field", help);
         Assert.Contains("safe-delete", help);
+        Assert.Contains("make-static", help);
     }
 
     [Fact]

--- a/tests/RoslynMcp.Cli.Tests/ToolRegistryTests.cs
+++ b/tests/RoslynMcp.Cli.Tests/ToolRegistryTests.cs
@@ -6,11 +6,11 @@ namespace RoslynMcp.Cli.Tests;
 public class ToolRegistryTests
 {
     [Fact]
-    public void BuildDefault_Registers47Tools()
+    public void BuildDefault_Registers48Tools()
     {
         var registry = ToolRegistry.BuildDefault();
         var tools = registry.GetAllTools();
-        Assert.Equal(47, tools.Count);
+        Assert.Equal(48, tools.Count);
     }
 
     [Fact]
@@ -89,6 +89,7 @@ public class ToolRegistryTests
     [InlineData("use-base-type", "Refactoring")]
     [InlineData("introduce-field", "Refactoring")]
     [InlineData("safe-delete", "Refactoring")]
+    [InlineData("make-static", "Refactoring")]
     [InlineData("find-references", "Query")]
     [InlineData("get-diagnostics", "Query")]
     [InlineData("diagnose", "Diagnostic")]
@@ -107,11 +108,11 @@ public class ToolRegistryTests
     }
 
     [Fact]
-    public void RefactoringToolCount_Is34()
+    public void RefactoringToolCount_Is35()
     {
         var registry = ToolRegistry.BuildDefault();
         var count = registry.GetAllTools().Count(t => t.Category == "Refactoring");
-        Assert.Equal(34, count);
+        Assert.Equal(35, count);
     }
 
     [Fact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Extract/MakeStaticOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Extract/MakeStaticOperationTests.cs
@@ -1,0 +1,596 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using RoslynMcp.Contracts.Errors;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.Refactoring;
+using RoslynMcp.Core.Refactoring.Extract;
+using RoslynMcp.Core.Workspace;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Refactoring.Extract;
+
+/// <summary>
+/// Operation-level tests for <see cref="MakeStaticOperation"/>.
+/// </summary>
+public class MakeStaticOperationTests
+{
+    #region Input Validation
+
+    [Fact]
+    public void Validate_MissingSourceFile_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            MakeStaticOperation.Validate(new MakeStaticParams
+            {
+                SourceFile = "",
+                StartLine = 1,
+                StartColumn = 1,
+                EndLine = 1,
+                EndColumn = 2
+            }));
+
+        Assert.Equal(ErrorCodes.MissingRequiredParam, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_RelativePath_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            MakeStaticOperation.Validate(new MakeStaticParams
+            {
+                SourceFile = "Types.cs",
+                StartLine = 1,
+                StartColumn = 1,
+                EndLine = 1,
+                EndColumn = 2
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidSourcePath, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_InvalidLine_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            MakeStaticOperation.Validate(new MakeStaticParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                StartLine = 0,
+                StartColumn = 1,
+                EndLine = 1,
+                EndColumn = 2
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidLineNumber, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_InvalidSelectionRange_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            MakeStaticOperation.Validate(new MakeStaticParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                StartLine = 2,
+                StartColumn = 1,
+                EndLine = 1,
+                EndColumn = 2
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidSelectionRange, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_MissingFile_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            MakeStaticOperation.Validate(new MakeStaticParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                StartLine = 1,
+                StartColumn = 1,
+                EndLine = 1,
+                EndColumn = 2
+            }));
+
+        Assert.Equal(ErrorCodes.SourceFileNotFound, ex.ErrorCode);
+    }
+
+    #endregion
+
+    #region P0 Happy Path
+
+    [SkippableFact]
+    public async Task MakeStatic_PureMethod_AddsStaticAndUpdatesCallSites()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public int Add(int a, int b)
+                {
+                    return a + b;
+                }
+
+                public int Use()
+                {
+                    var other = new Calculator();
+                    return other.Add(1, 2) + this.Add(3, 4) + Add(5, 6);
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new MakeStaticOperation(workspace.Context);
+        var span = FindSpan(source, "Add");
+
+        var result = await operation.ExecuteAsync(new MakeStaticParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = span.StartLine,
+            StartColumn = span.StartColumn,
+            EndLine = span.EndLine,
+            EndColumn = span.EndColumn,
+            SymbolName = "Add"
+        });
+
+        Assert.True(result.Success);
+        Assert.False(result.Preview);
+        Assert.NotNull(result.Symbol);
+        Assert.Equal("Add", result.Symbol.Name);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("public static int Add(int a, int b)", updated);
+        Assert.DoesNotContain("other.Add(1, 2)", updated);
+        Assert.DoesNotContain("this.Add(3, 4)", updated);
+        Assert.Contains("Calculator.Add(1, 2)", updated);
+        Assert.Contains("Calculator.Add(3, 4)", updated);
+        Assert.Contains("Add(5, 6)", updated);
+    }
+
+    [SkippableFact]
+    public async Task MakeStatic_MethodGroup_RewritesToTypeName()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public int Double(int x)
+                {
+                    return x * 2;
+                }
+
+                public void Use()
+                {
+                    var other = new Calculator();
+                    System.Func<int, int> fromInstance = other.Double;
+                    System.Func<int, int> fromThis = this.Double;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new MakeStaticOperation(workspace.Context);
+        var span = FindSpan(source, "Double");
+
+        var result = await operation.ExecuteAsync(new MakeStaticParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = span.StartLine,
+            StartColumn = span.StartColumn,
+            EndLine = span.EndLine,
+            EndColumn = span.EndColumn,
+            SymbolName = "Double"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("public static int Double(int x)", updated);
+        Assert.Contains("fromInstance = Calculator.Double", updated);
+        Assert.Contains("fromThis = Calculator.Double", updated);
+        Assert.DoesNotContain("other.Double", updated);
+        Assert.DoesNotContain("this.Double", updated);
+    }
+
+    #endregion
+
+    #region P0 Preview
+
+    [SkippableFact]
+    public async Task MakeStatic_Preview_DoesNotModifyFile()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public int Add(int a, int b)
+                {
+                    return a + b;
+                }
+
+                public int Use()
+                {
+                    return this.Add(1, 2);
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+        var operation = new MakeStaticOperation(workspace.Context);
+        var span = FindSpan(source, "Add");
+
+        var result = await operation.ExecuteAsync(new MakeStaticParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = span.StartLine,
+            StartColumn = span.StartColumn,
+            EndLine = span.EndLine,
+            EndColumn = span.EndColumn,
+            Preview = true
+        });
+
+        Assert.True(result.Success);
+        Assert.True(result.Preview);
+        Assert.NotNull(result.PendingChanges);
+        Assert.Contains(result.PendingChanges, change => change.Description.Contains("Add"));
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    #endregion
+
+    #region P0 Rejects
+
+    [SkippableFact]
+    public async Task MakeStatic_UsesInstanceField_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                private int _value;
+
+                public int Get()
+                {
+                    return _value;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new MakeStaticOperation(workspace.Context);
+        var span = FindSpan(source, "Get");
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new MakeStaticParams
+            {
+                SourceFile = workspace.SourcePath,
+                StartLine = span.StartLine,
+                StartColumn = span.StartColumn,
+                EndLine = span.EndLine,
+                EndColumn = span.EndColumn,
+                SymbolName = "Get"
+            }));
+
+        Assert.Equal(ErrorCodes.UsesInstanceMembers, ex.ErrorCode);
+        Assert.NotNull(ex.Details);
+        Assert.True(ex.Details.ContainsKey("members"));
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("public int Get()", before);
+        Assert.DoesNotContain("static", before);
+    }
+
+    [SkippableFact]
+    public async Task MakeStatic_UsesImplicitThisMethod_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public int Value()
+                {
+                    return 1;
+                }
+
+                public int Get()
+                {
+                    return Value();
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new MakeStaticOperation(workspace.Context);
+        var span = FindIdentifierSpan(source, "Get");
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new MakeStaticParams
+            {
+                SourceFile = workspace.SourcePath,
+                StartLine = span.StartLine,
+                StartColumn = span.StartColumn,
+                EndLine = span.EndLine,
+                EndColumn = span.EndColumn,
+                SymbolName = "Get"
+            }));
+
+        Assert.Equal(ErrorCodes.UsesInstanceMembers, ex.ErrorCode);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [SkippableFact]
+    public async Task MakeStatic_AlreadyStatic_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public static int Add(int a, int b)
+                {
+                    return a + b;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new MakeStaticOperation(workspace.Context);
+        var span = FindSpan(source, "Add");
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new MakeStaticParams
+            {
+                SourceFile = workspace.SourcePath,
+                StartLine = span.StartLine,
+                StartColumn = span.StartColumn,
+                EndLine = span.EndLine,
+                EndColumn = span.EndColumn,
+                SymbolName = "Add"
+            }));
+
+        Assert.Equal(ErrorCodes.AlreadyStatic, ex.ErrorCode);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [SkippableFact]
+    public async Task MakeStatic_NoSymbol_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public int Add(int a, int b)
+                {
+                    return a + b;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new MakeStaticOperation(workspace.Context);
+        var span = FindSpan(source, "return");
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new MakeStaticParams
+            {
+                SourceFile = workspace.SourcePath,
+                StartLine = span.StartLine,
+                StartColumn = span.StartColumn,
+                EndLine = span.EndLine,
+                EndColumn = span.EndColumn
+            }));
+
+        Assert.Equal(ErrorCodes.SymbolNotFound, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task MakeStatic_NonMethod_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                private int _value;
+
+                public int Get()
+                {
+                    return 42;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new MakeStaticOperation(workspace.Context);
+        var span = FindSpan(source, "_value");
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new MakeStaticParams
+            {
+                SourceFile = workspace.SourcePath,
+                StartLine = span.StartLine,
+                StartColumn = span.StartColumn,
+                EndLine = span.EndLine,
+                EndColumn = span.EndColumn,
+                SymbolName = "_value"
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidSymbolKind, ex.ErrorCode);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [Fact]
+    public void MakeStatic_UneditableDocument_Throws()
+    {
+        var workspace = new AdhocWorkspace();
+        var project = workspace.AddProject("P", LanguageNames.CSharp);
+        var document = workspace.AddDocument(project.Id, "Generated.cs", SourceText.From("class C {}"));
+
+        var ex = Assert.Throws<RefactoringException>(() =>
+            MakeStaticOperation.ValidateDocumentIsEditable(document, workspace));
+
+        Assert.Equal(ErrorCodes.DocumentNotEditable, ex.ErrorCode);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static string AbsoluteTestPath() =>
+        Path.Combine(Path.GetTempPath(), "RoslynMcpMakeStaticMissing.cs");
+
+    private static string NormalizeNewlines(string text) =>
+        text.Replace("\r\n", "\n", StringComparison.Ordinal);
+
+    private static (int StartLine, int StartColumn, int EndLine, int EndColumn) FindSpan(string source, string snippet)
+    {
+        var index = source.IndexOf(snippet, StringComparison.Ordinal);
+        if (index < 0)
+            throw new InvalidOperationException($"Snippet not found: {snippet}");
+
+        return (GetLineColumn(source, index).Line, GetLineColumn(source, index).Column,
+            GetLineColumn(source, index + snippet.Length).Line, GetLineColumn(source, index + snippet.Length).Column);
+    }
+
+    /// <summary>
+    /// Finds the first identifier occurrence that is a standalone token, not a
+    /// prefix of a longer identifier (for example <c>Get</c> in <c>Get()</c>
+    /// rather than the <c>Get</c> inside <c>GetHashCode</c>).
+    /// </summary>
+    private static (int StartLine, int StartColumn, int EndLine, int EndColumn) FindIdentifierSpan(
+        string source,
+        string identifier)
+    {
+        var start = 0;
+        while (start < source.Length)
+        {
+            var index = source.IndexOf(identifier, start, StringComparison.Ordinal);
+            if (index < 0)
+                throw new InvalidOperationException($"Identifier not found: {identifier}");
+
+            var beforeOk = index == 0 || !IsIdentifierPart(source[index - 1]);
+            var afterIndex = index + identifier.Length;
+            var afterOk = afterIndex >= source.Length || !IsIdentifierPart(source[afterIndex]);
+            if (beforeOk && afterOk)
+            {
+                return (GetLineColumn(source, index).Line, GetLineColumn(source, index).Column,
+                    GetLineColumn(source, afterIndex).Line, GetLineColumn(source, afterIndex).Column);
+            }
+
+            start = index + 1;
+        }
+
+        throw new InvalidOperationException($"Identifier not found: {identifier}");
+    }
+
+    private static bool IsIdentifierPart(char c) => char.IsLetterOrDigit(c) || c == '_';
+
+    private static (int Line, int Column) GetLineColumn(string source, int index)
+    {
+        var line = 1;
+        var column = 1;
+        for (var i = 0; i < index; i++)
+        {
+            if (source[i] == '\n')
+            {
+                line++;
+                column = 1;
+            }
+            else
+            {
+                column++;
+            }
+        }
+
+        return (line, column);
+    }
+
+    private sealed class TempWorkspace : IAsyncDisposable
+    {
+        public required string DirectoryPath { get; init; }
+        public required string ProjectPath { get; init; }
+        public required string SourcePath { get; init; }
+        public required WorkspaceContext Context { get; init; }
+
+        public static async Task<TempWorkspace> CreateAsync(string source, string fileName = "Types.cs")
+        {
+            Skip.IfNot(ModuleInitializer.MsBuildAvailable, ModuleInitializer.MsBuildError ?? "MSBuild not available");
+
+            var directory = Path.Combine(Path.GetTempPath(), "RoslynMcpMakeStatic_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(directory);
+
+            var projectPath = Path.Combine(directory, "TestApp.csproj");
+            var sourcePath = Path.Combine(directory, fileName);
+
+            await File.WriteAllTextAsync(projectPath, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net9.0</TargetFramework>
+                    <Nullable>enable</Nullable>
+                  </PropertyGroup>
+                </Project>
+                """);
+            await File.WriteAllTextAsync(sourcePath, source);
+
+            try
+            {
+                var provider = new MSBuildWorkspaceProvider();
+                var context = await provider.CreateContextAsync(projectPath);
+                if (context.GetDocumentByPath(sourcePath) == null)
+                {
+                    context.Dispose();
+                    throw new InvalidOperationException($"Workspace loaded but did not include {sourcePath}.");
+                }
+
+                return new TempWorkspace
+                {
+                    DirectoryPath = directory,
+                    ProjectPath = projectPath,
+                    SourcePath = sourcePath,
+                    Context = context
+                };
+            }
+            catch (Exception ex) when (ex is not SkipException)
+            {
+                try
+                {
+                    Directory.Delete(directory, recursive: true);
+                }
+                catch
+                {
+                    // ignore cleanup failures
+                }
+
+                Skip.If(true, $"Workspace load failed: {ex.Message}");
+                throw;
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            Context.Dispose();
+            await Task.Run(() =>
+            {
+                try
+                {
+                    Directory.Delete(DirectoryPath, recursive: true);
+                }
+                catch
+                {
+                    // ignore locked temp files
+                }
+            });
+        }
+    }
+
+    #endregion
+}

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Extract/MakeStaticOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Extract/MakeStaticOperationTests.cs
@@ -428,6 +428,81 @@ public class MakeStaticOperationTests
         Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
     }
 
+    [SkippableFact]
+    public async Task MakeStatic_ConditionalAccessInvocation_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public void Log()
+                {
+                }
+
+                public void Use(Calculator? other)
+                {
+                    other?.Log();
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new MakeStaticOperation(workspace.Context);
+        var span = FindIdentifierSpan(source, "Log");
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new MakeStaticParams
+            {
+                SourceFile = workspace.SourcePath,
+                StartLine = span.StartLine,
+                StartColumn = span.StartColumn,
+                EndLine = span.EndLine,
+                EndColumn = span.EndColumn,
+                SymbolName = "Log"
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidSelection, ex.ErrorCode);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("other?.Log();", before);
+        Assert.DoesNotContain("static", before);
+    }
+
+    [SkippableFact]
+    public async Task MakeStatic_ExternMethod_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public extern int Add(int a, int b);
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new MakeStaticOperation(workspace.Context);
+        var span = FindSpan(source, "Add");
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new MakeStaticParams
+            {
+                SourceFile = workspace.SourcePath,
+                StartLine = span.StartLine,
+                StartColumn = span.StartColumn,
+                EndLine = span.EndLine,
+                EndColumn = span.EndColumn,
+                SymbolName = "Add"
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidSymbolKind, ex.ErrorCode);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("public extern int Add(int a, int b);", before);
+        Assert.DoesNotContain("static", before);
+    }
+
     [Fact]
     public void MakeStatic_UneditableDocument_Throws()
     {

--- a/tests/RoslynMcp.Server.Tests/Tools/MakeStaticToolTests.cs
+++ b/tests/RoslynMcp.Server.Tests/Tools/MakeStaticToolTests.cs
@@ -1,0 +1,140 @@
+using System.Text.Json;
+using RoslynMcp.Server.Tests.TestHelpers;
+using RoslynMcp.Server.Tools;
+using RoslynMcp.Server.Transport;
+using Xunit;
+
+namespace RoslynMcp.Server.Tests.Tools;
+
+/// <summary>
+/// Unit tests for MakeStaticTool.
+/// Tests tool definition and argument validation.
+/// </summary>
+public class MakeStaticToolTests
+{
+    private readonly MakeStaticTool _tool;
+
+    public MakeStaticToolTests()
+    {
+        _tool = new MakeStaticTool(new ThrowingWorkspaceProvider());
+    }
+
+    #region GetDefinition Tests
+
+    [Fact]
+    public void GetDefinition_ReturnsCorrectName()
+    {
+        Assert.Equal("make_static", _tool.Name);
+    }
+
+    [Fact]
+    public void GetDefinition_ReturnsNonEmptyDescription()
+    {
+        Assert.NotNull(_tool.Description);
+        Assert.NotEmpty(_tool.Description);
+    }
+
+    [Fact]
+    public void GetDefinition_ReturnsCorrectSchema()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.Equal("object", root.GetProperty("type").GetString());
+        Assert.True(root.TryGetProperty("properties", out _));
+        Assert.True(root.TryGetProperty("required", out _));
+    }
+
+    [Fact]
+    public void GetDefinition_HasRequiredFields()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var required = doc.RootElement.GetProperty("required");
+
+        var requiredFields = new List<string>();
+        foreach (var item in required.EnumerateArray())
+        {
+            requiredFields.Add(item.GetString()!);
+        }
+
+        Assert.Contains("solutionPath", requiredFields);
+        Assert.Contains("sourceFile", requiredFields);
+        Assert.Contains("startLine", requiredFields);
+        Assert.Contains("startColumn", requiredFields);
+        Assert.Contains("endLine", requiredFields);
+        Assert.Contains("endColumn", requiredFields);
+    }
+
+    [Fact]
+    public void GetDefinition_HasProperties_ForAllParameters()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var properties = doc.RootElement.GetProperty("properties");
+
+        Assert.True(properties.TryGetProperty("solutionPath", out _));
+        Assert.True(properties.TryGetProperty("sourceFile", out _));
+        Assert.True(properties.TryGetProperty("startLine", out _));
+        Assert.True(properties.TryGetProperty("startColumn", out _));
+        Assert.True(properties.TryGetProperty("endLine", out _));
+        Assert.True(properties.TryGetProperty("endColumn", out _));
+        Assert.True(properties.TryGetProperty("symbolName", out _));
+        Assert.True(properties.TryGetProperty("preview", out _));
+    }
+
+    #endregion
+
+    #region ExecuteAsync Argument Validation Tests
+
+    [Fact]
+    public async Task ExecuteAsync_NullArguments_ReturnsError()
+    {
+        var result = await _tool.ExecuteAsync(null);
+
+        Assert.True(result.IsError);
+        Assert.Contains("Arguments required", GetResultText(result));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EmptyArguments_ReturnsError()
+    {
+        var args = JsonDocument.Parse("{}").RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MissingRequiredField_ReturnsError()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "solutionPath": "C:/test/test.sln",
+                "sourceFile": "C:/test/Test.cs",
+                "startLine": 10,
+                "startColumn": 5
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static string GetResultText(ToolResult result)
+    {
+        return result.Content.FirstOrDefault()?.Text ?? string.Empty;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Description

Adds `make_static` / `MakeStaticOperation`, the next Phase 3 increment after `safe_delete`. A selected instance method can be made static when it does not use instance state: the operation adds the `static` modifier, rewrites instance call sites to the containing type name, and updates method-group conversions.

Follow-up on review TAKEs:
- Reject `?.` invocation and method-group call sites instead of rewriting them to unconditional type-name calls (preserves null-conditional short-circuiting; also covers the preview vs apply mismatch).
- Reject `extern` methods, which have no body to analyze for instance state.

## 🔗 Related Issues

Closes #42

## 🎯 Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Test additions or updates

## 🧪 Testing

- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Manual testing performed (operation + tool + CLI registry tests locally)

P0 coverage:
- Happy path: add `static` and rewrite `instance.Method()` / `this.Method()` call sites
- Method-group conversions (`other.Method` / `this.Method` → `Type.Method`)
- Preview mode does not modify files
- Rejects: uses instance members (field and implicit-this method), already static, no symbol, non-method, uneditable document, `obj?.Method()` call sites, extern methods
- MCP + CLI registration; tool count 47 → 48; refactoring category 34 → 35

**Test Configuration**:
- OS: Linux
- .NET Version: 9.0.317

## ✅ Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have added XML documentation for public APIs
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## 📋 Additional Notes

Placement matches shipped Phase 3 ops (`SafeDeleteOperation`, `IntroduceFieldOperation`): Core operation in `Refactoring/Extract`, plus Contracts params, MCP tool, and CLI registration. Out of scope: `make_non_static`, constructors/operators as first-class targets, force-anything, undo.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6ce5715-8b16-4777-b9e0-cbe98c071ffa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6ce5715-8b16-4777-b9e0-cbe98c071ffa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

