### PR TITLE
Add make_non_static refactoring

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "roslyn-mcp",
   "version": "0.4.1",
-  "description": "Roslyn-powered C# refactoring MCP server — 48 tools for code navigation, analysis, generation, and refactoring across entire .NET solutions",
+  "description": "Roslyn-powered C# refactoring MCP server — 49 tools for code navigation, analysis, generation, and refactoring across entire .NET solutions",
   "author": {
     "name": "Joshua Ramirez"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - `introduce_field` — turn a selected local variable or expression into a class field, optionally initializing it in a constructor, with preview mode and rejects for missing expressions, uneditable documents, and invalid target types
 - `safe_delete` — delete a selected symbol only when it has no remaining references, with preview mode and rejects that include usage locations, missing symbols, and uneditable documents
 - `make_static` — add the static modifier to a selected instance method that does not use instance state, update call sites and method-group conversions to the containing type name, with preview mode and rejects for instance-member access, already-static methods, and uneditable documents
+- `make_non_static` — remove the static modifier from a selected static method, rewrite type-name call sites and method-group conversions to an instance receiver (or `this` in the same type), with preview mode and rejects for already-instance methods, missing receivers, extern methods, and uneditable documents
 
 ## [0.4.0] - 2026-02-23
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Let AI assistants like Claude safely refactor your C# codebase using the same Roslyn compiler platform that powers Visual Studio.
 
-Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that exposes **48 Roslyn-powered tools** to AI assistants and other MCP clients. It combines 26 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 7 code conversion tools -- giving your AI deep code intelligence, comprehensive refactoring, and modern C# syntax transformations with full solution-wide reference tracking and preview support.
+Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that exposes **49 Roslyn-powered tools** to AI assistants and other MCP clients. It combines 27 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 7 code conversion tools -- giving your AI deep code intelligence, comprehensive refactoring, and modern C# syntax transformations with full solution-wide reference tracking and preview support.
 
 ---
 
@@ -30,7 +30,7 @@ Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotoc
 
 ## Why RoslynMcpServer?
 
-- **48 tools** -- refactoring, navigation, analysis, generation, and conversion tools, the most comprehensive Roslyn MCP server available
+- **49 tools** -- refactoring, navigation, analysis, generation, and conversion tools, the most comprehensive Roslyn MCP server available
 - **Preview mode on every operation** -- see exactly what will change before applying
 - **Atomic file writes with rollback** -- if any file write fails, all changes are reverted
 - **Solution-wide reference updates** -- renames and moves propagate across your entire solution
@@ -102,7 +102,7 @@ Claude will use the `rename_symbol` tool to rename the class and update every re
 
 ## Standalone CLI
 
-All 48 tools are also available as a standalone CLI for use in scripts, CI/CD pipelines, and terminals without an AI assistant.
+All 49 tools are also available as a standalone CLI for use in scripts, CI/CD pipelines, and terminals without an AI assistant.
 
 ### Install
 
@@ -207,6 +207,7 @@ All tools accept a `solutionPath` parameter (absolute path to a `.sln`, `.slnx`,
 | `introduce_field` | Turn a selected local variable or expression into a class field, optionally initializing it in a constructor. | `sourceFile`, `startLine`, `startColumn`, `endLine`, `endColumn`, `fieldName`, `isReadonly`, `isStatic`, `initializeInConstructor`, `replaceAll` |
 | `safe_delete` | Delete a selected symbol only when it has no remaining references. If usages exist, reject with their locations. | `sourceFile`, `startLine`, `startColumn`, `endLine`, `endColumn`, `symbolName` |
 | `make_static` | Make a selected instance method static when it does not use instance state. Adds the static modifier and updates call sites and method-group conversions to the containing type name. | `sourceFile`, `startLine`, `startColumn`, `endLine`, `endColumn`, `symbolName` |
+| `make_non_static` | Make a selected static method an instance method when a valid instance receiver exists. Removes the static modifier and updates type-name call sites and method-group conversions to an instance receiver (or `this` in the same type). | `sourceFile`, `startLine`, `startColumn`, `endLine`, `endColumn`, `symbolName` |
 
 ### Inline
 

--- a/src/RoslynMcp.Cli/ToolRegistry.cs
+++ b/src/RoslynMcp.Cli/ToolRegistry.cs
@@ -47,7 +47,7 @@ public sealed class ToolEntry
 }
 
 /// <summary>
-/// Maps tool names to execution delegates for all 48 Roslyn tools.
+/// Maps tool names to execution delegates for all 49 Roslyn tools.
 /// </summary>
 public sealed class ToolRegistry
 {
@@ -139,7 +139,7 @@ public sealed class ToolRegistry
         _tools.Values.OrderBy(t => t.Category).ThenBy(t => t.Name).ToList();
 
     /// <summary>
-    /// Build the default registry with all 48 tools registered.
+    /// Build the default registry with all 49 tools registered.
     /// </summary>
     public static ToolRegistry BuildDefault()
     {
@@ -170,6 +170,8 @@ public sealed class ToolRegistry
             "safe-delete", "Delete a selected symbol only when it has no remaining references");
         r.RegisterRefactoring<MakeStaticOperation, MakeStaticParams>(
             "make-static", "Make a selected instance method static when it does not use instance state");
+        r.RegisterRefactoring<MakeNonStaticOperation, MakeNonStaticParams>(
+            "make-non-static", "Make a selected static method an instance method when a valid instance receiver exists");
 
         // ── Refactoring: Rename (1) ───────────────────────────────────
         r.RegisterRefactoring<RenameSymbolOperation, RenameSymbolParams>(

--- a/src/RoslynMcp.Contracts/Enums/RefactoringKind.cs
+++ b/src/RoslynMcp.Contracts/Enums/RefactoringKind.cs
@@ -50,6 +50,9 @@ public enum RefactoringKind
     /// <summary>Add the static modifier to an instance method that does not use instance state.</summary>
     MakeStatic,
 
+    /// <summary>Remove the static modifier from a method and rewrite call sites to an instance receiver.</summary>
+    MakeNonStatic,
+
     /// <summary>Extract expression to variable.</summary>
     ExtractVariable,
 

--- a/src/RoslynMcp.Contracts/Errors/ErrorCodes.cs
+++ b/src/RoslynMcp.Contracts/Errors/ErrorCodes.cs
@@ -369,7 +369,7 @@ public static class ErrorCodes
     public const string MemberHasUsages = "3119";
 
     // --------------------------------------------
-    // Make Static Errors (3120-3121)
+    // Make Static / Make Non-Static Errors (3120-3123)
     // --------------------------------------------
 
     /// <summary>Cannot make static because the method uses instance members.</summary>
@@ -377,6 +377,12 @@ public static class ErrorCodes
 
     /// <summary>Member is already static.</summary>
     public const string AlreadyStatic = "3121";
+
+    /// <summary>Member is already an instance member.</summary>
+    public const string AlreadyInstance = "3122";
+
+    /// <summary>Cannot make non-static because no valid instance receiver exists for a call site.</summary>
+    public const string NoValidInstanceReceiver = "3123";
 
     // ============================================
     // System Errors (4xxx)

--- a/src/RoslynMcp.Contracts/Models/MakeNonStaticParams.cs
+++ b/src/RoslynMcp.Contracts/Models/MakeNonStaticParams.cs
@@ -1,0 +1,42 @@
+namespace RoslynMcp.Contracts.Models;
+
+/// <summary>
+/// Parameters for the make_non_static tool.
+/// </summary>
+public sealed class MakeNonStaticParams
+{
+    /// <summary>
+    /// Absolute path to the source file.
+    /// </summary>
+    public required string SourceFile { get; init; }
+
+    /// <summary>
+    /// Start line of the selected method (1-based).
+    /// </summary>
+    public required int StartLine { get; init; }
+
+    /// <summary>
+    /// Start column of the selected method (1-based).
+    /// </summary>
+    public required int StartColumn { get; init; }
+
+    /// <summary>
+    /// End line of the selected method (1-based).
+    /// </summary>
+    public required int EndLine { get; init; }
+
+    /// <summary>
+    /// End column of the selected method (1-based).
+    /// </summary>
+    public required int EndColumn { get; init; }
+
+    /// <summary>
+    /// Optional method name used to confirm the selection.
+    /// </summary>
+    public string? SymbolName { get; init; }
+
+    /// <summary>
+    /// Return computed changes without applying. Default: false.
+    /// </summary>
+    public bool Preview { get; init; }
+}

--- a/src/RoslynMcp.Core/Refactoring/Extract/MakeNonStaticOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/MakeNonStaticOperation.cs
@@ -898,7 +898,7 @@ public sealed class MakeNonStaticOperation : RefactoringOperationBase<MakeNonSta
             return SyntaxFactory.IdentifierName(
                 SyntaxFactory.VerbatimIdentifier(
                     SyntaxFactory.TriviaList(),
-                    "@" + name,
+                    name,
                     name,
                     SyntaxFactory.TriviaList()));
         }

--- a/src/RoslynMcp.Core/Refactoring/Extract/MakeNonStaticOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/MakeNonStaticOperation.cs
@@ -649,11 +649,10 @@ public sealed class MakeNonStaticOperation : RefactoringOperationBase<MakeNonSta
         var unique = candidates
             .Distinct<ISymbol>(SymbolEqualityComparer.Default)
             .ToList();
-        if (unique.Count != 1)
+        if (unique.Count != 1 || string.IsNullOrEmpty(unique[0].Name))
             return null;
 
-        var name = unique[0].ToMinimalDisplayString(model, callSite.SpanStart);
-        return SyntaxFactory.ParseExpression(name);
+        return SyntaxFactory.IdentifierName(unique[0].Name);
     }
 
     private static bool IsUsableInstanceCandidate(

--- a/src/RoslynMcp.Core/Refactoring/Extract/MakeNonStaticOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/MakeNonStaticOperation.cs
@@ -1,0 +1,908 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Text;
+using RoslynMcp.Contracts.Enums;
+using RoslynMcp.Contracts.Errors;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.FileSystem;
+using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Resolution;
+using RoslynMcp.Core.Workspace;
+
+namespace RoslynMcp.Core.Refactoring.Extract;
+
+/// <summary>
+/// Removes the <c>static</c> modifier from a selected static method when a
+/// valid instance receiver exists for every call site, and rewrites type-name
+/// invocations and method-group conversions to that receiver (or <c>this</c>
+/// in the same type).
+/// </summary>
+public sealed class MakeNonStaticOperation : RefactoringOperationBase<MakeNonStaticParams>
+{
+    /// <summary>
+    /// Creates a new make-non-static operation.
+    /// </summary>
+    public MakeNonStaticOperation(WorkspaceContext context) : base(context)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override void ValidateParams(MakeNonStaticParams @params) => Validate(@params);
+
+    /// <summary>
+    /// Validates make-non-static parameters. Internal so tests can exercise
+    /// input rules without loading a workspace.
+    /// </summary>
+    internal static void Validate(MakeNonStaticParams @params)
+    {
+        if (string.IsNullOrWhiteSpace(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "sourceFile is required.");
+
+        if (!PathResolver.IsAbsolutePath(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.InvalidSourcePath, "sourceFile must be an absolute path.");
+
+        if (!PathResolver.IsValidCSharpFilePath(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.InvalidSourcePath, "sourceFile must be a .cs file.");
+
+        if (@params.StartLine < 1)
+            throw new RefactoringException(ErrorCodes.InvalidLineNumber, "startLine must be >= 1.");
+
+        if (@params.StartColumn < 1)
+            throw new RefactoringException(ErrorCodes.InvalidColumnNumber, "startColumn must be >= 1.");
+
+        if (@params.EndLine < 1)
+            throw new RefactoringException(ErrorCodes.InvalidLineNumber, "endLine must be >= 1.");
+
+        if (@params.EndColumn < 1)
+            throw new RefactoringException(ErrorCodes.InvalidColumnNumber, "endColumn must be >= 1.");
+
+        if (@params.EndLine < @params.StartLine ||
+            (@params.EndLine == @params.StartLine && @params.EndColumn < @params.StartColumn))
+            throw new RefactoringException(ErrorCodes.InvalidSelectionRange, "End must be after start.");
+
+        if (!File.Exists(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.SourceFileNotFound, $"Source file not found: {@params.SourceFile}");
+    }
+
+    /// <summary>
+    /// Rejects documents that cannot receive source edits.
+    /// </summary>
+    internal static void ValidateDocumentIsEditable(Document document, Microsoft.CodeAnalysis.Workspace workspace)
+    {
+        if (document is SourceGeneratedDocument)
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable (source-generated).");
+        }
+
+        if (string.IsNullOrWhiteSpace(document.FilePath) || !File.Exists(document.FilePath))
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable.");
+        }
+
+        if (!workspace.CanApplyChange(ApplyChangesKind.ChangeDocument))
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable (workspace cannot apply changes).");
+        }
+    }
+
+    /// <inheritdoc />
+    protected override async Task<RefactoringResult> ExecuteCoreAsync(
+        Guid operationId,
+        MakeNonStaticParams @params,
+        CancellationToken cancellationToken)
+    {
+        var document = GetDocumentOrThrow(@params.SourceFile);
+        ValidateDocumentIsEditable(document, Context.Workspace);
+
+        var root = await document.GetSyntaxRootAsync(cancellationToken);
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken);
+        if (root == null || semanticModel == null)
+            throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse file.");
+
+        var sourceText = await document.GetTextAsync(cancellationToken);
+        var span = GetSelectionSpan(sourceText, @params);
+        var symbol = ResolveSelectedSymbol(root, semanticModel, span, @params, cancellationToken);
+        var method = NormalizeMethodSymbol(symbol);
+        ValidateMethodCanBeMadeNonStatic(method);
+
+        var declarationDocuments = await GetDeclarationDocumentsAsync(method, cancellationToken);
+        foreach (var declarationDocument in declarationDocuments)
+            ValidateDocumentIsEditable(declarationDocument, Context.Workspace);
+
+        var plan = await BuildPlanAsync(method, cancellationToken);
+        if (@params.Preview)
+            return CreatePreviewResult(operationId, plan);
+
+        var newSolution = await ApplyPlanAsync(Context.Solution, plan, cancellationToken);
+        var commitResult = await CommitChangesAsync(newSolution, cancellationToken);
+
+        return RefactoringResult.Succeeded(
+            operationId,
+            new FileChanges
+            {
+                FilesModified = commitResult.FilesModified,
+                FilesCreated = commitResult.FilesCreated,
+                FilesDeleted = commitResult.FilesDeleted
+            },
+            new Contracts.Models.SymbolInfo
+            {
+                Name = method.Name,
+                FullyQualifiedName = method.ToDisplayString(),
+                Kind = SymbolKindMapper.Map(method)
+            },
+            plan.CallSites.Count,
+            0);
+    }
+
+    internal static TextSpan GetSelectionSpan(SourceText sourceText, MakeNonStaticParams @params)
+    {
+        if (@params.StartLine > sourceText.Lines.Count || @params.EndLine > sourceText.Lines.Count)
+            throw new RefactoringException(ErrorCodes.InvalidLineNumber, "Selection is outside the file.");
+
+        var startLine = sourceText.Lines[@params.StartLine - 1];
+        var endLine = sourceText.Lines[@params.EndLine - 1];
+        if (@params.StartColumn - 1 > startLine.Span.Length || @params.EndColumn - 1 > endLine.SpanIncludingLineBreak.Length)
+            throw new RefactoringException(ErrorCodes.InvalidColumnNumber, "Selection column is outside the line.");
+
+        var startPosition = startLine.Start + @params.StartColumn - 1;
+        var endPosition = endLine.Start + @params.EndColumn - 1;
+        if (endPosition < startPosition)
+            throw new RefactoringException(ErrorCodes.InvalidSelectionRange, "End must be after start.");
+
+        return TextSpan.FromBounds(startPosition, endPosition);
+    }
+
+    private static ISymbol ResolveSelectedSymbol(
+        SyntaxNode root,
+        SemanticModel semanticModel,
+        TextSpan span,
+        MakeNonStaticParams @params,
+        CancellationToken cancellationToken)
+    {
+        var token = root.FindToken(span.Start);
+        if (token.Span.OverlapsWith(span) || span.OverlapsWith(token.Span))
+        {
+            var tokenNode = token.Parent;
+            if (tokenNode != null)
+            {
+                var declaredOnToken = semanticModel.GetDeclaredSymbol(tokenNode, cancellationToken);
+                if (declaredOnToken != null && IdentifierOverlaps(tokenNode, span))
+                    return ConfirmSymbolName(declaredOnToken, @params.SymbolName);
+
+                if (token.IsKind(SyntaxKind.IdentifierToken))
+                {
+                    var tokenSymbol = semanticModel.GetSymbolInfo(tokenNode, cancellationToken).Symbol;
+                    if (tokenSymbol != null)
+                        return ConfirmSymbolName(tokenSymbol, @params.SymbolName);
+                }
+            }
+        }
+
+        var node = root.FindNode(span, getInnermostNodeForTie: true);
+        var declared = semanticModel.GetDeclaredSymbol(node, cancellationToken);
+        if (declared != null && IdentifierOverlaps(node, span))
+            return ConfirmSymbolName(declared, @params.SymbolName);
+
+        throw new RefactoringException(
+            ErrorCodes.SymbolNotFound,
+            "No symbol found at the specified selection.");
+    }
+
+    private static ISymbol ConfirmSymbolName(ISymbol symbol, string? expectedName)
+    {
+        if (!string.IsNullOrWhiteSpace(expectedName) && symbol.Name != expectedName)
+        {
+            throw new RefactoringException(
+                ErrorCodes.SymbolNotFound,
+                $"No symbol named '{expectedName}' found at the specified selection.");
+        }
+
+        return symbol;
+    }
+
+    private static bool IdentifierOverlaps(SyntaxNode node, TextSpan span)
+    {
+        var identifier = GetDeclarationIdentifier(node);
+        return identifier != null &&
+            (identifier.Value.Span.OverlapsWith(span) || span.OverlapsWith(identifier.Value.Span));
+    }
+
+    private static SyntaxToken? GetDeclarationIdentifier(SyntaxNode node) => node switch
+    {
+        MethodDeclarationSyntax method => method.Identifier,
+        LocalFunctionStatementSyntax localFunction => localFunction.Identifier,
+        ConstructorDeclarationSyntax constructor => constructor.Identifier,
+        DestructorDeclarationSyntax destructor => destructor.Identifier,
+        OperatorDeclarationSyntax @operator => @operator.OperatorToken,
+        ConversionOperatorDeclarationSyntax conversion => conversion.Type.GetLastToken(),
+        PropertyDeclarationSyntax property => property.Identifier,
+        EventDeclarationSyntax @event => @event.Identifier,
+        VariableDeclaratorSyntax variable => variable.Identifier,
+        TypeDeclarationSyntax type => type.Identifier,
+        ParameterSyntax parameter => parameter.Identifier,
+        _ => null
+    };
+
+    private static IMethodSymbol NormalizeMethodSymbol(ISymbol symbol)
+    {
+        symbol = symbol.OriginalDefinition;
+
+        if (symbol is IMethodSymbol { AssociatedSymbol: { } associated } &&
+            associated.Kind is Microsoft.CodeAnalysis.SymbolKind.Property or Microsoft.CodeAnalysis.SymbolKind.Event)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidSymbolKind,
+                $"Symbol '{associated.Name}' is not a method.");
+        }
+
+        if (symbol is not IMethodSymbol method)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidSymbolKind,
+                $"Symbol '{symbol.Name}' is not a method.");
+        }
+
+        return method;
+    }
+
+    private static void ValidateMethodCanBeMadeNonStatic(IMethodSymbol method)
+    {
+        if (method.MethodKind != MethodKind.Ordinary)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidSymbolKind,
+                $"Symbol '{method.Name}' is not an ordinary method that can be made an instance method.");
+        }
+
+        if (!method.IsStatic)
+        {
+            throw new RefactoringException(
+                ErrorCodes.AlreadyInstance,
+                $"Method '{method.Name}' is already an instance method.");
+        }
+
+        if (method.IsExtensionMethod)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidSymbolKind,
+                $"Method '{method.Name}' is an extension method and cannot be made an instance method.");
+        }
+
+        if (method.IsAbstract || method.IsOverride || HasVirtualModifier(method))
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidSymbolKind,
+                $"Method '{method.Name}' cannot be made an instance method because it is virtual, override, or abstract.");
+        }
+
+        if (method.IsExtern)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidSymbolKind,
+                $"Method '{method.Name}' cannot be made an instance method because it is extern.");
+        }
+
+        if (method.ContainingType == null)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidSymbolKind,
+                $"Method '{method.Name}' has no containing type.");
+        }
+
+        if (method.ContainingType.IsStatic)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidSymbolKind,
+                $"Method '{method.Name}' is in a static class and cannot be made an instance method.");
+        }
+
+        if (method.ContainingType.TypeKind == TypeKind.Interface)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidSymbolKind,
+                $"Method '{method.Name}' is an interface member and cannot be made an instance method.");
+        }
+
+        if (ImplementsInterface(method))
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidSymbolKind,
+                $"Method '{method.Name}' implements an interface and cannot be made an instance method.");
+        }
+
+        if (!method.Locations.Any(location => location.IsInSource))
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Method '{method.Name}' is not in an editable document.");
+        }
+    }
+
+    private static bool HasVirtualModifier(IMethodSymbol method)
+    {
+        foreach (var reference in method.DeclaringSyntaxReferences)
+        {
+            if (reference.GetSyntax() is MethodDeclarationSyntax declaration &&
+                declaration.Modifiers.Any(SyntaxKind.VirtualKeyword))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ImplementsInterface(IMethodSymbol method)
+    {
+        if (method.ExplicitInterfaceImplementations.Length > 0)
+            return true;
+
+        if (method.ContainingType == null)
+            return false;
+
+        foreach (var iface in method.ContainingType.AllInterfaces)
+        {
+            foreach (var member in iface.GetMembers(method.Name))
+            {
+                var implementation = method.ContainingType.FindImplementationForInterfaceMember(member);
+                if (implementation == null)
+                    continue;
+
+                if (SymbolEqualityComparer.Default.Equals(implementation, method) ||
+                    SymbolEqualityComparer.Default.Equals(implementation.OriginalDefinition, method.OriginalDefinition))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private async Task<IReadOnlyList<Document>> GetDeclarationDocumentsAsync(
+        IMethodSymbol method,
+        CancellationToken cancellationToken)
+    {
+        var documents = new List<Document>();
+        foreach (var reference in method.DeclaringSyntaxReferences)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var syntax = await reference.GetSyntaxAsync(cancellationToken);
+            var document = Context.Solution.GetDocument(syntax.SyntaxTree);
+            if (document == null)
+            {
+                throw new RefactoringException(
+                    ErrorCodes.DocumentNotEditable,
+                    $"Declaration of '{method.Name}' is not in an editable document.");
+            }
+
+            documents.Add(document);
+        }
+
+        if (documents.Count == 0)
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Method '{method.Name}' is not in an editable document.");
+        }
+
+        return documents;
+    }
+
+    private async Task<StaticPlan> BuildPlanAsync(IMethodSymbol method, CancellationToken cancellationToken)
+    {
+        var declarations = new List<DeclarationEdit>();
+        foreach (var reference in method.DeclaringSyntaxReferences)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var syntax = await reference.GetSyntaxAsync(cancellationToken);
+            if (syntax is not MethodDeclarationSyntax declaration)
+            {
+                throw new RefactoringException(
+                    ErrorCodes.InvalidSymbolKind,
+                    $"Declaration '{method.Name}' is not a method that can be made an instance method.");
+            }
+
+            declarations.Add(new DeclarationEdit(
+                declaration.SyntaxTree,
+                declaration.Span,
+                GetSignatureSnippet(declaration),
+                GetSignatureSnippet(RemoveStaticModifier(declaration))));
+        }
+
+        if (declarations.Count == 0)
+        {
+            throw new RefactoringException(
+                ErrorCodes.RoslynError,
+                $"Could not locate a declaration to make non-static for '{method.Name}'.");
+        }
+
+        var callSites = await FindCallSiteEditsAsync(method, cancellationToken);
+        return new StaticPlan(
+            method.Name,
+            method.ToDisplayString(),
+            SymbolKindMapper.Map(method),
+            declarations,
+            callSites);
+    }
+
+    private async Task<IReadOnlyList<CallSiteEdit>> FindCallSiteEditsAsync(
+        IMethodSymbol method,
+        CancellationToken cancellationToken)
+    {
+        var references = await SymbolFinder.FindReferencesAsync(method, Context.Solution, cancellationToken);
+        var edits = new List<CallSiteEdit>();
+
+        foreach (var referencedSymbol in references)
+        {
+            foreach (var location in referencedSymbol.Locations)
+            {
+                if (location.Document == null || !location.Location.IsInSource)
+                    continue;
+
+                if (IsDefinitionLocation(referencedSymbol.Definition, location.Location))
+                    continue;
+
+                ValidateDocumentIsEditable(location.Document, Context.Workspace);
+
+                var root = await location.Document.GetSyntaxRootAsync(cancellationToken);
+                var model = await location.Document.GetSemanticModelAsync(cancellationToken);
+                if (root == null || model == null)
+                    continue;
+
+                var nameNode = FindReferencedName(root, location.Location.SourceSpan);
+                if (nameNode == null)
+                    continue;
+
+                if (IsInNameof(nameNode))
+                    continue;
+
+                if (IsConditionalAccessCallSite(nameNode) && NeedsConditionalAccessRewrite(nameNode, model))
+                    throw CreateConditionalAccessException(method);
+
+                var rewrite = ResolveCallSiteRewrite(nameNode, method, model, cancellationToken);
+                if (rewrite == null)
+                    continue;
+
+                var replacement = CreateInstanceMemberAccess(rewrite.Receiver, nameNode)
+                    .WithTriviaFrom(rewrite.Target);
+
+                edits.Add(new CallSiteEdit(
+                    location.Document.FilePath ?? string.Empty,
+                    rewrite.Target.SyntaxTree,
+                    rewrite.Target.Span,
+                    rewrite.Target.ToString(),
+                    replacement.ToString(),
+                    rewrite.Receiver.ToString()));
+            }
+        }
+
+        return edits;
+    }
+
+    private static SimpleNameSyntax? FindReferencedName(SyntaxNode root, TextSpan span)
+    {
+        var node = root.FindNode(span, getInnermostNodeForTie: true);
+        return node as SimpleNameSyntax
+            ?? node.AncestorsAndSelf().OfType<SimpleNameSyntax>()
+                .FirstOrDefault(name => name.Span.Contains(span) || span.Contains(name.Span));
+    }
+
+    private static bool IsInNameof(SyntaxNode node)
+    {
+        foreach (var ancestor in node.AncestorsAndSelf().OfType<InvocationExpressionSyntax>())
+        {
+            if (ancestor.Expression is IdentifierNameSyntax identifier &&
+                identifier.Identifier.Text == "nameof")
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsConditionalAccessCallSite(SimpleNameSyntax name) =>
+        name.Parent is MemberBindingExpressionSyntax ||
+        name.Ancestors().OfType<ConditionalAccessExpressionSyntax>().Any(conditional =>
+            GetConditionalBindingName(conditional) == name);
+
+    private static bool NeedsConditionalAccessRewrite(SimpleNameSyntax name, SemanticModel model)
+    {
+        if (name.Parent is MemberAccessExpressionSyntax memberAccess && memberAccess.Name == name)
+            return IsTypeReceiver(memberAccess.Expression, model);
+
+        return name.Parent is not MemberBindingExpressionSyntax;
+    }
+
+    private static SimpleNameSyntax? GetConditionalBindingName(ConditionalAccessExpressionSyntax conditional) =>
+        conditional.WhenNotNull switch
+        {
+            MemberBindingExpressionSyntax binding => binding.Name,
+            InvocationExpressionSyntax invocation when invocation.Expression is MemberBindingExpressionSyntax binding =>
+                binding.Name,
+            _ => null
+        };
+
+    private static RefactoringException CreateConditionalAccessException(IMethodSymbol method)
+    {
+        return new RefactoringException(
+            ErrorCodes.InvalidSelection,
+            $"Cannot make '{method.Name}' an instance method because a call site uses null-conditional access (?.) that cannot be rewritten safely.",
+            new Dictionary<string, object>
+            {
+                ["symbolName"] = method.Name
+            },
+            ["Update or remove null-conditional call sites (invocations and method groups), then retry."]);
+    }
+
+    private static CallSiteRewrite? ResolveCallSiteRewrite(
+        SimpleNameSyntax name,
+        IMethodSymbol method,
+        SemanticModel model,
+        CancellationToken cancellationToken)
+    {
+        if (name.Parent is MemberAccessExpressionSyntax memberAccess && memberAccess.Name == name)
+        {
+            if (!IsTypeReceiver(memberAccess.Expression, model))
+                return null;
+
+            var receiver = FindInstanceReceiver(name, method, model, cancellationToken)
+                ?? throw CreateNoValidInstanceReceiverException(method, name);
+            return new CallSiteRewrite(memberAccess, receiver);
+        }
+
+        if (CanUseImplicitThis(name, method, model, cancellationToken))
+            return null;
+
+        var prefixed = FindInstanceReceiver(name, method, model, cancellationToken)
+            ?? throw CreateNoValidInstanceReceiverException(method, name);
+        return new CallSiteRewrite(name, prefixed);
+    }
+
+    private static bool IsTypeReceiver(ExpressionSyntax expression, SemanticModel model)
+    {
+        var symbol = model.GetSymbolInfo(expression).Symbol;
+        return symbol is INamespaceOrTypeSymbol;
+    }
+
+    internal static bool CanUseImplicitThis(
+        SyntaxNode callSite,
+        IMethodSymbol method,
+        SemanticModel model,
+        CancellationToken cancellationToken)
+    {
+        return CanUseThis(callSite, method, model, cancellationToken);
+    }
+
+    private static bool CanUseThis(
+        SyntaxNode callSite,
+        IMethodSymbol method,
+        SemanticModel model,
+        CancellationToken cancellationToken)
+    {
+        if (method.ContainingType == null)
+            return false;
+
+        var enclosing = GetEnclosingMember(model, callSite, cancellationToken);
+        if (enclosing == null || enclosing.IsStatic)
+            return false;
+
+        var enclosingType = enclosing.ContainingType;
+        return enclosingType != null && IsCompatibleReceiverType(enclosingType, method.ContainingType);
+    }
+
+    private static ISymbol? GetEnclosingMember(
+        SemanticModel model,
+        SyntaxNode node,
+        CancellationToken cancellationToken)
+    {
+        foreach (var ancestor in node.Ancestors())
+        {
+            switch (ancestor)
+            {
+                case LocalFunctionStatementSyntax localFunction:
+                    return model.GetDeclaredSymbol(localFunction, cancellationToken);
+                case AnonymousFunctionExpressionSyntax anonymous:
+                    return model.GetSymbolInfo(anonymous, cancellationToken).Symbol;
+                case AccessorDeclarationSyntax accessor:
+                    return model.GetDeclaredSymbol(accessor, cancellationToken);
+                case BaseMethodDeclarationSyntax method:
+                    return model.GetDeclaredSymbol(method, cancellationToken);
+                case ArrowExpressionClauseSyntax { Parent: BasePropertyDeclarationSyntax property }:
+                    return model.GetDeclaredSymbol(property, cancellationToken);
+            }
+        }
+
+        return null;
+    }
+
+    private static ExpressionSyntax? FindInstanceReceiver(
+        SyntaxNode callSite,
+        IMethodSymbol method,
+        SemanticModel model,
+        CancellationToken cancellationToken)
+    {
+        if (method.ContainingType == null)
+            return null;
+
+        if (CanUseThis(callSite, method, model, cancellationToken))
+            return SyntaxFactory.ThisExpression();
+
+        var candidates = new List<ISymbol>();
+        foreach (var symbol in model.LookupSymbols(callSite.SpanStart))
+        {
+            if (!IsUsableInstanceCandidate(symbol, method, model, callSite, cancellationToken))
+                continue;
+
+            candidates.Add(symbol);
+        }
+
+        var unique = candidates
+            .Distinct<ISymbol>(SymbolEqualityComparer.Default)
+            .ToList();
+        if (unique.Count != 1)
+            return null;
+
+        var name = unique[0].ToMinimalDisplayString(model, callSite.SpanStart);
+        return SyntaxFactory.ParseExpression(name);
+    }
+
+    private static bool IsUsableInstanceCandidate(
+        ISymbol symbol,
+        IMethodSymbol method,
+        SemanticModel model,
+        SyntaxNode callSite,
+        CancellationToken cancellationToken)
+    {
+        if (method.ContainingType == null)
+            return false;
+
+        if (symbol is IParameterSymbol { IsThis: true })
+            return false;
+
+        ITypeSymbol? type = symbol switch
+        {
+            ILocalSymbol local => local.Type,
+            IParameterSymbol parameter => parameter.Type,
+            IFieldSymbol field => field.Type,
+            IPropertySymbol { GetMethod: not null } property => property.Type,
+            _ => null
+        };
+
+        if (type == null || !IsCompatibleReceiverType(type, method.ContainingType))
+            return false;
+
+        if (symbol.IsStatic)
+            return true;
+
+        var enclosing = GetEnclosingMember(model, callSite, cancellationToken);
+        return enclosing is { IsStatic: false };
+    }
+
+    internal static bool IsCompatibleReceiverType(ITypeSymbol type, INamedTypeSymbol target)
+    {
+        for (ITypeSymbol? current = type; current != null; current = current.BaseType)
+        {
+            if (SymbolEqualityComparer.Default.Equals(current.OriginalDefinition, target.OriginalDefinition))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static RefactoringException CreateNoValidInstanceReceiverException(
+        IMethodSymbol method,
+        SyntaxNode callSite)
+    {
+        return new RefactoringException(
+            ErrorCodes.NoValidInstanceReceiver,
+            $"Cannot make '{method.Name}' an instance method because a call site has no valid instance receiver.",
+            new Dictionary<string, object>
+            {
+                ["symbolName"] = method.Name,
+                ["callSite"] = callSite.ToString()
+            },
+            ["Introduce a unique instance of the containing type at each call site, or keep the method static."]);
+    }
+
+    private static ExpressionSyntax CreateInstanceMemberAccess(ExpressionSyntax receiver, SimpleNameSyntax name)
+    {
+        return SyntaxFactory.MemberAccessExpression(
+            SyntaxKind.SimpleMemberAccessExpression,
+            receiver,
+            (SimpleNameSyntax)name.WithoutTrivia());
+    }
+
+    private static bool IsDefinitionLocation(ISymbol symbol, Location location)
+    {
+        return symbol.Locations.Any(definition =>
+            definition.IsInSource &&
+            definition.SourceTree == location.SourceTree &&
+            definition.SourceSpan == location.SourceSpan);
+    }
+
+    private static async Task<Solution> ApplyPlanAsync(
+        Solution solution,
+        StaticPlan plan,
+        CancellationToken cancellationToken)
+    {
+        var trees = plan.Declarations.Select(declaration => declaration.SyntaxTree)
+            .Concat(plan.CallSites.Select(callSite => callSite.SyntaxTree))
+            .Distinct();
+
+        foreach (var tree in trees)
+        {
+            var document = solution.GetDocument(tree)
+                ?? throw new RefactoringException(
+                    ErrorCodes.DocumentNotEditable,
+                    "A declaration or call-site document is no longer in the workspace.");
+
+            var root = await document.GetSyntaxRootAsync(cancellationToken)
+                ?? throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse file.");
+
+            var callSiteSpans = plan.CallSites
+                .Where(callSite => callSite.SyntaxTree == tree)
+                .ToDictionary(callSite => callSite.Span, callSite => callSite);
+            var declarationSpans = plan.Declarations
+                .Where(declaration => declaration.SyntaxTree == tree)
+                .Select(declaration => declaration.Span)
+                .ToHashSet();
+
+            var rewriteTargets = root.DescendantNodes()
+                .Where(node => callSiteSpans.ContainsKey(node.Span) &&
+                    (node is MemberAccessExpressionSyntax || node is SimpleNameSyntax))
+                .ToList();
+            var methods = root.DescendantNodes()
+                .OfType<MethodDeclarationSyntax>()
+                .Where(method => declarationSpans.Contains(method.Span))
+                .ToList();
+
+            var replacements = rewriteTargets.ToDictionary(
+                target => target.Span,
+                target => RewriteCallSite(target, callSiteSpans[target.Span]));
+
+            var methodAnn = new SyntaxAnnotation("make-non-static-method");
+            var rewriteAnn = new SyntaxAnnotation("make-non-static-call");
+            var methodSet = methods.Cast<SyntaxNode>().ToHashSet();
+            var rewriteSet = rewriteTargets.ToHashSet();
+            var annotateTargets = methodSet.Concat(rewriteSet).ToList();
+            if (annotateTargets.Count > 0)
+            {
+                root = root.ReplaceNodes(annotateTargets, (original, _) =>
+                {
+                    var node = original;
+                    if (methodSet.Contains(original))
+                        node = node.WithAdditionalAnnotations(methodAnn);
+                    if (rewriteSet.Contains(original))
+                        node = node.WithAdditionalAnnotations(rewriteAnn);
+                    return node;
+                });
+            }
+
+            var annotatedRewrites = root.GetAnnotatedNodes(rewriteAnn).ToList();
+            if (annotatedRewrites.Count > 0)
+            {
+                root = root.ReplaceNodes(annotatedRewrites, (original, _) =>
+                    replacements.TryGetValue(original.Span, out var replacement)
+                        ? replacement
+                        : original);
+            }
+
+            var annotatedMethods = root.GetAnnotatedNodes(methodAnn).OfType<MethodDeclarationSyntax>().ToList();
+            if (annotatedMethods.Count > 0)
+                root = root.ReplaceNodes(annotatedMethods, (original, _) => RemoveStaticModifier(original));
+
+            solution = document.WithSyntaxRoot(root).Project.Solution;
+        }
+
+        return solution;
+    }
+
+    private static SyntaxNode RewriteCallSite(SyntaxNode original, CallSiteEdit edit)
+    {
+        var receiver = SyntaxFactory.ParseExpression(edit.Receiver);
+        SimpleNameSyntax? name = original switch
+        {
+            MemberAccessExpressionSyntax memberAccess => memberAccess.Name,
+            SimpleNameSyntax simpleName => simpleName,
+            _ => null
+        };
+
+        if (name == null)
+            return original;
+
+        return CreateInstanceMemberAccess(receiver, name).WithTriviaFrom(original);
+    }
+
+    internal static MethodDeclarationSyntax RemoveStaticModifier(MethodDeclarationSyntax method)
+    {
+        var staticModifier = method.Modifiers.FirstOrDefault(token => token.IsKind(SyntaxKind.StaticKeyword));
+        if (staticModifier == default)
+            return method;
+
+        var modifiers = method.Modifiers;
+        var index = modifiers.IndexOf(staticModifier);
+
+        if (modifiers.Count == 1)
+        {
+            var returnType = method.ReturnType.WithLeadingTrivia(staticModifier.LeadingTrivia);
+            return method.WithModifiers(default).WithReturnType(returnType);
+        }
+
+        if (index == 0)
+        {
+            var next = modifiers[1].WithLeadingTrivia(staticModifier.LeadingTrivia);
+            modifiers = modifiers.RemoveAt(0);
+            modifiers = modifiers.Replace(modifiers[0], next);
+            return method.WithModifiers(modifiers);
+        }
+
+        return method.WithModifiers(modifiers.RemoveAt(index));
+    }
+
+    private static string GetSignatureSnippet(MethodDeclarationSyntax method)
+    {
+        var returnType = method.ReturnType.ToString();
+        var modifiers = string.Join(" ", method.Modifiers.Select(token => token.Text));
+        var signature = $"{modifiers} {returnType} {method.Identifier}{method.TypeParameterList}{method.ParameterList}";
+        return signature.Trim();
+    }
+
+    private static RefactoringResult CreatePreviewResult(Guid operationId, StaticPlan plan)
+    {
+        var pendingChanges = new List<PendingChange>();
+        foreach (var declaration in plan.Declarations)
+        {
+            pendingChanges.Add(new PendingChange
+            {
+                File = declaration.SyntaxTree.FilePath ?? string.Empty,
+                ChangeType = ChangeKind.Modify,
+                Description = $"Remove static modifier from '{plan.Name}'",
+                BeforeSnippet = declaration.Before,
+                AfterSnippet = declaration.After
+            });
+        }
+
+        foreach (var callSite in plan.CallSites)
+        {
+            pendingChanges.Add(new PendingChange
+            {
+                File = callSite.File,
+                ChangeType = ChangeKind.Modify,
+                Description = $"Update call site of '{plan.Name}' to use an instance receiver",
+                BeforeSnippet = callSite.Before,
+                AfterSnippet = callSite.After
+            });
+        }
+
+        return RefactoringResult.PreviewResult(operationId, pendingChanges);
+    }
+
+    private sealed record DeclarationEdit(SyntaxTree SyntaxTree, TextSpan Span, string Before, string After);
+
+    private sealed record CallSiteEdit(
+        string File,
+        SyntaxTree SyntaxTree,
+        TextSpan Span,
+        string Before,
+        string After,
+        string Receiver);
+
+    private sealed record CallSiteRewrite(SyntaxNode Target, ExpressionSyntax Receiver);
+
+    private sealed record StaticPlan(
+        string Name,
+        string FullyQualifiedName,
+        Contracts.Enums.SymbolKind Kind,
+        IReadOnlyList<DeclarationEdit> Declarations,
+        IReadOnlyList<CallSiteEdit> CallSites);
+}

--- a/src/RoslynMcp.Core/Refactoring/Extract/MakeNonStaticOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/MakeNonStaticOperation.cs
@@ -550,20 +550,24 @@ public sealed class MakeNonStaticOperation : RefactoringOperationBase<MakeNonSta
         SemanticModel model,
         CancellationToken cancellationToken)
     {
+        var requiredType = GetRequiredReceiverType(name, method, model, cancellationToken);
+        if (requiredType == null)
+            throw CreateNoValidInstanceReceiverException(method, name);
+
         if (name.Parent is MemberAccessExpressionSyntax memberAccess && memberAccess.Name == name)
         {
             if (!IsTypeReceiver(memberAccess.Expression, model))
                 return null;
 
-            var receiver = FindInstanceReceiver(name, method, model, cancellationToken)
+            var receiver = FindInstanceReceiver(name, method, requiredType, model, cancellationToken)
                 ?? throw CreateNoValidInstanceReceiverException(method, name);
             return new CallSiteRewrite(memberAccess, receiver);
         }
 
-        if (CanUseImplicitThis(name, method, model, cancellationToken))
+        if (CanUseImplicitThis(name, method, requiredType, model, cancellationToken))
             return null;
 
-        var prefixed = FindInstanceReceiver(name, method, model, cancellationToken)
+        var prefixed = FindInstanceReceiver(name, method, requiredType, model, cancellationToken)
             ?? throw CreateNoValidInstanceReceiverException(method, name);
         return new CallSiteRewrite(name, prefixed);
     }
@@ -574,30 +578,64 @@ public sealed class MakeNonStaticOperation : RefactoringOperationBase<MakeNonSta
         return symbol is INamespaceOrTypeSymbol;
     }
 
-    internal static bool CanUseImplicitThis(
-        SyntaxNode callSite,
-        IMethodSymbol method,
+    private static INamedTypeSymbol? GetRequiredReceiverType(
+        SyntaxNode nameNode,
+        IMethodSymbol selectedMethod,
         SemanticModel model,
         CancellationToken cancellationToken)
     {
-        return CanUseThis(callSite, method, model, cancellationToken);
+        var info = model.GetSymbolInfo(nameNode, cancellationToken);
+        var bound = info.Symbol as IMethodSymbol
+            ?? info.CandidateSymbols.OfType<IMethodSymbol>().FirstOrDefault();
+        return bound?.ContainingType ?? selectedMethod.ContainingType;
+    }
+
+    internal static bool CanUseImplicitThis(
+        SyntaxNode callSite,
+        IMethodSymbol method,
+        INamedTypeSymbol requiredType,
+        SemanticModel model,
+        CancellationToken cancellationToken)
+    {
+        if (!CanUseThis(callSite, requiredType, model, cancellationToken))
+            return false;
+
+        var enclosing = GetEnclosingMember(model, callSite, cancellationToken);
+        var enclosingType = enclosing?.ContainingType;
+        return enclosingType != null && !WouldRebindToHidingMember(enclosingType, method);
     }
 
     private static bool CanUseThis(
         SyntaxNode callSite,
-        IMethodSymbol method,
+        INamedTypeSymbol requiredType,
         SemanticModel model,
         CancellationToken cancellationToken)
     {
-        if (method.ContainingType == null)
+        if (IsInConstructorInitializer(callSite))
             return false;
 
         var enclosing = GetEnclosingMember(model, callSite, cancellationToken);
-        if (enclosing == null || enclosing.IsStatic)
+        if (enclosing == null || !IsInstanceThisContext(enclosing))
             return false;
 
         var enclosingType = enclosing.ContainingType;
-        return enclosingType != null && IsCompatibleReceiverType(enclosingType, method.ContainingType);
+        return enclosingType != null && IsCompatibleReceiverType(enclosingType, requiredType);
+    }
+
+    private static bool IsInConstructorInitializer(SyntaxNode node) =>
+        node.AncestorsAndSelf().OfType<ConstructorInitializerSyntax>().Any();
+
+    private static bool IsInstanceThisContext(ISymbol enclosing)
+    {
+        for (ISymbol? current = enclosing;
+             current is not null and not INamedTypeSymbol;
+             current = current.ContainingSymbol)
+        {
+            if (current.IsStatic)
+                return false;
+        }
+
+        return true;
     }
 
     private static ISymbol? GetEnclosingMember(
@@ -628,19 +666,31 @@ public sealed class MakeNonStaticOperation : RefactoringOperationBase<MakeNonSta
     private static ExpressionSyntax? FindInstanceReceiver(
         SyntaxNode callSite,
         IMethodSymbol method,
+        INamedTypeSymbol requiredType,
         SemanticModel model,
         CancellationToken cancellationToken)
     {
-        if (method.ContainingType == null)
-            return null;
-
-        if (CanUseThis(callSite, method, model, cancellationToken))
-            return SyntaxFactory.ThisExpression();
+        if (CanUseThis(callSite, requiredType, model, cancellationToken))
+        {
+            var enclosingType = GetEnclosingMember(model, callSite, cancellationToken)?.ContainingType;
+            if (enclosingType != null)
+            {
+                var thisReceiver = QualifyReceiverIfNeeded(
+                    SyntaxFactory.ThisExpression(),
+                    enclosingType,
+                    method,
+                    requiredType,
+                    model,
+                    callSite.SpanStart);
+                if (thisReceiver != null)
+                    return thisReceiver;
+            }
+        }
 
         var candidates = new List<ISymbol>();
         foreach (var symbol in model.LookupSymbols(callSite.SpanStart))
         {
-            if (!IsUsableInstanceCandidate(symbol, method, model, callSite, cancellationToken))
+            if (!IsUsableInstanceCandidate(symbol, requiredType, model, callSite, cancellationToken))
                 continue;
 
             candidates.Add(symbol);
@@ -652,50 +702,208 @@ public sealed class MakeNonStaticOperation : RefactoringOperationBase<MakeNonSta
         if (unique.Count != 1 || string.IsNullOrEmpty(unique[0].Name))
             return null;
 
-        return SyntaxFactory.IdentifierName(unique[0].Name);
+        var receiverType = GetDeclaredType(unique[0]);
+        if (receiverType == null)
+            return null;
+
+        return QualifyReceiverIfNeeded(
+            CreateReceiverIdentifier(unique[0].Name),
+            receiverType,
+            method,
+            requiredType,
+            model,
+            callSite.SpanStart);
     }
 
     private static bool IsUsableInstanceCandidate(
         ISymbol symbol,
-        IMethodSymbol method,
+        INamedTypeSymbol requiredType,
         SemanticModel model,
         SyntaxNode callSite,
         CancellationToken cancellationToken)
     {
-        if (method.ContainingType == null)
-            return false;
-
         if (symbol is IParameterSymbol { IsThis: true })
             return false;
 
-        ITypeSymbol? type = symbol switch
-        {
-            ILocalSymbol local => local.Type,
-            IParameterSymbol parameter => parameter.Type,
-            IFieldSymbol field => field.Type,
-            IPropertySymbol { GetMethod: not null } property => property.Type,
-            _ => null
-        };
-
-        if (type == null || !IsCompatibleReceiverType(type, method.ContainingType))
+        ITypeSymbol? type = GetDeclaredType(symbol);
+        if (type == null || !IsCompatibleReceiverType(type, requiredType))
             return false;
 
-        if (symbol.IsStatic)
+        if (symbol is ILocalSymbol local
+            && !IsDefinitelyAssignedAt(local, callSite, model))
+        {
+            return false;
+        }
+
+        if (symbol.IsStatic || symbol is ILocalSymbol or IParameterSymbol)
             return true;
 
         var enclosing = GetEnclosingMember(model, callSite, cancellationToken);
-        return enclosing is { IsStatic: false };
+        return enclosing != null && IsInstanceThisContext(enclosing);
+    }
+
+    private static ITypeSymbol? GetDeclaredType(ISymbol symbol) => symbol switch
+    {
+        ILocalSymbol local => local.Type,
+        IParameterSymbol parameter => parameter.Type,
+        IFieldSymbol field => field.Type,
+        IPropertySymbol { GetMethod: not null } property => property.Type,
+        _ => null
+    };
+
+    private static bool IsDefinitelyAssignedAt(
+        ILocalSymbol local,
+        SyntaxNode callSite,
+        SemanticModel model)
+    {
+        var statement = callSite.FirstAncestorOrSelf<StatementSyntax>();
+        var expression = callSite.FirstAncestorOrSelf<ExpressionSyntax>();
+
+        DataFlowAnalysis? analysis;
+        try
+        {
+            analysis = statement != null
+                ? model.AnalyzeDataFlow(statement)
+                : expression != null
+                    ? model.AnalyzeDataFlow(expression)
+                    : null;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+
+        if (analysis is null || !analysis.Succeeded)
+            return false;
+
+        foreach (var assigned in analysis.DefinitelyAssignedOnEntry)
+        {
+            if (SymbolEqualityComparer.Default.Equals(assigned, local))
+                return true;
+        }
+
+        return false;
     }
 
     internal static bool IsCompatibleReceiverType(ITypeSymbol type, INamedTypeSymbol target)
     {
         for (ITypeSymbol? current = type; current != null; current = current.BaseType)
         {
-            if (SymbolEqualityComparer.Default.Equals(current.OriginalDefinition, target.OriginalDefinition))
+            if (ConstructedTypesMatch(current, target))
                 return true;
         }
 
         return false;
+    }
+
+    private static bool ConstructedTypesMatch(ITypeSymbol candidate, INamedTypeSymbol required)
+    {
+        if (!SymbolEqualityComparer.Default.Equals(candidate.OriginalDefinition, required.OriginalDefinition))
+            return false;
+
+        if (candidate is not INamedTypeSymbol namedCandidate)
+            return false;
+
+        if (namedCandidate.TypeArguments.Length != required.TypeArguments.Length)
+            return false;
+
+        for (var i = 0; i < required.TypeArguments.Length; i++)
+        {
+            if (!SymbolEqualityComparer.Default.Equals(namedCandidate.TypeArguments[i], required.TypeArguments[i]))
+                return false;
+        }
+
+        return true;
+    }
+
+    private static bool WouldRebindToHidingMember(INamedTypeSymbol receiverType, IMethodSymbol method)
+    {
+        for (INamedTypeSymbol? type = receiverType; type != null; type = type.BaseType)
+        {
+            if (SymbolEqualityComparer.Default.Equals(
+                    type.OriginalDefinition,
+                    method.ContainingType.OriginalDefinition))
+            {
+                return false;
+            }
+
+            if (DeclaresHidingInstanceMethod(type, method))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool DeclaresHidingInstanceMethod(INamedTypeSymbol type, IMethodSymbol method)
+    {
+        foreach (var member in type.GetMembers(method.Name))
+        {
+            if (member is not IMethodSymbol candidate
+                || candidate.IsStatic
+                || candidate.IsOverride
+                || candidate.Parameters.Length != method.Parameters.Length
+                || candidate.TypeParameters.Length != method.TypeParameters.Length)
+            {
+                continue;
+            }
+
+            var parametersMatch = true;
+            for (var i = 0; i < method.Parameters.Length; i++)
+            {
+                if (!SymbolEqualityComparer.Default.Equals(
+                        candidate.Parameters[i].Type.OriginalDefinition,
+                        method.Parameters[i].Type.OriginalDefinition))
+                {
+                    parametersMatch = false;
+                    break;
+                }
+            }
+
+            if (parametersMatch)
+                return true;
+        }
+
+        return false;
+    }
+
+    private static ExpressionSyntax? QualifyReceiverIfNeeded(
+        ExpressionSyntax receiver,
+        ITypeSymbol receiverType,
+        IMethodSymbol method,
+        INamedTypeSymbol requiredType,
+        SemanticModel model,
+        int position)
+    {
+        var namedReceiver = receiverType as INamedTypeSymbol ?? receiverType.BaseType;
+        if (namedReceiver == null || !WouldRebindToHidingMember(namedReceiver, method))
+            return receiver;
+
+        var typeName = requiredType.ToMinimalDisplayString(model, position);
+        if (string.IsNullOrWhiteSpace(typeName))
+            return null;
+
+        var typeSyntax = SyntaxFactory.ParseTypeName(typeName);
+        if (typeSyntax.ContainsDiagnostics)
+            return null;
+
+        return SyntaxFactory.ParenthesizedExpression(
+            SyntaxFactory.CastExpression(typeSyntax, receiver));
+    }
+
+    private static IdentifierNameSyntax CreateReceiverIdentifier(string name)
+    {
+        var keywordKind = SyntaxFacts.GetKeywordKind(name);
+        if (keywordKind != SyntaxKind.None && SyntaxFacts.IsReservedKeyword(keywordKind))
+        {
+            return SyntaxFactory.IdentifierName(
+                SyntaxFactory.VerbatimIdentifier(
+                    SyntaxFactory.TriviaList(),
+                    "@" + name,
+                    name,
+                    SyntaxFactory.TriviaList()));
+        }
+
+        return SyntaxFactory.IdentifierName(name);
     }
 
     private static RefactoringException CreateNoValidInstanceReceiverException(

--- a/src/RoslynMcp.Core/Refactoring/Extract/MakeNonStaticOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/MakeNonStaticOperation.cs
@@ -605,6 +605,7 @@ public sealed class MakeNonStaticOperation : RefactoringOperationBase<MakeNonSta
         return enclosingType != null && !WouldRebindToHidingMember(enclosingType, method);
     }
 
+    // Receiver eligibility is decided per call site; this helper never mutates syntax.
     private static bool CanUseThis(
         SyntaxNode callSite,
         INamedTypeSymbol requiredType,

--- a/src/RoslynMcp.Server/McpServerHost.cs
+++ b/src/RoslynMcp.Server/McpServerHost.cs
@@ -55,6 +55,7 @@ public sealed class McpServerHost : IAsyncDisposable
         _toolRegistry.Register(new IntroduceFieldTool(workspaceProvider));
         _toolRegistry.Register(new SafeDeleteTool(workspaceProvider));
         _toolRegistry.Register(new MakeStaticTool(workspaceProvider));
+        _toolRegistry.Register(new MakeNonStaticTool(workspaceProvider));
 
         // Code Navigation / Query Tools
         _toolRegistry.Register(new FindReferencesTool(workspaceProvider));

--- a/src/RoslynMcp.Server/RoslynMcp.Server.csproj
+++ b/src/RoslynMcp.Server/RoslynMcp.Server.csproj
@@ -18,7 +18,7 @@
     <Version>0.4.0</Version>
     <Authors>Joshua Ramirez</Authors>
     <Company>RedJay</Company>
-    <Description>MCP Server for Roslyn-powered C# refactoring operations. Install as a global tool to use with Claude Code, Claude Desktop, or other MCP clients. Provides 48 tools: 26 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 7 code conversion tools.</Description>
+    <Description>MCP Server for Roslyn-powered C# refactoring operations. Install as a global tool to use with Claude Code, Claude Desktop, or other MCP clients. Provides 49 tools: 27 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 7 code conversion tools.</Description>
     <PackageTags>roslyn;mcp;refactoring;csharp;model-context-protocol;code-analysis;dotnet;ai-tools;claude</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/JoshuaRamirez/RoslynMcpServer</RepositoryUrl>

--- a/src/RoslynMcp.Server/Tools/MakeNonStaticTool.cs
+++ b/src/RoslynMcp.Server/Tools/MakeNonStaticTool.cs
@@ -1,0 +1,154 @@
+using System.Text.Json;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.Refactoring;
+using RoslynMcp.Core.Refactoring.Extract;
+using RoslynMcp.Core.Workspace;
+using RoslynMcp.Server.Transport;
+
+namespace RoslynMcp.Server.Tools;
+
+/// <summary>
+/// MCP tool handler for make_non_static operation.
+/// </summary>
+public sealed class MakeNonStaticTool : IToolHandler
+{
+    private readonly IWorkspaceProvider _workspaceProvider;
+    private readonly JsonSerializerOptions _jsonOptions;
+
+    /// <summary>
+    /// Creates a new make-non-static tool.
+    /// </summary>
+    public MakeNonStaticTool(IWorkspaceProvider workspaceProvider)
+    {
+        _workspaceProvider = workspaceProvider;
+        _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = false
+        };
+    }
+
+    /// <inheritdoc />
+    public string Name => "make_non_static";
+
+    /// <inheritdoc />
+    public string Description => "Make a selected static method an instance method when a valid instance receiver exists. Removes the static modifier and updates type-name call sites and method-group conversions to an instance receiver (or this in the same type).";
+
+    /// <inheritdoc />
+    public object InputSchema => new
+    {
+        type = "object",
+        required = new[] { "solutionPath", "sourceFile", "startLine", "startColumn", "endLine", "endColumn" },
+        properties = new
+        {
+            solutionPath = new
+            {
+                type = "string",
+                description = "Absolute path to the .sln or .csproj file"
+            },
+            sourceFile = new
+            {
+                type = "string",
+                description = "Absolute path to the source file"
+            },
+            startLine = new
+            {
+                type = "integer",
+                description = "Start line of the selected method (1-based)"
+            },
+            startColumn = new
+            {
+                type = "integer",
+                description = "Start column of the selected method (1-based)"
+            },
+            endLine = new
+            {
+                type = "integer",
+                description = "End line of the selected method (1-based)"
+            },
+            endColumn = new
+            {
+                type = "integer",
+                description = "End column of the selected method (1-based)"
+            },
+            symbolName = new
+            {
+                type = "string",
+                description = "Optional method name used to confirm the selection"
+            },
+            preview = new
+            {
+                type = "boolean",
+                description = "Return computed changes without applying",
+                @default = false
+            }
+        },
+        additionalProperties = false
+    };
+
+    /// <inheritdoc />
+    public async Task<ToolResult> ExecuteAsync(JsonElement? arguments, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (arguments == null)
+            {
+                return ToolResult.Error("Arguments required");
+            }
+
+            var args = JsonSerializer.Deserialize<MakeNonStaticArgs>(arguments.Value.GetRawText(), _jsonOptions);
+            if (args == null)
+            {
+                return ToolResult.Error("Failed to parse arguments");
+            }
+
+            using var context = await _workspaceProvider.CreateContextAsync(
+                args.SolutionPath,
+                cancellationToken);
+
+            var operation = new MakeNonStaticOperation(context);
+            var @params = new MakeNonStaticParams
+            {
+                SourceFile = args.SourceFile,
+                StartLine = args.StartLine,
+                StartColumn = args.StartColumn,
+                EndLine = args.EndLine,
+                EndColumn = args.EndColumn,
+                SymbolName = args.SymbolName,
+                Preview = args.Preview ?? false
+            };
+
+            var result = await operation.ExecuteAsync(@params, cancellationToken);
+
+            var json = JsonSerializer.Serialize(result, _jsonOptions);
+            return result.Success ? ToolResult.Success(json) : ToolResult.Error(json);
+        }
+        catch (RefactoringException ex)
+        {
+            var error = ex.ToError();
+            var json = JsonSerializer.Serialize(new { success = false, error }, _jsonOptions);
+            return ToolResult.Error(json);
+        }
+        catch (Exception ex)
+        {
+            var json = JsonSerializer.Serialize(new
+            {
+                success = false,
+                error = new { code = "INTERNAL_ERROR", message = ex.Message }
+            }, _jsonOptions);
+            return ToolResult.Error(json);
+        }
+    }
+
+    private sealed class MakeNonStaticArgs
+    {
+        public string SolutionPath { get; init; } = "";
+        public string SourceFile { get; init; } = "";
+        public int StartLine { get; init; }
+        public int StartColumn { get; init; }
+        public int EndLine { get; init; }
+        public int EndColumn { get; init; }
+        public string? SymbolName { get; init; }
+        public bool? Preview { get; init; }
+    }
+}

--- a/tests/RoslynMcp.Cli.Tests/HelpGeneratorTests.cs
+++ b/tests/RoslynMcp.Cli.Tests/HelpGeneratorTests.cs
@@ -15,17 +15,18 @@ public class HelpGeneratorTests
     }
 
     [Fact]
-    public void GenerateGlobalHelp_Lists48Tools()
+    public void GenerateGlobalHelp_Lists49Tools()
     {
         var registry = ToolRegistry.BuildDefault();
         var help = HelpGenerator.GenerateGlobalHelp(registry);
-        Assert.Contains("Total: 48 tools", help);
+        Assert.Contains("Total: 49 tools", help);
         Assert.Contains("pull-members-up", help);
         Assert.Contains("push-members-down", help);
         Assert.Contains("use-base-type", help);
         Assert.Contains("introduce-field", help);
         Assert.Contains("safe-delete", help);
         Assert.Contains("make-static", help);
+        Assert.Contains("make-non-static", help);
     }
 
     [Fact]

--- a/tests/RoslynMcp.Cli.Tests/ToolRegistryTests.cs
+++ b/tests/RoslynMcp.Cli.Tests/ToolRegistryTests.cs
@@ -6,11 +6,11 @@ namespace RoslynMcp.Cli.Tests;
 public class ToolRegistryTests
 {
     [Fact]
-    public void BuildDefault_Registers48Tools()
+    public void BuildDefault_Registers49Tools()
     {
         var registry = ToolRegistry.BuildDefault();
         var tools = registry.GetAllTools();
-        Assert.Equal(48, tools.Count);
+        Assert.Equal(49, tools.Count);
     }
 
     [Fact]
@@ -90,6 +90,7 @@ public class ToolRegistryTests
     [InlineData("introduce-field", "Refactoring")]
     [InlineData("safe-delete", "Refactoring")]
     [InlineData("make-static", "Refactoring")]
+    [InlineData("make-non-static", "Refactoring")]
     [InlineData("find-references", "Query")]
     [InlineData("get-diagnostics", "Query")]
     [InlineData("diagnose", "Diagnostic")]
@@ -108,11 +109,11 @@ public class ToolRegistryTests
     }
 
     [Fact]
-    public void RefactoringToolCount_Is35()
+    public void RefactoringToolCount_Is36()
     {
         var registry = ToolRegistry.BuildDefault();
         var count = registry.GetAllTools().Count(t => t.Category == "Refactoring");
-        Assert.Equal(35, count);
+        Assert.Equal(36, count);
     }
 
     [Fact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Extract/MakeNonStaticOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Extract/MakeNonStaticOperationTests.cs
@@ -1,0 +1,639 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using RoslynMcp.Contracts.Errors;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.Refactoring;
+using RoslynMcp.Core.Refactoring.Extract;
+using RoslynMcp.Core.Workspace;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Refactoring.Extract;
+
+/// <summary>
+/// Operation-level tests for <see cref="MakeNonStaticOperation"/>.
+/// </summary>
+public class MakeNonStaticOperationTests
+{
+    #region Input Validation
+
+    [Fact]
+    public void Validate_MissingSourceFile_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            MakeNonStaticOperation.Validate(new MakeNonStaticParams
+            {
+                SourceFile = "",
+                StartLine = 1,
+                StartColumn = 1,
+                EndLine = 1,
+                EndColumn = 2
+            }));
+
+        Assert.Equal(ErrorCodes.MissingRequiredParam, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_RelativePath_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            MakeNonStaticOperation.Validate(new MakeNonStaticParams
+            {
+                SourceFile = "Types.cs",
+                StartLine = 1,
+                StartColumn = 1,
+                EndLine = 1,
+                EndColumn = 2
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidSourcePath, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_InvalidLine_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            MakeNonStaticOperation.Validate(new MakeNonStaticParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                StartLine = 0,
+                StartColumn = 1,
+                EndLine = 1,
+                EndColumn = 2
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidLineNumber, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_InvalidSelectionRange_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            MakeNonStaticOperation.Validate(new MakeNonStaticParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                StartLine = 2,
+                StartColumn = 1,
+                EndLine = 1,
+                EndColumn = 2
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidSelectionRange, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_MissingFile_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            MakeNonStaticOperation.Validate(new MakeNonStaticParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                StartLine = 1,
+                StartColumn = 1,
+                EndLine = 1,
+                EndColumn = 2
+            }));
+
+        Assert.Equal(ErrorCodes.SourceFileNotFound, ex.ErrorCode);
+    }
+
+    #endregion
+
+    #region P0 Happy Path
+
+    [SkippableFact]
+    public async Task MakeNonStatic_StaticMethod_RemovesStaticAndUpdatesCallSites()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public static int Add(int a, int b)
+                {
+                    return a + b;
+                }
+
+                public int Use()
+                {
+                    var other = new Calculator();
+                    return Calculator.Add(1, 2) + Calculator.Add(3, 4) + Add(5, 6);
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new MakeNonStaticOperation(workspace.Context);
+        var span = FindSpan(source, "Add");
+
+        var result = await operation.ExecuteAsync(new MakeNonStaticParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = span.StartLine,
+            StartColumn = span.StartColumn,
+            EndLine = span.EndLine,
+            EndColumn = span.EndColumn,
+            SymbolName = "Add"
+        });
+
+        Assert.True(result.Success);
+        Assert.False(result.Preview);
+        Assert.NotNull(result.Symbol);
+        Assert.Equal("Add", result.Symbol.Name);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("public int Add(int a, int b)", updated);
+        Assert.DoesNotContain("public static int Add", updated);
+        Assert.DoesNotContain("Calculator.Add(1, 2)", updated);
+        Assert.DoesNotContain("Calculator.Add(3, 4)", updated);
+        Assert.Contains("this.Add(1, 2)", updated);
+        Assert.Contains("this.Add(3, 4)", updated);
+        Assert.Contains("Add(5, 6)", updated);
+    }
+
+    [SkippableFact]
+    public async Task MakeNonStatic_MethodGroup_RewritesToInstanceReceiver()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public static int Double(int x)
+                {
+                    return x * 2;
+                }
+
+                public void Use()
+                {
+                    System.Func<int, int> fromType = Calculator.Double;
+                    System.Func<int, int> fromUnqualified = Double;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new MakeNonStaticOperation(workspace.Context);
+        var span = FindSpan(source, "Double");
+
+        var result = await operation.ExecuteAsync(new MakeNonStaticParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = span.StartLine,
+            StartColumn = span.StartColumn,
+            EndLine = span.EndLine,
+            EndColumn = span.EndColumn,
+            SymbolName = "Double"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("public int Double(int x)", updated);
+        Assert.Contains("fromType = this.Double", updated);
+        Assert.Contains("fromUnqualified = Double", updated);
+        Assert.DoesNotContain("Calculator.Double", updated);
+    }
+
+    [SkippableFact]
+    public async Task MakeNonStatic_UniqueExternalReceiver_RewritesToThatInstance()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public static int Add(int a, int b)
+                {
+                    return a + b;
+                }
+            }
+
+            public class Consumer
+            {
+                public int Use(Calculator calc)
+                {
+                    return Calculator.Add(1, 2);
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new MakeNonStaticOperation(workspace.Context);
+        var span = FindSpan(source, "Add");
+
+        var result = await operation.ExecuteAsync(new MakeNonStaticParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = span.StartLine,
+            StartColumn = span.StartColumn,
+            EndLine = span.EndLine,
+            EndColumn = span.EndColumn,
+            SymbolName = "Add"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("public int Add(int a, int b)", updated);
+        Assert.Contains("return calc.Add(1, 2);", updated);
+        Assert.DoesNotContain("Calculator.Add(1, 2)", updated);
+    }
+
+    #endregion
+
+    #region P0 Preview
+
+    [SkippableFact]
+    public async Task MakeNonStatic_Preview_DoesNotModifyFile()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public static int Add(int a, int b)
+                {
+                    return a + b;
+                }
+
+                public int Use()
+                {
+                    return Calculator.Add(1, 2);
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+        var operation = new MakeNonStaticOperation(workspace.Context);
+        var span = FindSpan(source, "Add");
+
+        var result = await operation.ExecuteAsync(new MakeNonStaticParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = span.StartLine,
+            StartColumn = span.StartColumn,
+            EndLine = span.EndLine,
+            EndColumn = span.EndColumn,
+            Preview = true
+        });
+
+        Assert.True(result.Success);
+        Assert.True(result.Preview);
+        Assert.NotNull(result.PendingChanges);
+        Assert.Contains(result.PendingChanges, change => change.Description.Contains("Add"));
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    #endregion
+
+    #region P0 Rejects
+
+    [SkippableFact]
+    public async Task MakeNonStatic_AlreadyInstance_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public int Add(int a, int b)
+                {
+                    return a + b;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new MakeNonStaticOperation(workspace.Context);
+        var span = FindSpan(source, "Add");
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new MakeNonStaticParams
+            {
+                SourceFile = workspace.SourcePath,
+                StartLine = span.StartLine,
+                StartColumn = span.StartColumn,
+                EndLine = span.EndLine,
+                EndColumn = span.EndColumn,
+                SymbolName = "Add"
+            }));
+
+        Assert.Equal(ErrorCodes.AlreadyInstance, ex.ErrorCode);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [SkippableFact]
+    public async Task MakeNonStatic_NoSymbol_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public static int Add(int a, int b)
+                {
+                    return a + b;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new MakeNonStaticOperation(workspace.Context);
+        var span = FindSpan(source, "return");
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new MakeNonStaticParams
+            {
+                SourceFile = workspace.SourcePath,
+                StartLine = span.StartLine,
+                StartColumn = span.StartColumn,
+                EndLine = span.EndLine,
+                EndColumn = span.EndColumn
+            }));
+
+        Assert.Equal(ErrorCodes.SymbolNotFound, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task MakeNonStatic_NonMethod_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                private static int _value;
+
+                public static int Get()
+                {
+                    return 42;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new MakeNonStaticOperation(workspace.Context);
+        var span = FindSpan(source, "_value");
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new MakeNonStaticParams
+            {
+                SourceFile = workspace.SourcePath,
+                StartLine = span.StartLine,
+                StartColumn = span.StartColumn,
+                EndLine = span.EndLine,
+                EndColumn = span.EndColumn,
+                SymbolName = "_value"
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidSymbolKind, ex.ErrorCode);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [SkippableFact]
+    public async Task MakeNonStatic_NoValidInstanceReceiver_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public static int Add(int a, int b)
+                {
+                    return a + b;
+                }
+            }
+
+            public class Consumer
+            {
+                public int Use()
+                {
+                    return Calculator.Add(1, 2);
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new MakeNonStaticOperation(workspace.Context);
+        var span = FindSpan(source, "Add");
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new MakeNonStaticParams
+            {
+                SourceFile = workspace.SourcePath,
+                StartLine = span.StartLine,
+                StartColumn = span.StartColumn,
+                EndLine = span.EndLine,
+                EndColumn = span.EndColumn,
+                SymbolName = "Add"
+            }));
+
+        Assert.Equal(ErrorCodes.NoValidInstanceReceiver, ex.ErrorCode);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("public static int Add(int a, int b)", before);
+        Assert.Contains("Calculator.Add(1, 2)", before);
+    }
+
+    [SkippableFact]
+    public async Task MakeNonStatic_ExternMethod_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public static extern int Add(int a, int b);
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new MakeNonStaticOperation(workspace.Context);
+        var span = FindSpan(source, "Add");
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new MakeNonStaticParams
+            {
+                SourceFile = workspace.SourcePath,
+                StartLine = span.StartLine,
+                StartColumn = span.StartColumn,
+                EndLine = span.EndLine,
+                EndColumn = span.EndColumn,
+                SymbolName = "Add"
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidSymbolKind, ex.ErrorCode);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("public static extern int Add(int a, int b);", before);
+    }
+
+    [SkippableFact]
+    public async Task MakeNonStatic_StaticClass_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public static class Calculator
+            {
+                public static int Add(int a, int b)
+                {
+                    return a + b;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new MakeNonStaticOperation(workspace.Context);
+        var span = FindSpan(source, "Add");
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new MakeNonStaticParams
+            {
+                SourceFile = workspace.SourcePath,
+                StartLine = span.StartLine,
+                StartColumn = span.StartColumn,
+                EndLine = span.EndLine,
+                EndColumn = span.EndColumn,
+                SymbolName = "Add"
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidSymbolKind, ex.ErrorCode);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("public static int Add(int a, int b)", before);
+    }
+
+    [Fact]
+    public void MakeNonStatic_UneditableDocument_Throws()
+    {
+        var workspace = new AdhocWorkspace();
+        var project = workspace.AddProject("P", LanguageNames.CSharp);
+        var document = workspace.AddDocument(project.Id, "Generated.cs", SourceText.From("class C {}"));
+
+        var ex = Assert.Throws<RefactoringException>(() =>
+            MakeNonStaticOperation.ValidateDocumentIsEditable(document, workspace));
+
+        Assert.Equal(ErrorCodes.DocumentNotEditable, ex.ErrorCode);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static string AbsoluteTestPath() =>
+        Path.Combine(Path.GetTempPath(), "RoslynMcpMakeNonStaticMissing.cs");
+
+    private static string NormalizeNewlines(string text) =>
+        text.Replace("\r\n", "\n", StringComparison.Ordinal);
+
+    private static (int StartLine, int StartColumn, int EndLine, int EndColumn) FindSpan(string source, string snippet)
+    {
+        var index = source.IndexOf(snippet, StringComparison.Ordinal);
+        if (index < 0)
+            throw new InvalidOperationException($"Snippet not found: {snippet}");
+
+        return (GetLineColumn(source, index).Line, GetLineColumn(source, index).Column,
+            GetLineColumn(source, index + snippet.Length).Line, GetLineColumn(source, index + snippet.Length).Column);
+    }
+
+    private static (int Line, int Column) GetLineColumn(string source, int index)
+    {
+        var line = 1;
+        var column = 1;
+        for (var i = 0; i < index; i++)
+        {
+            if (source[i] == '\n')
+            {
+                line++;
+                column = 1;
+            }
+            else
+            {
+                column++;
+            }
+        }
+
+        return (line, column);
+    }
+
+    private sealed class TempWorkspace : IAsyncDisposable
+    {
+        public required string DirectoryPath { get; init; }
+        public required string ProjectPath { get; init; }
+        public required string SourcePath { get; init; }
+        public required WorkspaceContext Context { get; init; }
+
+        public static async Task<TempWorkspace> CreateAsync(string source, string fileName = "Types.cs")
+        {
+            Skip.IfNot(ModuleInitializer.MsBuildAvailable, ModuleInitializer.MsBuildError ?? "MSBuild not available");
+
+            var directory = Path.Combine(Path.GetTempPath(), "RoslynMcpMakeNonStatic_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(directory);
+
+            var projectPath = Path.Combine(directory, "TestApp.csproj");
+            var sourcePath = Path.Combine(directory, fileName);
+
+            await File.WriteAllTextAsync(projectPath, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net9.0</TargetFramework>
+                    <Nullable>enable</Nullable>
+                  </PropertyGroup>
+                </Project>
+                """);
+            await File.WriteAllTextAsync(sourcePath, source);
+
+            try
+            {
+                var provider = new MSBuildWorkspaceProvider();
+                var context = await provider.CreateContextAsync(projectPath);
+                if (context.GetDocumentByPath(sourcePath) == null)
+                {
+                    context.Dispose();
+                    throw new InvalidOperationException($"Workspace loaded but did not include {sourcePath}.");
+                }
+
+                return new TempWorkspace
+                {
+                    DirectoryPath = directory,
+                    ProjectPath = projectPath,
+                    SourcePath = sourcePath,
+                    Context = context
+                };
+            }
+            catch (Exception ex) when (ex is not SkipException)
+            {
+                try
+                {
+                    Directory.Delete(directory, recursive: true);
+                }
+                catch
+                {
+                    // ignore cleanup failures
+                }
+
+                Skip.If(true, $"Workspace load failed: {ex.Message}");
+                throw;
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            Context.Dispose();
+            await Task.Run(() =>
+            {
+                try
+                {
+                    Directory.Delete(DirectoryPath, recursive: true);
+                }
+                catch
+                {
+                    // ignore locked temp files
+                }
+            });
+        }
+    }
+
+    #endregion
+}

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Extract/MakeNonStaticOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Extract/MakeNonStaticOperationTests.cs
@@ -519,6 +519,413 @@ public class MakeNonStaticOperationTests
 
     #endregion
 
+    #region Review fold
+
+    [SkippableFact]
+    public async Task MakeNonStatic_GenericReceiverTypeArgumentMismatch_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Container<T>
+            {
+                public static T Get(T value)
+                {
+                    return value;
+                }
+            }
+
+            public class Consumer
+            {
+                public string Use(Container<string> strings)
+                {
+                    return Container<int>.Get(1).ToString();
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new MakeNonStaticOperation(workspace.Context);
+        var span = FindIdentifierSpan(source, "Get");
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new MakeNonStaticParams
+            {
+                SourceFile = workspace.SourcePath,
+                StartLine = span.StartLine,
+                StartColumn = span.StartColumn,
+                EndLine = span.EndLine,
+                EndColumn = span.EndColumn,
+                SymbolName = "Get"
+            }));
+
+        Assert.Equal(ErrorCodes.NoValidInstanceReceiver, ex.ErrorCode);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("Container<int>.Get(1)", before);
+    }
+
+    [SkippableFact]
+    public async Task MakeNonStatic_MatchingGenericReceiver_RewritesToThatInstance()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Container<T>
+            {
+                public static T Get(T value)
+                {
+                    return value;
+                }
+            }
+
+            public class Consumer
+            {
+                public int Use(Container<int> ints)
+                {
+                    return Container<int>.Get(1);
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new MakeNonStaticOperation(workspace.Context);
+        var span = FindIdentifierSpan(source, "Get");
+
+        var result = await operation.ExecuteAsync(new MakeNonStaticParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = span.StartLine,
+            StartColumn = span.StartColumn,
+            EndLine = span.EndLine,
+            EndColumn = span.EndColumn,
+            SymbolName = "Get"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("public T Get(T value)", updated);
+        Assert.Contains("return ints.Get(1);", updated);
+        Assert.DoesNotContain("Container<int>.Get(1)", updated);
+    }
+
+    [SkippableFact]
+    public async Task MakeNonStatic_HidingDerivedMethod_CastsThisToSelectedType()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Base
+            {
+                public static int Value()
+                {
+                    return 1;
+                }
+            }
+
+            public class Derived : Base
+            {
+                public int Value()
+                {
+                    return 2;
+                }
+
+                public int Use()
+                {
+                    return Base.Value();
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new MakeNonStaticOperation(workspace.Context);
+        var span = FindIdentifierSpan(source, "Value");
+
+        var result = await operation.ExecuteAsync(new MakeNonStaticParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = span.StartLine,
+            StartColumn = span.StartColumn,
+            EndLine = span.EndLine,
+            EndColumn = span.EndColumn,
+            SymbolName = "Value"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("public int Value()", updated);
+        Assert.DoesNotContain("public static int Value()", updated);
+        Assert.Contains("return ((Base)this).Value();", updated);
+        Assert.DoesNotContain("return this.Value();", updated);
+        Assert.DoesNotContain("return Base.Value();", updated);
+    }
+
+    [SkippableFact]
+    public async Task MakeNonStatic_DerivedWithoutHiding_RewritesToThis()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Base
+            {
+                public static int Value()
+                {
+                    return 1;
+                }
+            }
+
+            public class Derived : Base
+            {
+                public int Use()
+                {
+                    return Base.Value();
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new MakeNonStaticOperation(workspace.Context);
+        var span = FindIdentifierSpan(source, "Value");
+
+        var result = await operation.ExecuteAsync(new MakeNonStaticParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = span.StartLine,
+            StartColumn = span.StartColumn,
+            EndLine = span.EndLine,
+            EndColumn = span.EndColumn,
+            SymbolName = "Value"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("return this.Value();", updated);
+        Assert.DoesNotContain("return Base.Value();", updated);
+        Assert.DoesNotContain("((Base)this)", updated);
+    }
+
+    [SkippableFact]
+    public async Task MakeNonStatic_ConstructorInitializerThis_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class C
+            {
+                public static int CreateValue()
+                {
+                    return 1;
+                }
+
+                public C() : this(C.CreateValue())
+                {
+                }
+
+                public C(int value)
+                {
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new MakeNonStaticOperation(workspace.Context);
+        var span = FindIdentifierSpan(source, "CreateValue");
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new MakeNonStaticParams
+            {
+                SourceFile = workspace.SourcePath,
+                StartLine = span.StartLine,
+                StartColumn = span.StartColumn,
+                EndLine = span.EndLine,
+                EndColumn = span.EndColumn,
+                SymbolName = "CreateValue"
+            }));
+
+        Assert.Equal(ErrorCodes.NoValidInstanceReceiver, ex.ErrorCode);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains(": this(C.CreateValue())", before);
+    }
+
+    [SkippableFact]
+    public async Task MakeNonStatic_UnassignedLocal_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public static int Add(int a, int b)
+                {
+                    return a + b;
+                }
+            }
+
+            public class Consumer
+            {
+                public int Use()
+                {
+                    Calculator calc;
+                    return Calculator.Add(1, 2);
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new MakeNonStaticOperation(workspace.Context);
+        var span = FindIdentifierSpan(source, "Add");
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new MakeNonStaticParams
+            {
+                SourceFile = workspace.SourcePath,
+                StartLine = span.StartLine,
+                StartColumn = span.StartColumn,
+                EndLine = span.EndLine,
+                EndColumn = span.EndColumn,
+                SymbolName = "Add"
+            }));
+
+        Assert.Equal(ErrorCodes.NoValidInstanceReceiver, ex.ErrorCode);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("Calculator calc;", before);
+        Assert.Contains("return Calculator.Add(1, 2);", before);
+    }
+
+    [SkippableFact]
+    public async Task MakeNonStatic_AssignedLocal_RewritesToThatInstance()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public static int Add(int a, int b)
+                {
+                    return a + b;
+                }
+            }
+
+            public class Consumer
+            {
+                public int Use()
+                {
+                    var calc = new Calculator();
+                    return Calculator.Add(1, 2);
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new MakeNonStaticOperation(workspace.Context);
+        var span = FindIdentifierSpan(source, "Add");
+
+        var result = await operation.ExecuteAsync(new MakeNonStaticParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = span.StartLine,
+            StartColumn = span.StartColumn,
+            EndLine = span.EndLine,
+            EndColumn = span.EndColumn,
+            SymbolName = "Add"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("return calc.Add(1, 2);", updated);
+        Assert.DoesNotContain("return Calculator.Add(1, 2);", updated);
+    }
+
+    [SkippableFact]
+    public async Task MakeNonStatic_NestedFunctionInStaticMember_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public static int Add(int a, int b)
+                {
+                    return a + b;
+                }
+
+                public static int Use()
+                {
+                    System.Func<int> local = () => Calculator.Add(1, 2);
+                    return local();
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new MakeNonStaticOperation(workspace.Context);
+        var span = FindIdentifierSpan(source, "Add");
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new MakeNonStaticParams
+            {
+                SourceFile = workspace.SourcePath,
+                StartLine = span.StartLine,
+                StartColumn = span.StartColumn,
+                EndLine = span.EndLine,
+                EndColumn = span.EndColumn,
+                SymbolName = "Add"
+            }));
+
+        Assert.Equal(ErrorCodes.NoValidInstanceReceiver, ex.ErrorCode);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("() => Calculator.Add(1, 2)", before);
+    }
+
+    [SkippableFact]
+    public async Task MakeNonStatic_VerbatimKeywordReceiver_PreservesAtPrefix()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public static int Add(int a, int b)
+                {
+                    return a + b;
+                }
+            }
+
+            public class Consumer
+            {
+                public int Use(Calculator @class)
+                {
+                    return Calculator.Add(1, 2);
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new MakeNonStaticOperation(workspace.Context);
+        var span = FindIdentifierSpan(source, "Add");
+
+        var result = await operation.ExecuteAsync(new MakeNonStaticParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = span.StartLine,
+            StartColumn = span.StartColumn,
+            EndLine = span.EndLine,
+            EndColumn = span.EndColumn,
+            SymbolName = "Add"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("return @class.Add(1, 2);", updated);
+        Assert.DoesNotContain("return class.Add(1, 2);", updated);
+        Assert.DoesNotContain("return Calculator.Add(1, 2);", updated);
+    }
+
+    #endregion
+
     #region Helpers
 
     private static string AbsoluteTestPath() =>
@@ -536,6 +943,39 @@ public class MakeNonStaticOperationTests
         return (GetLineColumn(source, index).Line, GetLineColumn(source, index).Column,
             GetLineColumn(source, index + snippet.Length).Line, GetLineColumn(source, index + snippet.Length).Column);
     }
+
+    /// <summary>
+    /// Finds the first identifier occurrence that is a standalone token, not a
+    /// prefix of a longer identifier (for example <c>Get</c> in <c>Get()</c>
+    /// rather than the <c>Get</c> inside <c>GetHashCode</c>).
+    /// </summary>
+    private static (int StartLine, int StartColumn, int EndLine, int EndColumn) FindIdentifierSpan(
+        string source,
+        string identifier)
+    {
+        var start = 0;
+        while (start < source.Length)
+        {
+            var index = source.IndexOf(identifier, start, StringComparison.Ordinal);
+            if (index < 0)
+                throw new InvalidOperationException($"Identifier not found: {identifier}");
+
+            var beforeOk = index == 0 || !IsIdentifierPart(source[index - 1]);
+            var afterIndex = index + identifier.Length;
+            var afterOk = afterIndex >= source.Length || !IsIdentifierPart(source[afterIndex]);
+            if (beforeOk && afterOk)
+            {
+                return (GetLineColumn(source, index).Line, GetLineColumn(source, index).Column,
+                    GetLineColumn(source, afterIndex).Line, GetLineColumn(source, afterIndex).Column);
+            }
+
+            start = index + 1;
+        }
+
+        throw new InvalidOperationException($"Identifier not found: {identifier}");
+    }
+
+    private static bool IsIdentifierPart(char c) => char.IsLetterOrDigit(c) || c == '_';
 
     private static (int Line, int Column) GetLineColumn(string source, int index)
     {

--- a/tests/RoslynMcp.Server.Tests/Tools/MakeNonStaticToolTests.cs
+++ b/tests/RoslynMcp.Server.Tests/Tools/MakeNonStaticToolTests.cs
@@ -1,0 +1,140 @@
+using System.Text.Json;
+using RoslynMcp.Server.Tests.TestHelpers;
+using RoslynMcp.Server.Tools;
+using RoslynMcp.Server.Transport;
+using Xunit;
+
+namespace RoslynMcp.Server.Tests.Tools;
+
+/// <summary>
+/// Unit tests for MakeNonStaticTool.
+/// Tests tool definition and argument validation.
+/// </summary>
+public class MakeNonStaticToolTests
+{
+    private readonly MakeNonStaticTool _tool;
+
+    public MakeNonStaticToolTests()
+    {
+        _tool = new MakeNonStaticTool(new ThrowingWorkspaceProvider());
+    }
+
+    #region GetDefinition Tests
+
+    [Fact]
+    public void GetDefinition_ReturnsCorrectName()
+    {
+        Assert.Equal("make_non_static", _tool.Name);
+    }
+
+    [Fact]
+    public void GetDefinition_ReturnsNonEmptyDescription()
+    {
+        Assert.NotNull(_tool.Description);
+        Assert.NotEmpty(_tool.Description);
+    }
+
+    [Fact]
+    public void GetDefinition_ReturnsCorrectSchema()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.Equal("object", root.GetProperty("type").GetString());
+        Assert.True(root.TryGetProperty("properties", out _));
+        Assert.True(root.TryGetProperty("required", out _));
+    }
+
+    [Fact]
+    public void GetDefinition_HasRequiredFields()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var required = doc.RootElement.GetProperty("required");
+
+        var requiredFields = new List<string>();
+        foreach (var item in required.EnumerateArray())
+        {
+            requiredFields.Add(item.GetString()!);
+        }
+
+        Assert.Contains("solutionPath", requiredFields);
+        Assert.Contains("sourceFile", requiredFields);
+        Assert.Contains("startLine", requiredFields);
+        Assert.Contains("startColumn", requiredFields);
+        Assert.Contains("endLine", requiredFields);
+        Assert.Contains("endColumn", requiredFields);
+    }
+
+    [Fact]
+    public void GetDefinition_HasProperties_ForAllParameters()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var properties = doc.RootElement.GetProperty("properties");
+
+        Assert.True(properties.TryGetProperty("solutionPath", out _));
+        Assert.True(properties.TryGetProperty("sourceFile", out _));
+        Assert.True(properties.TryGetProperty("startLine", out _));
+        Assert.True(properties.TryGetProperty("startColumn", out _));
+        Assert.True(properties.TryGetProperty("endLine", out _));
+        Assert.True(properties.TryGetProperty("endColumn", out _));
+        Assert.True(properties.TryGetProperty("symbolName", out _));
+        Assert.True(properties.TryGetProperty("preview", out _));
+    }
+
+    #endregion
+
+    #region ExecuteAsync Argument Validation Tests
+
+    [Fact]
+    public async Task ExecuteAsync_NullArguments_ReturnsError()
+    {
+        var result = await _tool.ExecuteAsync(null);
+
+        Assert.True(result.IsError);
+        Assert.Contains("Arguments required", GetResultText(result));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EmptyArguments_ReturnsError()
+    {
+        var args = JsonDocument.Parse("{}").RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MissingRequiredField_ReturnsError()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "solutionPath": "C:/test/test.sln",
+                "sourceFile": "C:/test/Test.cs",
+                "startLine": 10,
+                "startColumn": 5
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static string GetResultText(ToolResult result)
+    {
+        return result.Content.FirstOrDefault()?.Text ?? string.Empty;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Description

Make a selected static method an instance method when that is valid. This is the Phase 3 inverse of `make_static` (PR #43).

- Drop the `static` modifier from an ordinary static method
- Rewrite `Type.Method()` and method-group conversions to `this` when the call site is in the same type, or to a unique in-scope instance otherwise
- Preview mode returns pending changes without writing files
- Reject: no symbol, already instance, non-method, uneditable document, extern, static class, extension method, interface member, and no valid instance receiver

Placement matches the shipped `MakeStaticOperation` under `Refactoring/Extract` (not a new Additional folder).

## 🔗 Related Issues

Closes #44

## 🎯 Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📚 Documentation update
- [x] ✅ Test additions or updates

## 🧪 Testing

- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Manual testing performed (operation + tool + CLI registry tests locally)

P0 coverage (MakeStatic test style):
- Happy path: remove `static` and rewrite `Type.Method()` to `this.Method()` in the same type
- Method-group conversions (`Type.Method` → `this.Method`; unqualified stays implicit `this`)
- Unique in-scope receiver in another type (`Calculator.Add` → `calc.Add`)
- Preview mode does not modify files
- Rejects: already instance, no symbol, non-method, no valid instance receiver, extern, static class, uneditable document
- MCP + CLI registration; tool count 48 → 49; refactoring category 35 → 36

Review-fold receiver fixes (same PR):
- Constructed generic receivers must match type arguments (`Container<string>` is not valid for `Container<int>.Get`)
- Derived `this` that would rebind to a hiding instance method is cast (`((Base)this).Value()`)
- Constructor initializers reject illegal `this`
- Locals must be definitely assigned at the call site
- Nested functions inside a static member do not emit `this`
- Verbatim/keyword receiver names keep the `@` prefix (`@class.Add`)

Local results (Linux, .NET 9.0.308):
- Format: `dotnet format --verify-no-changes` clean
- Build: `TreatWarningsAsErrors=true` clean
- Tests: Core 451, Server 393, CLI 98 — all passed, 0 skipped

**Test Configuration**:
- OS: Linux
- .NET Version: 9.0.308

## ✅ Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have added XML documentation for public APIs
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## 📋 Additional Notes

Out of scope per #44: constructors/operators as first-class targets, force-anything, undo.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f83011c-3634-4743-b5fb-a6cb995e6ab9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f83011c-3634-4743-b5fb-a6cb995e6ab9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

