### PR TITLE
Add convert_to_block_body refactoring

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "roslyn-mcp",
   "version": "0.4.1",
-  "description": "Roslyn-powered C# refactoring MCP server — 49 tools for code navigation, analysis, generation, and refactoring across entire .NET solutions",
+  "description": "Roslyn-powered C# refactoring MCP server — 50 tools for code navigation, analysis, generation, and refactoring across entire .NET solutions",
   "author": {
     "name": "Joshua Ramirez"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - `safe_delete` — delete a selected symbol only when it has no remaining references, with preview mode and rejects that include usage locations, missing symbols, and uneditable documents
 - `make_static` — add the static modifier to a selected instance method that does not use instance state, update call sites and method-group conversions to the containing type name, with preview mode and rejects for instance-member access, already-static methods, and uneditable documents
 - `make_non_static` — remove the static modifier from a selected static method, rewrite type-name call sites and method-group conversions to an instance receiver (or `this` in the same type), with preview mode and rejects for already-instance methods, missing receivers, extern methods, and uneditable documents
+- `convert_to_block_body` — convert a selected expression-bodied member (`=> expr`) to a block body (`{ return expr; }` or `{ expr; }` as appropriate), including properties and accessors, with preview mode and rejects for missing symbols, already-block bodies, unsupported members, and uneditable documents
 
 ## [0.4.0] - 2026-02-23
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Let AI assistants like Claude safely refactor your C# codebase using the same Roslyn compiler platform that powers Visual Studio.
 
-Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that exposes **49 Roslyn-powered tools** to AI assistants and other MCP clients. It combines 27 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 7 code conversion tools -- giving your AI deep code intelligence, comprehensive refactoring, and modern C# syntax transformations with full solution-wide reference tracking and preview support.
+Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that exposes **50 Roslyn-powered tools** to AI assistants and other MCP clients. It combines 27 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 8 code conversion tools -- giving your AI deep code intelligence, comprehensive refactoring, and modern C# syntax transformations with full solution-wide reference tracking and preview support.
 
 ---
 
@@ -30,7 +30,7 @@ Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotoc
 
 ## Why RoslynMcpServer?
 
-- **49 tools** -- refactoring, navigation, analysis, generation, and conversion tools, the most comprehensive Roslyn MCP server available
+- **50 tools** -- refactoring, navigation, analysis, generation, and conversion tools, the most comprehensive Roslyn MCP server available
 - **Preview mode on every operation** -- see exactly what will change before applying
 - **Atomic file writes with rollback** -- if any file write fails, all changes are reverted
 - **Solution-wide reference updates** -- renames and moves propagate across your entire solution
@@ -102,7 +102,7 @@ Claude will use the `rename_symbol` tool to rename the class and update every re
 
 ## Standalone CLI
 
-All 49 tools are also available as a standalone CLI for use in scripts, CI/CD pipelines, and terminals without an AI assistant.
+All 50 tools are also available as a standalone CLI for use in scripts, CI/CD pipelines, and terminals without an AI assistant.
 
 ### Install
 
@@ -237,6 +237,7 @@ All tools accept a `solutionPath` parameter (absolute path to a `.sln`, `.slnx`,
 |------|-------------|----------------|
 | `convert_to_async` | Convert a synchronous method to async/await pattern. | `sourceFile`, `methodName`, `line`, `renameToAsync` |
 | `convert_expression_body` | Toggle between expression body (`=> expr;`) and block body (`{ return expr; }`). | `sourceFile`, `direction`, `memberName`, `line` |
+| `convert_to_block_body` | Convert a selected expression-bodied member (`=> expr`) to a block body. Methods become `{ return expr; }` or `{ expr; }` as appropriate; properties and accessors that are expression-bodied are converted too. | `sourceFile`, `memberName`, `line` |
 | `convert_property` | Convert between auto-property and full property with backing field. | `sourceFile`, `direction`, `propertyName`, `line` |
 | `convert_foreach_linq` | Convert foreach loops with Add patterns to LINQ Select/Where expressions. | `sourceFile`, `line` |
 | `convert_to_pattern_matching` | Convert if/is chains and switch statements to switch expressions. | `sourceFile`, `line` |

--- a/src/RoslynMcp.Cli/ToolRegistry.cs
+++ b/src/RoslynMcp.Cli/ToolRegistry.cs
@@ -47,7 +47,7 @@ public sealed class ToolEntry
 }
 
 /// <summary>
-/// Maps tool names to execution delegates for all 49 Roslyn tools.
+/// Maps tool names to execution delegates for all 50 Roslyn tools.
 /// </summary>
 public sealed class ToolRegistry
 {
@@ -139,7 +139,7 @@ public sealed class ToolRegistry
         _tools.Values.OrderBy(t => t.Category).ThenBy(t => t.Name).ToList();
 
     /// <summary>
-    /// Build the default registry with all 49 tools registered.
+    /// Build the default registry with all 50 tools registered.
     /// </summary>
     public static ToolRegistry BuildDefault()
     {
@@ -191,11 +191,13 @@ public sealed class ToolRegistry
         r.RegisterRefactoring<EncapsulateFieldOperation, EncapsulateFieldParams>(
             "encapsulate-field", "Encapsulate a field into a property");
 
-        // ── Refactoring: Convert (6) ──────────────────────────────────
+        // ── Refactoring: Convert (7) ──────────────────────────────────
         r.RegisterRefactoring<ConvertToAsyncOperation, ConvertToAsyncParams>(
             "convert-to-async", "Convert a synchronous method to async");
         r.RegisterRefactoring<ConvertExpressionBodyOperation, ConvertExpressionBodyParams>(
             "convert-expression-body", "Toggle between expression body and block body");
+        r.RegisterRefactoring<ConvertToBlockBodyOperation, ConvertToBlockBodyParams>(
+            "convert-to-block-body", "Convert an expression-bodied member to a block body");
         r.RegisterRefactoring<ConvertPropertyOperation, ConvertPropertyParams>(
             "convert-property", "Convert between auto-property and full property");
         r.RegisterRefactoring<ConvertForeachLinqOperation, ConvertForeachLinqParams>(

--- a/src/RoslynMcp.Contracts/Errors/ErrorCodes.cs
+++ b/src/RoslynMcp.Contracts/Errors/ErrorCodes.cs
@@ -384,6 +384,13 @@ public static class ErrorCodes
     /// <summary>Cannot make non-static because no valid instance receiver exists for a call site.</summary>
     public const string NoValidInstanceReceiver = "3123";
 
+    // --------------------------------------------
+    // Convert Body Errors (3124)
+    // --------------------------------------------
+
+    /// <summary>Member already uses a block body.</summary>
+    public const string AlreadyBlockBody = "3124";
+
     // ============================================
     // System Errors (4xxx)
     // ============================================

--- a/src/RoslynMcp.Contracts/Models/ConvertToBlockBodyParams.cs
+++ b/src/RoslynMcp.Contracts/Models/ConvertToBlockBodyParams.cs
@@ -1,0 +1,27 @@
+namespace RoslynMcp.Contracts.Models;
+
+/// <summary>
+/// Parameters for the convert_to_block_body tool.
+/// </summary>
+public sealed class ConvertToBlockBodyParams
+{
+    /// <summary>
+    /// Absolute path to the source file.
+    /// </summary>
+    public required string SourceFile { get; init; }
+
+    /// <summary>
+    /// Name of the member to convert.
+    /// </summary>
+    public string? MemberName { get; init; }
+
+    /// <summary>
+    /// 1-based line number for position-based resolution.
+    /// </summary>
+    public int? Line { get; init; }
+
+    /// <summary>
+    /// Return computed changes without applying. Default: false.
+    /// </summary>
+    public bool Preview { get; init; }
+}

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertToBlockBodyOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertToBlockBodyOperation.cs
@@ -1,0 +1,467 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using RoslynMcp.Contracts.Enums;
+using RoslynMcp.Contracts.Errors;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.FileSystem;
+using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Workspace;
+
+namespace RoslynMcp.Core.Refactoring.Convert;
+
+/// <summary>
+/// Converts an expression-bodied member (<c>=&gt; expr</c>) to a block body.
+/// Inverse of <see cref="ConvertExpressionBodyOperation"/> in the ToExpressionBody direction.
+/// </summary>
+public sealed class ConvertToBlockBodyOperation : RefactoringOperationBase<ConvertToBlockBodyParams>
+{
+    /// <summary>
+    /// Creates a new convert-to-block-body operation.
+    /// </summary>
+    public ConvertToBlockBodyOperation(WorkspaceContext context) : base(context)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override void ValidateParams(ConvertToBlockBodyParams @params) => Validate(@params);
+
+    /// <summary>
+    /// Validates convert-to-block-body parameters. Internal so tests can exercise
+    /// input rules without loading a workspace.
+    /// </summary>
+    internal static void Validate(ConvertToBlockBodyParams @params)
+    {
+        if (string.IsNullOrWhiteSpace(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "sourceFile is required.");
+
+        if (!PathResolver.IsAbsolutePath(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.InvalidSourcePath, "sourceFile must be an absolute path.");
+
+        if (!PathResolver.IsValidCSharpFilePath(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.InvalidSourcePath, "sourceFile must be a .cs file.");
+
+        if (!@params.Line.HasValue && string.IsNullOrWhiteSpace(@params.MemberName))
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "Either memberName or line must be provided.");
+
+        if (@params.Line.HasValue && @params.Line.Value < 1)
+            throw new RefactoringException(ErrorCodes.InvalidLineNumber, "Line number must be >= 1.");
+
+        if (!File.Exists(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.SourceFileNotFound, $"Source file not found: {@params.SourceFile}");
+    }
+
+    /// <summary>
+    /// Rejects documents that cannot receive source edits.
+    /// </summary>
+    internal static void ValidateDocumentIsEditable(Document document, Microsoft.CodeAnalysis.Workspace workspace)
+    {
+        if (document is SourceGeneratedDocument)
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable (source-generated).");
+        }
+
+        if (string.IsNullOrWhiteSpace(document.FilePath) || !File.Exists(document.FilePath))
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable.");
+        }
+
+        if (!workspace.CanApplyChange(ApplyChangesKind.ChangeDocument))
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable (workspace cannot apply changes).");
+        }
+    }
+
+    /// <inheritdoc />
+    protected override async Task<RefactoringResult> ExecuteCoreAsync(
+        Guid operationId,
+        ConvertToBlockBodyParams @params,
+        CancellationToken cancellationToken)
+    {
+        var document = GetDocumentOrThrow(@params.SourceFile);
+        ValidateDocumentIsEditable(document, Context.Workspace);
+
+        var root = await document.GetSyntaxRootAsync(cancellationToken);
+        if (root == null)
+            throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse file.");
+
+        var member = FindMember(root, @params.MemberName, @params.Line);
+        if (member == null)
+        {
+            throw new RefactoringException(
+                ErrorCodes.SymbolNotFound,
+                $"Member '{@params.MemberName ?? $"at line {@params.Line}"}' not found.");
+        }
+
+        if (!IsConvertibleKind(member))
+        {
+            throw new RefactoringException(
+                ErrorCodes.CannotConvert,
+                $"Member '{GetMemberName(member) ?? member.Kind().ToString()}' does not support block body conversion.");
+        }
+
+        var (newMember, beforeSnippet, afterSnippet) = ConvertToBlockBody(member);
+
+        if (@params.Preview)
+        {
+            var pendingChanges = new List<PendingChange>
+            {
+                new()
+                {
+                    File = @params.SourceFile,
+                    ChangeType = ChangeKind.Modify,
+                    Description = $"Convert '{GetMemberName(member)}' to block body",
+                    BeforeSnippet = beforeSnippet,
+                    AfterSnippet = afterSnippet
+                }
+            };
+            return RefactoringResult.PreviewResult(operationId, pendingChanges);
+        }
+
+        var newRoot = root.ReplaceNode(member, newMember);
+        var newDocument = document.WithSyntaxRoot(newRoot);
+        var commitResult = await CommitChangesAsync(newDocument.Project.Solution, cancellationToken);
+
+        return RefactoringResult.Succeeded(
+            operationId,
+            new FileChanges
+            {
+                FilesModified = commitResult.FilesModified,
+                FilesCreated = commitResult.FilesCreated,
+                FilesDeleted = commitResult.FilesDeleted
+            },
+            new Contracts.Models.SymbolInfo
+            {
+                Name = GetMemberName(member) ?? string.Empty,
+                FullyQualifiedName = GetMemberName(member) ?? string.Empty,
+                Kind = MapKind(member)
+            },
+            0,
+            0);
+    }
+
+    private static SyntaxNode? FindMember(SyntaxNode root, string? memberName, int? line)
+    {
+        var candidates = root.DescendantNodes()
+            .Where(node => node is MemberDeclarationSyntax or LocalFunctionStatementSyntax)
+            .ToList();
+
+        IEnumerable<SyntaxNode> filtered = candidates;
+
+        if (!string.IsNullOrWhiteSpace(memberName))
+            filtered = filtered.Where(node => GetMemberName(node) == memberName);
+
+        if (line.HasValue)
+        {
+            filtered = filtered.Where(node => ContainsLine(node, line.Value));
+            return filtered.OrderBy(node => node.Span.Length).FirstOrDefault();
+        }
+
+        return filtered.FirstOrDefault();
+    }
+
+    private static bool ContainsLine(SyntaxNode node, int line)
+    {
+        var span = node.GetLocation().GetLineSpan();
+        var start = span.StartLinePosition.Line + 1;
+        var end = span.EndLinePosition.Line + 1;
+        return line >= start && line <= end;
+    }
+
+    private static bool IsConvertibleKind(SyntaxNode node) => node is
+        MethodDeclarationSyntax or
+        PropertyDeclarationSyntax or
+        IndexerDeclarationSyntax or
+        OperatorDeclarationSyntax or
+        ConversionOperatorDeclarationSyntax or
+        ConstructorDeclarationSyntax or
+        DestructorDeclarationSyntax or
+        LocalFunctionStatementSyntax or
+        EventDeclarationSyntax;
+
+    private static string? GetMemberName(SyntaxNode member) => member switch
+    {
+        MethodDeclarationSyntax method => method.Identifier.Text,
+        PropertyDeclarationSyntax property => property.Identifier.Text,
+        IndexerDeclarationSyntax => "this[]",
+        OperatorDeclarationSyntax op => $"operator {op.OperatorToken.Text}",
+        ConversionOperatorDeclarationSyntax => "implicit/explicit operator",
+        ConstructorDeclarationSyntax constructor => constructor.Identifier.Text,
+        DestructorDeclarationSyntax destructor => destructor.Identifier.Text,
+        LocalFunctionStatementSyntax localFunction => localFunction.Identifier.Text,
+        EventDeclarationSyntax @event => @event.Identifier.Text,
+        FieldDeclarationSyntax field => field.Declaration.Variables.FirstOrDefault()?.Identifier.Text,
+        EventFieldDeclarationSyntax eventField => eventField.Declaration.Variables.FirstOrDefault()?.Identifier.Text,
+        TypeDeclarationSyntax type => type.Identifier.Text,
+        _ => null
+    };
+
+    private static Contracts.Enums.SymbolKind MapKind(SyntaxNode member) => member switch
+    {
+        PropertyDeclarationSyntax or IndexerDeclarationSyntax => Contracts.Enums.SymbolKind.Property,
+        EventDeclarationSyntax => Contracts.Enums.SymbolKind.Event,
+        _ => Contracts.Enums.SymbolKind.Method
+    };
+
+    private static (SyntaxNode newNode, string before, string after) ConvertToBlockBody(SyntaxNode member)
+    {
+        return member switch
+        {
+            MethodDeclarationSyntax method => ConvertMethod(method),
+            LocalFunctionStatementSyntax localFunction => ConvertLocalFunction(localFunction),
+            OperatorDeclarationSyntax op => ConvertOperator(op),
+            ConversionOperatorDeclarationSyntax conversion => ConvertConversionOperator(conversion),
+            ConstructorDeclarationSyntax constructor => ConvertConstructor(constructor),
+            DestructorDeclarationSyntax destructor => ConvertDestructor(destructor),
+            PropertyDeclarationSyntax property => ConvertProperty(property),
+            IndexerDeclarationSyntax indexer => ConvertIndexer(indexer),
+            EventDeclarationSyntax @event => ConvertEvent(@event),
+            _ => throw new RefactoringException(
+                ErrorCodes.CannotConvert,
+                "Member type does not support block body conversion.")
+        };
+    }
+
+    private static (SyntaxNode newNode, string before, string after) ConvertMethod(MethodDeclarationSyntax method)
+    {
+        EnsureExpressionBody(method.ExpressionBody, method.Body, "Method");
+        var expr = method.ExpressionBody!.Expression;
+        var stmt = CreateStatement(expr, useReturn: !IsVoidReturn(method.ReturnType));
+        var before = FormatExpressionBody(expr);
+        var newMethod = method
+            .WithExpressionBody(null)
+            .WithSemicolonToken(default)
+            .WithBody(SyntaxFactory.Block(stmt))
+            .NormalizeWhitespace();
+        return (newMethod, before, newMethod.Body!.ToString().Trim());
+    }
+
+    private static (SyntaxNode newNode, string before, string after) ConvertLocalFunction(
+        LocalFunctionStatementSyntax localFunction)
+    {
+        EnsureExpressionBody(localFunction.ExpressionBody, localFunction.Body, "Local function");
+        var expr = localFunction.ExpressionBody!.Expression;
+        var stmt = CreateStatement(expr, useReturn: !IsVoidReturn(localFunction.ReturnType));
+        var before = FormatExpressionBody(expr);
+        var converted = localFunction
+            .WithExpressionBody(null)
+            .WithSemicolonToken(default)
+            .WithBody(SyntaxFactory.Block(stmt))
+            .NormalizeWhitespace();
+        return (converted, before, converted.Body!.ToString().Trim());
+    }
+
+    private static (SyntaxNode newNode, string before, string after) ConvertOperator(OperatorDeclarationSyntax op)
+    {
+        EnsureExpressionBody(op.ExpressionBody, op.Body, "Operator");
+        var expr = op.ExpressionBody!.Expression;
+        var stmt = CreateStatement(expr, useReturn: true);
+        var before = FormatExpressionBody(expr);
+        var converted = op
+            .WithExpressionBody(null)
+            .WithSemicolonToken(default)
+            .WithBody(SyntaxFactory.Block(stmt))
+            .NormalizeWhitespace();
+        return (converted, before, converted.Body!.ToString().Trim());
+    }
+
+    private static (SyntaxNode newNode, string before, string after) ConvertConversionOperator(
+        ConversionOperatorDeclarationSyntax conversion)
+    {
+        EnsureExpressionBody(conversion.ExpressionBody, conversion.Body, "Conversion operator");
+        var expr = conversion.ExpressionBody!.Expression;
+        var stmt = CreateStatement(expr, useReturn: true);
+        var before = FormatExpressionBody(expr);
+        var converted = conversion
+            .WithExpressionBody(null)
+            .WithSemicolonToken(default)
+            .WithBody(SyntaxFactory.Block(stmt))
+            .NormalizeWhitespace();
+        return (converted, before, converted.Body!.ToString().Trim());
+    }
+
+    private static (SyntaxNode newNode, string before, string after) ConvertConstructor(
+        ConstructorDeclarationSyntax constructor)
+    {
+        EnsureExpressionBody(constructor.ExpressionBody, constructor.Body, "Constructor");
+        var expr = constructor.ExpressionBody!.Expression;
+        var stmt = CreateStatement(expr, useReturn: false);
+        var before = FormatExpressionBody(expr);
+        var converted = constructor
+            .WithExpressionBody(null)
+            .WithSemicolonToken(default)
+            .WithBody(SyntaxFactory.Block(stmt))
+            .NormalizeWhitespace();
+        return (converted, before, converted.Body!.ToString().Trim());
+    }
+
+    private static (SyntaxNode newNode, string before, string after) ConvertDestructor(
+        DestructorDeclarationSyntax destructor)
+    {
+        EnsureExpressionBody(destructor.ExpressionBody, destructor.Body, "Destructor");
+        var expr = destructor.ExpressionBody!.Expression;
+        var stmt = CreateStatement(expr, useReturn: false);
+        var before = FormatExpressionBody(expr);
+        var converted = destructor
+            .WithExpressionBody(null)
+            .WithSemicolonToken(default)
+            .WithBody(SyntaxFactory.Block(stmt))
+            .NormalizeWhitespace();
+        return (converted, before, converted.Body!.ToString().Trim());
+    }
+
+    private static (SyntaxNode newNode, string before, string after) ConvertProperty(PropertyDeclarationSyntax property)
+    {
+        if (property.ExpressionBody != null)
+        {
+            var expr = property.ExpressionBody.Expression;
+            var accessor = CreateBlockAccessor(SyntaxKind.GetAccessorDeclaration, expr, useReturn: true);
+            var before = FormatExpressionBody(expr);
+            var newProp = property
+                .WithExpressionBody(null)
+                .WithSemicolonToken(default)
+                .WithAccessorList(SyntaxFactory.AccessorList(SyntaxFactory.SingletonList(accessor)))
+                .NormalizeWhitespace();
+            return (newProp, before, newProp.AccessorList!.ToString().Trim());
+        }
+
+        return ConvertAccessors(
+            property,
+            property.AccessorList,
+            updated => property.WithAccessorList(updated).NormalizeWhitespace(),
+            converted => converted.AccessorList!.ToString().Trim(),
+            "Property");
+    }
+
+    private static (SyntaxNode newNode, string before, string after) ConvertIndexer(IndexerDeclarationSyntax indexer)
+    {
+        if (indexer.ExpressionBody != null)
+        {
+            var expr = indexer.ExpressionBody.Expression;
+            var accessor = CreateBlockAccessor(SyntaxKind.GetAccessorDeclaration, expr, useReturn: true);
+            var before = FormatExpressionBody(expr);
+            var converted = indexer
+                .WithExpressionBody(null)
+                .WithSemicolonToken(default)
+                .WithAccessorList(SyntaxFactory.AccessorList(SyntaxFactory.SingletonList(accessor)))
+                .NormalizeWhitespace();
+            return (converted, before, converted.AccessorList!.ToString().Trim());
+        }
+
+        return ConvertAccessors(
+            indexer,
+            indexer.AccessorList,
+            updated => indexer.WithAccessorList(updated).NormalizeWhitespace(),
+            converted => converted.AccessorList!.ToString().Trim(),
+            "Indexer");
+    }
+
+    private static (SyntaxNode newNode, string before, string after) ConvertEvent(EventDeclarationSyntax @event)
+    {
+        return ConvertAccessors(
+            @event,
+            @event.AccessorList,
+            updated => @event.WithAccessorList(updated).NormalizeWhitespace(),
+            converted => converted.AccessorList!.ToString().Trim(),
+            "Event");
+    }
+
+    private static (SyntaxNode newNode, string before, string after) ConvertAccessors<T>(
+        T member,
+        AccessorListSyntax? accessorList,
+        Func<AccessorListSyntax, T> withAccessors,
+        Func<T, string> afterSnippet,
+        string memberKind)
+        where T : SyntaxNode
+    {
+        if (accessorList == null)
+        {
+            throw new RefactoringException(
+                ErrorCodes.CannotConvert,
+                $"{memberKind} does not have an expression body.");
+        }
+
+        var expressionBodied = accessorList.Accessors.Where(accessor => accessor.ExpressionBody != null).ToList();
+        if (expressionBodied.Count == 0)
+        {
+            if (accessorList.Accessors.Any(accessor => accessor.Body != null))
+            {
+                throw new RefactoringException(
+                    ErrorCodes.AlreadyBlockBody,
+                    $"{memberKind} already has a block body.");
+            }
+
+            throw new RefactoringException(
+                ErrorCodes.CannotConvert,
+                $"{memberKind} does not have an expression body.");
+        }
+
+        var before = string.Join(
+            " ",
+            expressionBodied.Select(accessor =>
+                $"{accessor.Keyword.Text} {FormatExpressionBody(accessor.ExpressionBody!.Expression)}"));
+
+        var convertedAccessors = accessorList.Accessors.Select(accessor =>
+        {
+            if (accessor.ExpressionBody == null)
+                return accessor;
+
+            var useReturn = accessor.IsKind(SyntaxKind.GetAccessorDeclaration) ||
+                            accessor.IsKind(SyntaxKind.InitAccessorDeclaration);
+            return CreateBlockAccessor(accessor.Kind(), accessor.ExpressionBody.Expression, useReturn)
+                .WithModifiers(accessor.Modifiers);
+        });
+
+        var converted = withAccessors(accessorList.WithAccessors(SyntaxFactory.List(convertedAccessors)));
+        return (converted, before, afterSnippet(converted));
+    }
+
+    private static AccessorDeclarationSyntax CreateBlockAccessor(
+        SyntaxKind kind,
+        ExpressionSyntax expression,
+        bool useReturn)
+    {
+        return SyntaxFactory.AccessorDeclaration(kind)
+            .WithBody(SyntaxFactory.Block(CreateStatement(expression, useReturn)));
+    }
+
+    private static void EnsureExpressionBody(ArrowExpressionClauseSyntax? expressionBody, BlockSyntax? body, string memberKind)
+    {
+        if (expressionBody != null)
+            return;
+
+        if (body != null)
+        {
+            throw new RefactoringException(
+                ErrorCodes.AlreadyBlockBody,
+                $"{memberKind} already has a block body.");
+        }
+
+        throw new RefactoringException(
+            ErrorCodes.CannotConvert,
+            $"{memberKind} does not have an expression body.");
+    }
+
+    private static StatementSyntax CreateStatement(ExpressionSyntax expression, bool useReturn)
+    {
+        if (expression is ThrowExpressionSyntax throwExpression)
+            return SyntaxFactory.ThrowStatement(throwExpression.Expression);
+
+        if (useReturn)
+            return SyntaxFactory.ReturnStatement(expression);
+
+        return SyntaxFactory.ExpressionStatement(expression);
+    }
+
+    private static bool IsVoidReturn(TypeSyntax returnType) =>
+        returnType is PredefinedTypeSyntax predefined && predefined.Keyword.IsKind(SyntaxKind.VoidKeyword);
+
+    private static string FormatExpressionBody(ExpressionSyntax expression) =>
+        $"=> {expression.NormalizeWhitespace()};";
+}

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertToBlockBodyOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertToBlockBodyOperation.cs
@@ -232,7 +232,7 @@ public sealed class ConvertToBlockBodyOperation : RefactoringOperationBase<Conve
     {
         EnsureExpressionBody(method.ExpressionBody, method.Body, "Method");
         var expr = method.ExpressionBody!.Expression;
-        var stmt = CreateStatement(expr, useReturn: !IsVoidReturn(method.ReturnType));
+        var stmt = CreateStatement(expr, useReturn: !IsNonReturning(method.ReturnType, method.Modifiers));
         var before = FormatExpressionBody(expr);
         var newMethod = method
             .WithExpressionBody(null)
@@ -247,7 +247,7 @@ public sealed class ConvertToBlockBodyOperation : RefactoringOperationBase<Conve
     {
         EnsureExpressionBody(localFunction.ExpressionBody, localFunction.Body, "Local function");
         var expr = localFunction.ExpressionBody!.Expression;
-        var stmt = CreateStatement(expr, useReturn: !IsVoidReturn(localFunction.ReturnType));
+        var stmt = CreateStatement(expr, useReturn: !IsNonReturning(localFunction.ReturnType, localFunction.Modifiers));
         var before = FormatExpressionBody(expr);
         var converted = localFunction
             .WithExpressionBody(null)
@@ -408,18 +408,19 @@ public sealed class ConvertToBlockBodyOperation : RefactoringOperationBase<Conve
                 $"{accessor.Keyword.Text} {FormatExpressionBody(accessor.ExpressionBody!.Expression)}"));
 
         var convertedAccessors = accessorList.Accessors.Select(accessor =>
-        {
-            if (accessor.ExpressionBody == null)
-                return accessor;
-
-            var useReturn = accessor.IsKind(SyntaxKind.GetAccessorDeclaration) ||
-                            accessor.IsKind(SyntaxKind.InitAccessorDeclaration);
-            return CreateBlockAccessor(accessor.Kind(), accessor.ExpressionBody.Expression, useReturn)
-                .WithModifiers(accessor.Modifiers);
-        });
+            accessor.ExpressionBody == null ? accessor : ConvertAccessorToBlock(accessor));
 
         var converted = withAccessors(accessorList.WithAccessors(SyntaxFactory.List(convertedAccessors)));
         return (converted, before, afterSnippet(converted));
+    }
+
+    private static AccessorDeclarationSyntax ConvertAccessorToBlock(AccessorDeclarationSyntax accessor)
+    {
+        var useReturn = accessor.IsKind(SyntaxKind.GetAccessorDeclaration);
+        return accessor
+            .WithExpressionBody(null)
+            .WithSemicolonToken(default)
+            .WithBody(SyntaxFactory.Block(CreateStatement(accessor.ExpressionBody!.Expression, useReturn)));
     }
 
     private static AccessorDeclarationSyntax CreateBlockAccessor(
@@ -459,8 +460,23 @@ public sealed class ConvertToBlockBodyOperation : RefactoringOperationBase<Conve
         return SyntaxFactory.ExpressionStatement(expression);
     }
 
+    private static bool IsNonReturning(TypeSyntax returnType, SyntaxTokenList modifiers) =>
+        IsVoidReturn(returnType) ||
+        (modifiers.Any(SyntaxKind.AsyncKeyword) && IsNonGenericTaskLike(returnType));
+
     private static bool IsVoidReturn(TypeSyntax returnType) =>
         returnType is PredefinedTypeSyntax predefined && predefined.Keyword.IsKind(SyntaxKind.VoidKeyword);
+
+    private static bool IsNonGenericTaskLike(TypeSyntax returnType) => returnType switch
+    {
+        GenericNameSyntax => false,
+        QualifiedNameSyntax qualified => IsNonGenericTaskLike(qualified.Right),
+        AliasQualifiedNameSyntax alias => IsNonGenericTaskLike(alias.Name),
+        IdentifierNameSyntax identifier => IsTaskLikeName(identifier.Identifier.Text),
+        _ => false
+    };
+
+    private static bool IsTaskLikeName(string name) => name is "Task" or "ValueTask";
 
     private static string FormatExpressionBody(ExpressionSyntax expression) =>
         $"=> {expression.NormalizeWhitespace()};";

--- a/src/RoslynMcp.Server/McpServerHost.cs
+++ b/src/RoslynMcp.Server/McpServerHost.cs
@@ -83,6 +83,7 @@ public sealed class McpServerHost : IAsyncDisposable
         // Data Flow & Conversion Tools
         _toolRegistry.Register(new AnalyzeDataFlowTool(workspaceProvider));
         _toolRegistry.Register(new ConvertExpressionBodyTool(workspaceProvider));
+        _toolRegistry.Register(new ConvertToBlockBodyTool(workspaceProvider));
         _toolRegistry.Register(new ConvertPropertyTool(workspaceProvider));
         _toolRegistry.Register(new IntroduceParameterTool(workspaceProvider));
 

--- a/src/RoslynMcp.Server/RoslynMcp.Server.csproj
+++ b/src/RoslynMcp.Server/RoslynMcp.Server.csproj
@@ -18,7 +18,7 @@
     <Version>0.4.0</Version>
     <Authors>Joshua Ramirez</Authors>
     <Company>RedJay</Company>
-    <Description>MCP Server for Roslyn-powered C# refactoring operations. Install as a global tool to use with Claude Code, Claude Desktop, or other MCP clients. Provides 49 tools: 27 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 7 code conversion tools.</Description>
+    <Description>MCP Server for Roslyn-powered C# refactoring operations. Install as a global tool to use with Claude Code, Claude Desktop, or other MCP clients. Provides 50 tools: 27 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 8 code conversion tools.</Description>
     <PackageTags>roslyn;mcp;refactoring;csharp;model-context-protocol;code-analysis;dotnet;ai-tools;claude</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/JoshuaRamirez/RoslynMcpServer</RepositoryUrl>

--- a/src/RoslynMcp.Server/Tools/ConvertToBlockBodyTool.cs
+++ b/src/RoslynMcp.Server/Tools/ConvertToBlockBodyTool.cs
@@ -1,0 +1,134 @@
+using System.Text.Json;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.Refactoring;
+using RoslynMcp.Core.Refactoring.Convert;
+using RoslynMcp.Core.Workspace;
+using RoslynMcp.Server.Transport;
+
+namespace RoslynMcp.Server.Tools;
+
+/// <summary>
+/// MCP tool handler for convert_to_block_body operation.
+/// </summary>
+public sealed class ConvertToBlockBodyTool : IToolHandler
+{
+    private readonly IWorkspaceProvider _workspaceProvider;
+    private readonly JsonSerializerOptions _jsonOptions;
+
+    /// <summary>
+    /// Creates a new convert-to-block-body tool.
+    /// </summary>
+    public ConvertToBlockBodyTool(IWorkspaceProvider workspaceProvider)
+    {
+        _workspaceProvider = workspaceProvider;
+        _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = false
+        };
+    }
+
+    /// <inheritdoc />
+    public string Name => "convert_to_block_body";
+
+    /// <inheritdoc />
+    public string Description => "Convert a selected expression-bodied C# member (=> expr) to a block body. Methods become { return expr; } or { expr; } as appropriate; properties and accessors that are expression-bodied are converted too.";
+
+    /// <inheritdoc />
+    public object InputSchema => new
+    {
+        type = "object",
+        required = new[] { "solutionPath", "sourceFile" },
+        properties = new
+        {
+            solutionPath = new
+            {
+                type = "string",
+                description = "Absolute path to the .sln or .csproj file"
+            },
+            sourceFile = new
+            {
+                type = "string",
+                description = "Absolute path to the source file"
+            },
+            memberName = new
+            {
+                type = "string",
+                description = "Name of the member to convert"
+            },
+            line = new
+            {
+                type = "integer",
+                description = "Line number of the member (1-based). Required when memberName is omitted.",
+                minimum = 1
+            },
+            preview = new
+            {
+                type = "boolean",
+                description = "Return computed changes without applying",
+                @default = false
+            }
+        },
+        additionalProperties = false
+    };
+
+    /// <inheritdoc />
+    public async Task<ToolResult> ExecuteAsync(JsonElement? arguments, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (arguments == null)
+            {
+                return ToolResult.Error("Arguments required");
+            }
+
+            var args = JsonSerializer.Deserialize<ConvertToBlockBodyArgs>(arguments.Value.GetRawText(), _jsonOptions);
+            if (args == null)
+            {
+                return ToolResult.Error("Failed to parse arguments");
+            }
+
+            using var context = await _workspaceProvider.CreateContextAsync(
+                args.SolutionPath,
+                cancellationToken);
+
+            var operation = new ConvertToBlockBodyOperation(context);
+            var @params = new ConvertToBlockBodyParams
+            {
+                SourceFile = args.SourceFile,
+                MemberName = args.MemberName,
+                Line = args.Line,
+                Preview = args.Preview ?? false
+            };
+
+            var result = await operation.ExecuteAsync(@params, cancellationToken);
+
+            var json = JsonSerializer.Serialize(result, _jsonOptions);
+            return result.Success ? ToolResult.Success(json) : ToolResult.Error(json);
+        }
+        catch (RefactoringException ex)
+        {
+            var error = ex.ToError();
+            var json = JsonSerializer.Serialize(new { success = false, error }, _jsonOptions);
+            return ToolResult.Error(json);
+        }
+        catch (Exception ex)
+        {
+            var json = JsonSerializer.Serialize(new
+            {
+                success = false,
+                error = new { code = "INTERNAL_ERROR", message = ex.Message }
+            }, _jsonOptions);
+            return ToolResult.Error(json);
+        }
+    }
+
+    private sealed class ConvertToBlockBodyArgs
+    {
+        public string SolutionPath { get; init; } = "";
+        public string SourceFile { get; init; } = "";
+        public string? MemberName { get; init; }
+        public int? Line { get; init; }
+        public bool? Preview { get; init; }
+    }
+}

--- a/tests/RoslynMcp.Cli.Tests/HelpGeneratorTests.cs
+++ b/tests/RoslynMcp.Cli.Tests/HelpGeneratorTests.cs
@@ -15,11 +15,11 @@ public class HelpGeneratorTests
     }
 
     [Fact]
-    public void GenerateGlobalHelp_Lists49Tools()
+    public void GenerateGlobalHelp_Lists50Tools()
     {
         var registry = ToolRegistry.BuildDefault();
         var help = HelpGenerator.GenerateGlobalHelp(registry);
-        Assert.Contains("Total: 49 tools", help);
+        Assert.Contains("Total: 50 tools", help);
         Assert.Contains("pull-members-up", help);
         Assert.Contains("push-members-down", help);
         Assert.Contains("use-base-type", help);
@@ -27,6 +27,7 @@ public class HelpGeneratorTests
         Assert.Contains("safe-delete", help);
         Assert.Contains("make-static", help);
         Assert.Contains("make-non-static", help);
+        Assert.Contains("convert-to-block-body", help);
     }
 
     [Fact]

--- a/tests/RoslynMcp.Cli.Tests/ToolRegistryTests.cs
+++ b/tests/RoslynMcp.Cli.Tests/ToolRegistryTests.cs
@@ -6,11 +6,11 @@ namespace RoslynMcp.Cli.Tests;
 public class ToolRegistryTests
 {
     [Fact]
-    public void BuildDefault_Registers49Tools()
+    public void BuildDefault_Registers50Tools()
     {
         var registry = ToolRegistry.BuildDefault();
         var tools = registry.GetAllTools();
-        Assert.Equal(49, tools.Count);
+        Assert.Equal(50, tools.Count);
     }
 
     [Fact]
@@ -96,6 +96,7 @@ public class ToolRegistryTests
     [InlineData("diagnose", "Diagnostic")]
     [InlineData("move-type-to-file", "Refactoring")]
     [InlineData("convert-to-async", "Refactoring")]
+    [InlineData("convert-to-block-body", "Refactoring")]
     [InlineData("generate-constructor", "Refactoring")]
     [InlineData("add-missing-usings", "Refactoring")]
     [InlineData("format-document", "Refactoring")]
@@ -109,11 +110,11 @@ public class ToolRegistryTests
     }
 
     [Fact]
-    public void RefactoringToolCount_Is36()
+    public void RefactoringToolCount_Is37()
     {
         var registry = ToolRegistry.BuildDefault();
         var count = registry.GetAllTools().Count(t => t.Category == "Refactoring");
-        Assert.Equal(36, count);
+        Assert.Equal(37, count);
     }
 
     [Fact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertToBlockBodyOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertToBlockBodyOperationTests.cs
@@ -1,0 +1,474 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using RoslynMcp.Contracts.Errors;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.Refactoring;
+using RoslynMcp.Core.Refactoring.Convert;
+using RoslynMcp.Core.Workspace;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Refactoring;
+
+/// <summary>
+/// Operation-level tests for <see cref="ConvertToBlockBodyOperation"/>.
+/// </summary>
+public class ConvertToBlockBodyOperationTests
+{
+    #region Input Validation
+
+    [Fact]
+    public void Validate_MissingSourceFile_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            ConvertToBlockBodyOperation.Validate(new ConvertToBlockBodyParams
+            {
+                SourceFile = "",
+                MemberName = "Get"
+            }));
+
+        Assert.Equal(ErrorCodes.MissingRequiredParam, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_RelativePath_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            ConvertToBlockBodyOperation.Validate(new ConvertToBlockBodyParams
+            {
+                SourceFile = "Types.cs",
+                MemberName = "Get"
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidSourcePath, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_NoMemberOrLine_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            ConvertToBlockBodyOperation.Validate(new ConvertToBlockBodyParams
+            {
+                SourceFile = AbsoluteTestPath()
+            }));
+
+        Assert.Equal(ErrorCodes.MissingRequiredParam, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_InvalidLine_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            ConvertToBlockBodyOperation.Validate(new ConvertToBlockBodyParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                Line = 0
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidLineNumber, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_MissingFile_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            ConvertToBlockBodyOperation.Validate(new ConvertToBlockBodyParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                MemberName = "Get"
+            }));
+
+        Assert.Equal(ErrorCodes.SourceFileNotFound, ex.ErrorCode);
+    }
+
+    #endregion
+
+    #region P0 Happy Path
+
+    [SkippableFact]
+    public async Task Convert_ReturningMethod_InsertsReturnBlock()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public int Add(int a, int b) => a + b;
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ConvertToBlockBodyOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new ConvertToBlockBodyParams
+        {
+            SourceFile = workspace.SourcePath,
+            MemberName = "Add"
+        });
+
+        Assert.True(result.Success);
+        Assert.False(result.Preview);
+        Assert.NotNull(result.Symbol);
+        Assert.Equal("Add", result.Symbol.Name);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.DoesNotContain("=>", updated);
+        Assert.Contains("return a + b;", updated);
+    }
+
+    [SkippableFact]
+    public async Task Convert_VoidMethod_InsertsExpressionStatement()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Logger
+            {
+                public void Log(string message) => System.Console.WriteLine(message);
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ConvertToBlockBodyOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new ConvertToBlockBodyParams
+        {
+            SourceFile = workspace.SourcePath,
+            MemberName = "Log"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.DoesNotContain("=>", updated);
+        Assert.Contains("System.Console.WriteLine(message);", updated);
+        Assert.DoesNotContain("return System.Console.WriteLine", updated);
+    }
+
+    [SkippableFact]
+    public async Task Convert_ExpressionBodiedProperty_CreatesGetterBlock()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Person
+            {
+                public string First { get; set; } = "Ada";
+                public string Last { get; set; } = "Lovelace";
+                public string FullName => First + " " + Last;
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ConvertToBlockBodyOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new ConvertToBlockBodyParams
+        {
+            SourceFile = workspace.SourcePath,
+            MemberName = "FullName"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.DoesNotContain("FullName =>", updated);
+        Assert.Contains("get", updated);
+        Assert.Contains("return First + \" \" + Last;", updated);
+    }
+
+    [SkippableFact]
+    public async Task Convert_ExpressionBodiedAccessor_ConvertsGetter()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Person
+            {
+                private string _name = "Ada";
+                public string Name
+                {
+                    get => _name;
+                    set => _name = value;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ConvertToBlockBodyOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new ConvertToBlockBodyParams
+        {
+            SourceFile = workspace.SourcePath,
+            MemberName = "Name"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.DoesNotContain("get =>", updated);
+        Assert.DoesNotContain("set =>", updated);
+        Assert.Contains("return _name;", updated);
+        Assert.Contains("_name = value;", updated);
+    }
+
+    [SkippableFact]
+    public async Task Convert_ByLine_FindsMember()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public int Value => 42;
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ConvertToBlockBodyOperation(workspace.Context);
+        var line = FindLine(source, "Value =>");
+
+        var result = await operation.ExecuteAsync(new ConvertToBlockBodyParams
+        {
+            SourceFile = workspace.SourcePath,
+            Line = line
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("return 42;", updated);
+    }
+
+    #endregion
+
+    #region P0 Preview
+
+    [SkippableFact]
+    public async Task Convert_Preview_DoesNotModifyFile()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public int Add(int a, int b) => a + b;
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+        var operation = new ConvertToBlockBodyOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new ConvertToBlockBodyParams
+        {
+            SourceFile = workspace.SourcePath,
+            MemberName = "Add",
+            Preview = true
+        });
+
+        Assert.True(result.Success);
+        Assert.True(result.Preview);
+        Assert.NotNull(result.PendingChanges);
+        Assert.Contains(result.PendingChanges, change => change.Description.Contains("Add"));
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    #endregion
+
+    #region P0 Rejects
+
+    [SkippableFact]
+    public async Task Convert_NoSymbol_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public int Add(int a, int b) => a + b;
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ConvertToBlockBodyOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new ConvertToBlockBodyParams
+            {
+                SourceFile = workspace.SourcePath,
+                MemberName = "Missing"
+            }));
+
+        Assert.Equal(ErrorCodes.SymbolNotFound, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task Convert_AlreadyBlockBody_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public int Add(int a, int b)
+                {
+                    return a + b;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ConvertToBlockBodyOperation(workspace.Context);
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new ConvertToBlockBodyParams
+            {
+                SourceFile = workspace.SourcePath,
+                MemberName = "Add"
+            }));
+
+        Assert.Equal(ErrorCodes.AlreadyBlockBody, ex.ErrorCode);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [SkippableFact]
+    public async Task Convert_UnsupportedMember_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Calculator
+            {
+                public int Value;
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ConvertToBlockBodyOperation(workspace.Context);
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new ConvertToBlockBodyParams
+            {
+                SourceFile = workspace.SourcePath,
+                MemberName = "Value"
+            }));
+
+        Assert.Equal(ErrorCodes.CannotConvert, ex.ErrorCode);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [Fact]
+    public void Convert_UneditableDocument_Throws()
+    {
+        var workspace = new AdhocWorkspace();
+        var project = workspace.AddProject("P", LanguageNames.CSharp);
+        var document = workspace.AddDocument(project.Id, "Generated.cs", SourceText.From("class C {}"));
+
+        var ex = Assert.Throws<RefactoringException>(() =>
+            ConvertToBlockBodyOperation.ValidateDocumentIsEditable(document, workspace));
+
+        Assert.Equal(ErrorCodes.DocumentNotEditable, ex.ErrorCode);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static string AbsoluteTestPath() =>
+        Path.Combine(Path.GetTempPath(), "RoslynMcpConvertToBlockBodyMissing.cs");
+
+    private static string NormalizeNewlines(string text) =>
+        text.Replace("\r\n", "\n", StringComparison.Ordinal);
+
+    private static int FindLine(string source, string snippet)
+    {
+        var index = source.IndexOf(snippet, StringComparison.Ordinal);
+        if (index < 0)
+            throw new InvalidOperationException($"Snippet not found: {snippet}");
+
+        var line = 1;
+        for (var i = 0; i < index; i++)
+        {
+            if (source[i] == '\n')
+                line++;
+        }
+
+        return line;
+    }
+
+    private sealed class TempWorkspace : IAsyncDisposable
+    {
+        public required string DirectoryPath { get; init; }
+        public required string ProjectPath { get; init; }
+        public required string SourcePath { get; init; }
+        public required WorkspaceContext Context { get; init; }
+
+        public static async Task<TempWorkspace> CreateAsync(string source, string fileName = "Types.cs")
+        {
+            Skip.IfNot(ModuleInitializer.MsBuildAvailable, ModuleInitializer.MsBuildError ?? "MSBuild not available");
+
+            var directory = Path.Combine(Path.GetTempPath(), "RoslynMcpConvertToBlockBody_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(directory);
+
+            var projectPath = Path.Combine(directory, "TestApp.csproj");
+            var sourcePath = Path.Combine(directory, fileName);
+
+            await File.WriteAllTextAsync(projectPath, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net9.0</TargetFramework>
+                    <Nullable>enable</Nullable>
+                  </PropertyGroup>
+                </Project>
+                """);
+            await File.WriteAllTextAsync(sourcePath, source);
+
+            try
+            {
+                var provider = new MSBuildWorkspaceProvider();
+                var context = await provider.CreateContextAsync(projectPath);
+                if (context.GetDocumentByPath(sourcePath) == null)
+                {
+                    context.Dispose();
+                    throw new InvalidOperationException($"Workspace loaded but did not include {sourcePath}.");
+                }
+
+                return new TempWorkspace
+                {
+                    DirectoryPath = directory,
+                    ProjectPath = projectPath,
+                    SourcePath = sourcePath,
+                    Context = context
+                };
+            }
+            catch (Exception ex) when (ex is not SkipException)
+            {
+                try
+                {
+                    Directory.Delete(directory, recursive: true);
+                }
+                catch
+                {
+                    // ignore cleanup failures
+                }
+
+                Skip.If(true, $"Workspace load failed: {ex.Message}");
+                throw;
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            Context.Dispose();
+            await Task.Run(() =>
+            {
+                try
+                {
+                    Directory.Delete(DirectoryPath, recursive: true);
+                }
+                catch
+                {
+                    // ignore locked temp files
+                }
+            });
+        }
+    }
+
+    #endregion
+}

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertToBlockBodyOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertToBlockBodyOperationTests.cs
@@ -233,6 +233,193 @@ public class ConvertToBlockBodyOperationTests
         Assert.Contains("return 42;", updated);
     }
 
+    [SkippableFact]
+    public async Task Convert_AsyncTaskMethod_InsertsExpressionStatement()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public async System.Threading.Tasks.Task Run() => await WorkAsync();
+
+                private static System.Threading.Tasks.Task WorkAsync() => System.Threading.Tasks.Task.CompletedTask;
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ConvertToBlockBodyOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new ConvertToBlockBodyParams
+        {
+            SourceFile = workspace.SourcePath,
+            MemberName = "Run"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("await WorkAsync();", updated);
+        Assert.DoesNotContain("return await WorkAsync", updated);
+    }
+
+    [SkippableFact]
+    public async Task Convert_AsyncValueTaskMethod_InsertsExpressionStatement()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public async System.Threading.Tasks.ValueTask Run() => await WorkAsync();
+
+                private static System.Threading.Tasks.ValueTask WorkAsync() => System.Threading.Tasks.ValueTask.CompletedTask;
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ConvertToBlockBodyOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new ConvertToBlockBodyParams
+        {
+            SourceFile = workspace.SourcePath,
+            MemberName = "Run"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("await WorkAsync();", updated);
+        Assert.DoesNotContain("return await WorkAsync", updated);
+    }
+
+    [SkippableFact]
+    public async Task Convert_AsyncTaskOfTMethod_InsertsReturn()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public async System.Threading.Tasks.Task<int> Get() => await WorkAsync();
+
+                private static System.Threading.Tasks.Task<int> WorkAsync() => System.Threading.Tasks.Task.FromResult(1);
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ConvertToBlockBodyOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new ConvertToBlockBodyParams
+        {
+            SourceFile = workspace.SourcePath,
+            MemberName = "Get"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("return await WorkAsync();", updated);
+    }
+
+    [SkippableFact]
+    public async Task Convert_AsyncTaskLocalFunction_InsertsExpressionStatement()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public void Host()
+                {
+                    async System.Threading.Tasks.Task Run() => await WorkAsync();
+                }
+
+                private static System.Threading.Tasks.Task WorkAsync() => System.Threading.Tasks.Task.CompletedTask;
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ConvertToBlockBodyOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new ConvertToBlockBodyParams
+        {
+            SourceFile = workspace.SourcePath,
+            MemberName = "Run"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("await WorkAsync();", updated);
+        Assert.DoesNotContain("return await WorkAsync", updated);
+    }
+
+    [SkippableFact]
+    public async Task Convert_InitAccessor_InsertsExpressionStatement()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Person
+            {
+                private string _name = "Ada";
+                public string Name
+                {
+                    get => _name;
+                    init => _name = value;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ConvertToBlockBodyOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new ConvertToBlockBodyParams
+        {
+            SourceFile = workspace.SourcePath,
+            MemberName = "Name"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.DoesNotContain("init =>", updated);
+        Assert.Contains("return _name;", updated);
+        Assert.Contains("_name = value;", updated);
+        Assert.DoesNotContain("return _name = value", updated);
+    }
+
+    [SkippableFact]
+    public async Task Convert_Accessor_PreservesAttributes()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Person
+            {
+                private string _name = "Ada";
+                public string Name
+                {
+                    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+                    get => _name;
+                    set => _name = value;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ConvertToBlockBodyOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new ConvertToBlockBodyParams
+        {
+            SourceFile = workspace.SourcePath,
+            MemberName = "Name"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("MethodImpl", updated);
+        Assert.Contains("AggressiveInlining", updated);
+        Assert.Contains("return _name;", updated);
+        Assert.DoesNotContain("get =>", updated);
+    }
+
     #endregion
 
     #region P0 Preview

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertToBlockBodyOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertToBlockBodyOperationTests.cs
@@ -659,3 +659,4 @@ public class ConvertToBlockBodyOperationTests
 
     #endregion
 }
+

--- a/tests/RoslynMcp.Server.Tests/Tools/ConvertToBlockBodyToolTests.cs
+++ b/tests/RoslynMcp.Server.Tests/Tools/ConvertToBlockBodyToolTests.cs
@@ -1,0 +1,117 @@
+using System.Text.Json;
+using RoslynMcp.Server.Tests.TestHelpers;
+using RoslynMcp.Server.Tools;
+using RoslynMcp.Server.Transport;
+using Xunit;
+
+namespace RoslynMcp.Server.Tests.Tools;
+
+/// <summary>
+/// Unit tests for ConvertToBlockBodyTool.
+/// Tests tool definition and argument validation.
+/// </summary>
+public class ConvertToBlockBodyToolTests
+{
+    private readonly ConvertToBlockBodyTool _tool;
+
+    public ConvertToBlockBodyToolTests()
+    {
+        // Fails loudly if workspace creation is attempted; argument validation is exercised via ExecuteAsync error paths.
+        _tool = new ConvertToBlockBodyTool(new ThrowingWorkspaceProvider());
+    }
+
+    #region GetDefinition Tests
+
+    [Fact]
+    public void GetDefinition_ReturnsCorrectName()
+    {
+        Assert.Equal("convert_to_block_body", _tool.Name);
+    }
+
+    [Fact]
+    public void GetDefinition_ReturnsNonEmptyDescription()
+    {
+        Assert.NotNull(_tool.Description);
+        Assert.NotEmpty(_tool.Description);
+    }
+
+    [Fact]
+    public void GetDefinition_ReturnsCorrectSchema()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.Equal("object", root.GetProperty("type").GetString());
+        Assert.True(root.TryGetProperty("properties", out _));
+        Assert.True(root.TryGetProperty("required", out _));
+    }
+
+    [Fact]
+    public void GetDefinition_HasRequiredFields()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var required = doc.RootElement.GetProperty("required");
+
+        var requiredFields = new List<string>();
+        foreach (var item in required.EnumerateArray())
+        {
+            requiredFields.Add(item.GetString()!);
+        }
+
+        Assert.Contains("solutionPath", requiredFields);
+        Assert.Contains("sourceFile", requiredFields);
+    }
+
+    [Fact]
+    public void GetDefinition_HasProperties_ForAllParameters()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var properties = doc.RootElement.GetProperty("properties");
+
+        Assert.True(properties.TryGetProperty("solutionPath", out _));
+        Assert.True(properties.TryGetProperty("sourceFile", out _));
+        Assert.True(properties.TryGetProperty("memberName", out _));
+        Assert.True(properties.TryGetProperty("line", out _));
+        Assert.True(properties.TryGetProperty("preview", out _));
+    }
+
+    #endregion
+
+    #region ExecuteAsync Argument Validation Tests
+
+    [Fact]
+    public async Task ExecuteAsync_NullArguments_ReturnsError()
+    {
+        var result = await _tool.ExecuteAsync(null);
+
+        Assert.True(result.IsError);
+        Assert.Contains("Arguments required", GetResultText(result));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EmptyArguments_ReturnsError()
+    {
+        var args = JsonDocument.Parse("{}").RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static string GetResultText(ToolResult result)
+    {
+        return result.Content.FirstOrDefault()?.Text ?? string.Empty;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Ship bounded `convert_to_block_body` / `ConvertToBlockBodyOperation`, the Convert Phase 1 inverse of the already-shipped `ConvertExpressionBodyOperation`.

The existing `convert_expression_body` tool stays bidirectional via its `direction` parameter. This PR adds a dedicated operation, MCP tool, and CLI entry next to it rather than overloading that public API.

- Methods: `=> expr` → `{ return expr; }` or `{ expr; }` (void)
- Properties and accessors that are expression-bodied convert to block accessors
- Throw expressions become `throw` statements (`return throw` is invalid)
- Preview mode returns pending changes without writing files
- Reject: no symbol, already a block body, uneditable document, unsupported member (fields, types, members with no expression body)

Review-fold fixes:
- `async Task` / `async ValueTask` methods and local functions emit an expression statement, not `return`
- `init` accessors are void-like (same as `set`); only `get` emits `return`
- Accessor conversion mutates the existing node so attribute lists and trivia are preserved

## Related Issues

Closes #46

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [x] Test additions or updates

## Testing

- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Manual testing performed (operation + tool + CLI registry tests locally)

P0 coverage (ConvertExpressionBody + recent leftover style):
- Happy path: returning method, void method, property `=> expr`, accessor `get =>` / `set =>`
- Line-based resolution
- Preview mode does not modify files
- Rejects: no symbol, already block body, unsupported member, uneditable document
- MCP + CLI registration; tool count 49 → 50; refactoring category 36 → 37

Review-fold coverage:
- `async Task` / `async ValueTask` method and local function → expression statement
- `async Task<T>` still returns
- `init =>` → expression statement, not `return`
- Accessor `[MethodImpl]` is preserved

**Test Configuration**:
- OS: Linux
- .NET Version: 9.0.317

## Additional Notes

Out of scope per #46: `convert_to_async`, foreach/linq, encapsulate, undo, Dependabot, extra leftover issues.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9ce5752-12c5-49e2-9ea2-203660ca84b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9ce5752-12c5-49e2-9ea2-203660ca84b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

