### PR TITLE
Add generate_property refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - `make_static` — add the static modifier to a selected instance method that does not use instance state, update call sites and method-group conversions to the containing type name, with preview mode and rejects for instance-member access, already-static methods, and uneditable documents
 - `make_non_static` — remove the static modifier from a selected static method, rewrite type-name call sites and method-group conversions to an instance receiver (or `this` in the same type), with preview mode and rejects for already-instance methods, missing receivers, extern methods, and uneditable documents
 - `convert_to_block_body` — convert a selected expression-bodied member (`=> expr`) to a block body (`{ return expr; }` or `{ expr; }` as appropriate), including properties and accessors, with preview mode and rejects for missing symbols, already-block bodies, unsupported members, and uneditable documents
+- `generate_property` — generate an auto-property `{ get; set; }`, init-only property `{ get; init; }`, or backing-field property `{ get => field; set => field = value; }` on a selected type, with preview mode and rejects for missing symbols, uneditable documents, unsupported targets, and name clashes
 
 ## [0.4.0] - 2026-02-23
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Let AI assistants like Claude safely refactor your C# codebase using the same Roslyn compiler platform that powers Visual Studio.
 
-Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that exposes **50 Roslyn-powered tools** to AI assistants and other MCP clients. It combines 27 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 8 code conversion tools -- giving your AI deep code intelligence, comprehensive refactoring, and modern C# syntax transformations with full solution-wide reference tracking and preview support.
+Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that exposes **51 Roslyn-powered tools** to AI assistants and other MCP clients. It combines 28 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 8 code conversion tools -- giving your AI deep code intelligence, comprehensive refactoring, and modern C# syntax transformations with full solution-wide reference tracking and preview support.
 
 ---
 
@@ -30,7 +30,7 @@ Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotoc
 
 ## Why RoslynMcpServer?
 
-- **50 tools** -- refactoring, navigation, analysis, generation, and conversion tools, the most comprehensive Roslyn MCP server available
+- **51 tools** -- refactoring, navigation, analysis, generation, and conversion tools, the most comprehensive Roslyn MCP server available
 - **Preview mode on every operation** -- see exactly what will change before applying
 - **Atomic file writes with rollback** -- if any file write fails, all changes are reverted
 - **Solution-wide reference updates** -- renames and moves propagate across your entire solution
@@ -102,7 +102,7 @@ Claude will use the `rename_symbol` tool to rename the class and update every re
 
 ## Standalone CLI
 
-All 50 tools are also available as a standalone CLI for use in scripts, CI/CD pipelines, and terminals without an AI assistant.
+All 51 tools are also available as a standalone CLI for use in scripts, CI/CD pipelines, and terminals without an AI assistant.
 
 ### Install
 
@@ -228,6 +228,7 @@ All tools accept a `solutionPath` parameter (absolute path to a `.sln`, `.slnx`,
 | Tool | Description | Key Parameters |
 |------|-------------|----------------|
 | `generate_constructor` | Generate a constructor that initializes fields and/or properties of a type. | `sourceFile`, `typeName`, `members`, `addNullChecks` |
+| `generate_property` | Generate a property on a type: auto-property `{ get; set; }`, init-only `{ get; init; }`, or a backing-field form when a field is the target. | `sourceFile`, `typeName`, `propertyName`, `propertyType`, `fieldName`, `visibility`, `initOnly` |
 | `generate_overrides` | Generate override methods for base class virtual/abstract members. | `sourceFile`, `typeName`, `members`, `callBase` |
 | `implement_interface` | Generate interface member implementations for a type. | `sourceFile`, `typeName`, `interfaceName`, `explicitImplementation`, `members` |
 

--- a/src/RoslynMcp.Cli/ToolRegistry.cs
+++ b/src/RoslynMcp.Cli/ToolRegistry.cs
@@ -47,7 +47,7 @@ public sealed class ToolEntry
 }
 
 /// <summary>
-/// Maps tool names to execution delegates for all 50 Roslyn tools.
+/// Maps tool names to execution delegates for all 51 Roslyn tools.
 /// </summary>
 public sealed class ToolRegistry
 {
@@ -139,7 +139,7 @@ public sealed class ToolRegistry
         _tools.Values.OrderBy(t => t.Category).ThenBy(t => t.Name).ToList();
 
     /// <summary>
-    /// Build the default registry with all 50 tools registered.
+    /// Build the default registry with all 51 tools registered.
     /// </summary>
     public static ToolRegistry BuildDefault()
     {
@@ -207,9 +207,11 @@ public sealed class ToolRegistry
         r.RegisterRefactoring<ConvertToPatternMatchingOperation, ConvertToPatternMatchingParams>(
             "convert-to-pattern-matching", "Convert type checks to pattern matching");
 
-        // ── Refactoring: Generate (6) ─────────────────────────────────
+        // ── Refactoring: Generate (7) ─────────────────────────────────
         r.RegisterRefactoring<GenerateConstructorOperation, GenerateConstructorParams>(
             "generate-constructor", "Generate a constructor from fields/properties");
+        r.RegisterRefactoring<GeneratePropertyOperation, GeneratePropertyParams>(
+            "generate-property", "Generate a property on a type (auto, init-only, or backing-field)");
         r.RegisterRefactoring<GenerateEqualsHashCodeOperation, GenerateEqualsHashCodeParams>(
             "generate-equals-hashcode", "Generate Equals and GetHashCode overrides");
         r.RegisterRefactoring<GenerateOverridesOperation, GenerateOverridesParams>(

--- a/src/RoslynMcp.Contracts/Enums/RefactoringKind.cs
+++ b/src/RoslynMcp.Contracts/Enums/RefactoringKind.cs
@@ -67,6 +67,9 @@ public enum RefactoringKind
     /// <summary>Generate constructor from fields/properties.</summary>
     GenerateConstructor,
 
+    /// <summary>Generate a property on a type.</summary>
+    GenerateProperty,
+
     /// <summary>Generate method stub.</summary>
     GenerateMethodStub,
 

--- a/src/RoslynMcp.Contracts/Models/GeneratePropertyParams.cs
+++ b/src/RoslynMcp.Contracts/Models/GeneratePropertyParams.cs
@@ -1,0 +1,50 @@
+namespace RoslynMcp.Contracts.Models;
+
+/// <summary>
+/// Parameters for the generate_property tool.
+/// </summary>
+public sealed class GeneratePropertyParams
+{
+    /// <summary>
+    /// Absolute path to the source file.
+    /// </summary>
+    public required string SourceFile { get; init; }
+
+    /// <summary>
+    /// Name of the type to add the property to.
+    /// </summary>
+    public required string TypeName { get; init; }
+
+    /// <summary>
+    /// Name of the property to generate. When omitted and <see cref="FieldName"/> is set,
+    /// the name is derived from the field (leading underscores stripped, first letter capitalized).
+    /// </summary>
+    public string? PropertyName { get; init; }
+
+    /// <summary>
+    /// C# type of the property (for example <c>string</c> or <c>int</c>).
+    /// Required for auto-properties; inferred from the field when <see cref="FieldName"/> is set.
+    /// </summary>
+    public string? PropertyType { get; init; }
+
+    /// <summary>
+    /// Optional field to wrap. When set, generates
+    /// <c>{ get =&gt; field; set =&gt; field = value; }</c> instead of an auto-property.
+    /// </summary>
+    public string? FieldName { get; init; }
+
+    /// <summary>
+    /// Accessibility of the generated property. Default: public.
+    /// </summary>
+    public string? Visibility { get; init; }
+
+    /// <summary>
+    /// Generate an init-only setter (<c>{ get; init; }</c> or <c>init =&gt;</c>). Default: false.
+    /// </summary>
+    public bool InitOnly { get; init; }
+
+    /// <summary>
+    /// Return computed changes without applying. Default: false.
+    /// </summary>
+    public bool Preview { get; init; }
+}

--- a/src/RoslynMcp.Core/Refactoring/Generate/GeneratePropertyOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GeneratePropertyOperation.cs
@@ -108,7 +108,7 @@ public sealed class GeneratePropertyOperation : RefactoringOperationBase<Generat
         if (root == null || semanticModel == null)
             throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse file.");
 
-        var typeDecl = root.DescendantNodes().OfType<TypeDeclarationSyntax>()
+        var typeDecl = root.DescendantNodes().OfType<BaseTypeDeclarationSyntax>()
             .FirstOrDefault(t => t.Identifier.Text == @params.TypeName);
 
         if (typeDecl == null)
@@ -127,6 +127,13 @@ public sealed class GeneratePropertyOperation : RefactoringOperationBase<Generat
         }
 
         ValidateTypeCanHostProperty(typeSymbol);
+
+        if (typeDecl is not TypeDeclarationSyntax hostTypeDecl)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidSymbolKind,
+                $"Type '{typeSymbol.Name}' is not a supported target for generate_property.");
+        }
 
         IFieldSymbol? backingField = null;
         if (!string.IsNullOrWhiteSpace(@params.FieldName))
@@ -152,8 +159,8 @@ public sealed class GeneratePropertyOperation : RefactoringOperationBase<Generat
         if (@params.Preview)
             return CreatePreviewResult(operationId, @params, propertyName, property);
 
-        var newTypeDecl = InsertProperty(typeDecl, property);
-        var newRoot = root.ReplaceNode(typeDecl, newTypeDecl);
+        var newTypeDecl = InsertProperty(hostTypeDecl, property);
+        var newRoot = root.ReplaceNode(hostTypeDecl, newTypeDecl);
         var newDocument = document.WithSyntaxRoot(newRoot);
         var commitResult = await CommitChangesAsync(newDocument.Project.Solution, cancellationToken);
 

--- a/src/RoslynMcp.Core/Refactoring/Generate/GeneratePropertyOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GeneratePropertyOperation.cs
@@ -1,0 +1,391 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using RoslynMcp.Contracts.Enums;
+using RoslynMcp.Contracts.Errors;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.FileSystem;
+using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Workspace;
+
+namespace RoslynMcp.Core.Refactoring.Generate;
+
+/// <summary>
+/// Generates a property on a selected type: auto-property <c>{ get; set; }</c>,
+/// init-only <c>{ get; init; }</c>, or a backing-field form when a field is the target.
+/// </summary>
+public sealed class GeneratePropertyOperation : RefactoringOperationBase<GeneratePropertyParams>
+{
+    private static readonly HashSet<string> ValidVisibilities = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "public", "private", "protected", "internal", "protected internal", "private protected"
+    };
+
+    /// <summary>
+    /// Creates a new generate property operation.
+    /// </summary>
+    /// <param name="context">Workspace context.</param>
+    public GeneratePropertyOperation(WorkspaceContext context) : base(context)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override void ValidateParams(GeneratePropertyParams @params) => Validate(@params);
+
+    /// <summary>
+    /// Validates generate-property parameters. Internal so tests can exercise
+    /// input rules without loading a workspace.
+    /// </summary>
+    internal static void Validate(GeneratePropertyParams @params)
+    {
+        if (string.IsNullOrWhiteSpace(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "sourceFile is required.");
+
+        if (string.IsNullOrWhiteSpace(@params.TypeName))
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "typeName is required.");
+
+        if (!PathResolver.IsAbsolutePath(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.InvalidSourcePath, "sourceFile must be an absolute path.");
+
+        if (!PathResolver.IsValidCSharpFilePath(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.InvalidSourcePath, "sourceFile must be a .cs file.");
+
+        var hasField = !string.IsNullOrWhiteSpace(@params.FieldName);
+        if (string.IsNullOrWhiteSpace(@params.PropertyName) && !hasField)
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "propertyName is required unless fieldName is provided.");
+
+        if (string.IsNullOrWhiteSpace(@params.PropertyType) && !hasField)
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "propertyType is required unless fieldName is provided.");
+
+        if (@params.PropertyName != null && !IsValidIdentifier(@params.PropertyName))
+            throw new RefactoringException(ErrorCodes.InvalidSymbolName, $"Invalid property name: {@params.PropertyName}");
+
+        if (!string.IsNullOrWhiteSpace(@params.Visibility) && !ValidVisibilities.Contains(@params.Visibility.Trim()))
+            throw new RefactoringException(ErrorCodes.InvalidVisibility, $"Invalid visibility: {@params.Visibility}");
+
+        if (!File.Exists(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.SourceFileNotFound, $"Source file not found: {@params.SourceFile}");
+    }
+
+    /// <summary>
+    /// Rejects documents that cannot receive source edits.
+    /// </summary>
+    internal static void ValidateDocumentIsEditable(Document document, Microsoft.CodeAnalysis.Workspace workspace)
+    {
+        if (document is SourceGeneratedDocument)
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable (source-generated).");
+        }
+
+        if (string.IsNullOrWhiteSpace(document.FilePath) || !File.Exists(document.FilePath))
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable.");
+        }
+
+        if (!workspace.CanApplyChange(ApplyChangesKind.ChangeDocument))
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable (workspace cannot apply changes).");
+        }
+    }
+
+    /// <inheritdoc />
+    protected override async Task<RefactoringResult> ExecuteCoreAsync(
+        Guid operationId,
+        GeneratePropertyParams @params,
+        CancellationToken cancellationToken)
+    {
+        var document = GetDocumentOrThrow(@params.SourceFile);
+        ValidateDocumentIsEditable(document, Context.Workspace);
+
+        var root = await document.GetSyntaxRootAsync(cancellationToken);
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken);
+        if (root == null || semanticModel == null)
+            throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse file.");
+
+        var typeDecl = root.DescendantNodes().OfType<TypeDeclarationSyntax>()
+            .FirstOrDefault(t => t.Identifier.Text == @params.TypeName);
+
+        if (typeDecl == null)
+        {
+            throw new RefactoringException(
+                ErrorCodes.SymbolNotFound,
+                $"No type named '{@params.TypeName}' found in the source file.");
+        }
+
+        var typeSymbol = semanticModel.GetDeclaredSymbol(typeDecl, cancellationToken) as INamedTypeSymbol;
+        if (typeSymbol == null)
+        {
+            throw new RefactoringException(
+                ErrorCodes.SymbolNotFound,
+                $"Could not resolve a symbol for type '{@params.TypeName}'.");
+        }
+
+        ValidateTypeCanHostProperty(typeSymbol);
+
+        IFieldSymbol? backingField = null;
+        if (!string.IsNullOrWhiteSpace(@params.FieldName))
+        {
+            backingField = ResolveBackingField(typeSymbol, @params.FieldName);
+            ValidateFieldCanBeWrapped(backingField);
+        }
+
+        var propertyName = ResolvePropertyName(@params, backingField);
+        var propertyType = ResolvePropertyType(@params, backingField);
+        ValidateNoNameClash(typeSymbol, propertyName);
+
+        var visibility = string.IsNullOrWhiteSpace(@params.Visibility) ? "public" : @params.Visibility.Trim();
+        var property = backingField != null
+            ? CreatePropertyWithBackingField(propertyName, propertyType, backingField, visibility, @params.InitOnly)
+            : CreateAutoProperty(propertyName, propertyType, visibility, @params.InitOnly);
+
+        if (typeSymbol.IsStatic && !property.Modifiers.Any(SyntaxKind.StaticKeyword))
+        {
+            property = property.AddModifiers(SyntaxFactory.Token(SyntaxKind.StaticKeyword));
+        }
+
+        if (@params.Preview)
+            return CreatePreviewResult(operationId, @params, propertyName, property);
+
+        var newTypeDecl = InsertProperty(typeDecl, property);
+        var newRoot = root.ReplaceNode(typeDecl, newTypeDecl);
+        var newDocument = document.WithSyntaxRoot(newRoot);
+        var commitResult = await CommitChangesAsync(newDocument.Project.Solution, cancellationToken);
+
+        return RefactoringResult.Succeeded(
+            operationId,
+            new FileChanges
+            {
+                FilesModified = commitResult.FilesModified,
+                FilesCreated = commitResult.FilesCreated,
+                FilesDeleted = commitResult.FilesDeleted
+            },
+            new Contracts.Models.SymbolInfo
+            {
+                Name = propertyName,
+                FullyQualifiedName = $"{typeSymbol.ToDisplayString()}.{propertyName}",
+                Kind = Contracts.Enums.SymbolKind.Property
+            },
+            0,
+            0);
+    }
+
+    internal static void ValidateTypeCanHostProperty(INamedTypeSymbol typeSymbol)
+    {
+        if (typeSymbol.TypeKind is TypeKind.Enum or TypeKind.Delegate or TypeKind.Interface)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidSymbolKind,
+                $"Type '{typeSymbol.Name}' is not a supported target for generate_property.");
+        }
+    }
+
+    internal static void ValidateFieldCanBeWrapped(IFieldSymbol field)
+    {
+        if (field.IsConst)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidSymbolKind,
+                $"Field '{field.Name}' is not a supported target (const fields cannot be wrapped).");
+        }
+
+        if (field.IsImplicitlyDeclared)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidSymbolKind,
+                $"Field '{field.Name}' is not a supported target.");
+        }
+    }
+
+    internal static void ValidateNoNameClash(INamedTypeSymbol typeSymbol, string propertyName)
+    {
+        var existing = typeSymbol.GetMembers(propertyName)
+            .FirstOrDefault(m => !m.IsImplicitlyDeclared);
+        if (existing != null)
+        {
+            throw new RefactoringException(
+                ErrorCodes.NameCollision,
+                $"A member named '{propertyName}' already exists on '{typeSymbol.Name}'.");
+        }
+    }
+
+    private static IFieldSymbol ResolveBackingField(INamedTypeSymbol typeSymbol, string fieldName)
+    {
+        var field = typeSymbol.GetMembers(fieldName)
+            .OfType<IFieldSymbol>()
+            .FirstOrDefault(f => !f.IsImplicitlyDeclared);
+
+        if (field == null)
+        {
+            throw new RefactoringException(
+                ErrorCodes.SymbolNotFound,
+                $"No field named '{fieldName}' found on type '{typeSymbol.Name}'.");
+        }
+
+        return field;
+    }
+
+    private static string ResolvePropertyName(GeneratePropertyParams @params, IFieldSymbol? backingField)
+    {
+        if (!string.IsNullOrWhiteSpace(@params.PropertyName))
+            return @params.PropertyName;
+
+        return DerivePropertyName(backingField!.Name);
+    }
+
+    private static string ResolvePropertyType(GeneratePropertyParams @params, IFieldSymbol? backingField)
+    {
+        if (!string.IsNullOrWhiteSpace(@params.PropertyType))
+            return @params.PropertyType;
+
+        return backingField!.Type.ToDisplayString();
+    }
+
+    internal static string DerivePropertyName(string fieldName)
+    {
+        var name = fieldName.TrimStart('_');
+        if (name.Length == 0)
+            return "Value";
+
+        return char.ToUpperInvariant(name[0]) + name.Substring(1);
+    }
+
+    /// <summary>
+    /// Creates an auto-property: <c>{ get; set; }</c> or <c>{ get; init; }</c>.
+    /// </summary>
+    internal static PropertyDeclarationSyntax CreateAutoProperty(
+        string name,
+        string type,
+        string visibility,
+        bool initOnly = false)
+    {
+        var accessors = new List<AccessorDeclarationSyntax>
+        {
+            SyntaxFactory.AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
+                .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken)),
+            SyntaxFactory.AccessorDeclaration(
+                    initOnly ? SyntaxKind.InitAccessorDeclaration : SyntaxKind.SetAccessorDeclaration)
+                .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken))
+        };
+
+        return SyntaxFactory.PropertyDeclaration(
+                SyntaxFactory.ParseTypeName(type).WithTrailingTrivia(SyntaxFactory.Space),
+                name)
+            .WithModifiers(SyntaxFactory.TokenList(ParseVisibilityTokens(visibility)))
+            .WithAccessorList(SyntaxFactory.AccessorList(SyntaxFactory.List(accessors)))
+            .NormalizeWhitespace();
+    }
+
+    /// <summary>
+    /// Creates a property with a backing field:
+    /// <c>{ get =&gt; _field; set =&gt; _field = value; }</c>.
+    /// </summary>
+    internal static PropertyDeclarationSyntax CreatePropertyWithBackingField(
+        string name,
+        string type,
+        IFieldSymbol backingField,
+        string visibility,
+        bool initOnly = false)
+    {
+        var fieldName = backingField.Name;
+        var getAccessor = SyntaxFactory.AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
+            .WithExpressionBody(SyntaxFactory.ArrowExpressionClause(SyntaxFactory.IdentifierName(fieldName)))
+            .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken));
+
+        var setAccessor = SyntaxFactory.AccessorDeclaration(
+                initOnly ? SyntaxKind.InitAccessorDeclaration : SyntaxKind.SetAccessorDeclaration)
+            .WithExpressionBody(SyntaxFactory.ArrowExpressionClause(
+                SyntaxFactory.AssignmentExpression(
+                    SyntaxKind.SimpleAssignmentExpression,
+                    SyntaxFactory.IdentifierName(fieldName),
+                    SyntaxFactory.IdentifierName("value"))))
+            .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken));
+
+        return SyntaxFactory.PropertyDeclaration(
+                SyntaxFactory.ParseTypeName(type).WithTrailingTrivia(SyntaxFactory.Space),
+                name)
+            .WithModifiers(SyntaxFactory.TokenList(ParseVisibilityTokens(visibility)))
+            .WithAccessorList(SyntaxFactory.AccessorList(SyntaxFactory.List(new[] { getAccessor, setAccessor })))
+            .NormalizeWhitespace();
+    }
+
+    private static TypeDeclarationSyntax InsertProperty(
+        TypeDeclarationSyntax typeDeclaration,
+        PropertyDeclarationSyntax property)
+    {
+        var members = typeDeclaration.Members.ToList();
+        var insertIndex = 0;
+
+        for (var i = 0; i < members.Count; i++)
+        {
+            if (members[i] is FieldDeclarationSyntax or PropertyDeclarationSyntax or ConstructorDeclarationSyntax)
+                insertIndex = i + 1;
+        }
+
+        members.Insert(
+            insertIndex,
+            property
+                .WithLeadingTrivia(SyntaxFactory.CarriageReturnLineFeed, SyntaxFactory.CarriageReturnLineFeed)
+                .WithTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed));
+
+        return typeDeclaration.WithMembers(SyntaxFactory.List(members));
+    }
+
+    private static RefactoringResult CreatePreviewResult(
+        Guid operationId,
+        GeneratePropertyParams @params,
+        string propertyName,
+        PropertyDeclarationSyntax property)
+    {
+        var afterSnippet = property.NormalizeWhitespace().ToFullString();
+        var pendingChanges = new List<PendingChange>
+        {
+            new()
+            {
+                File = @params.SourceFile,
+                ChangeType = ChangeKind.Modify,
+                Description = $"Generate property '{propertyName}' on {@params.TypeName}",
+                BeforeSnippet = $"// Type '{@params.TypeName}' (no property '{propertyName}')",
+                AfterSnippet = afterSnippet
+            }
+        };
+
+        return RefactoringResult.PreviewResult(operationId, pendingChanges);
+    }
+
+    private static IEnumerable<SyntaxToken> ParseVisibilityTokens(string visibility)
+    {
+        var tokens = visibility
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(ParseVisibilityKeyword)
+            .ToList();
+
+        if (tokens.Count == 0)
+            tokens.Add(SyntaxFactory.Token(SyntaxKind.PublicKeyword));
+
+        return tokens;
+    }
+
+    private static SyntaxToken ParseVisibilityKeyword(string keyword) => keyword.ToLowerInvariant() switch
+    {
+        "public" => SyntaxFactory.Token(SyntaxKind.PublicKeyword),
+        "private" => SyntaxFactory.Token(SyntaxKind.PrivateKeyword),
+        "protected" => SyntaxFactory.Token(SyntaxKind.ProtectedKeyword),
+        "internal" => SyntaxFactory.Token(SyntaxKind.InternalKeyword),
+        _ => SyntaxFactory.Token(SyntaxKind.PublicKeyword)
+    };
+
+    private static bool IsValidIdentifier(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return false;
+        if (!char.IsLetter(name[0]) && name[0] != '_')
+            return false;
+        return name.All(c => char.IsLetterOrDigit(c) || c == '_');
+    }
+}

--- a/src/RoslynMcp.Core/Refactoring/Generate/GeneratePropertyOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GeneratePropertyOperation.cs
@@ -139,19 +139,20 @@ public sealed class GeneratePropertyOperation : RefactoringOperationBase<Generat
         if (!string.IsNullOrWhiteSpace(@params.FieldName))
         {
             backingField = ResolveBackingField(typeSymbol, @params.FieldName);
-            ValidateFieldCanBeWrapped(backingField);
+            ValidateFieldCanBeWrapped(backingField, @params.InitOnly);
         }
 
         var propertyName = ResolvePropertyName(@params, backingField);
         var propertyType = ResolvePropertyType(@params, backingField);
         ValidateNoNameClash(typeSymbol, propertyName);
+        ValidateAutoPropertyAccessors(typeSymbol, @params.InitOnly, hasBackingField: backingField != null);
 
         var visibility = string.IsNullOrWhiteSpace(@params.Visibility) ? "public" : @params.Visibility.Trim();
         var property = backingField != null
             ? CreatePropertyWithBackingField(propertyName, propertyType, backingField, visibility, @params.InitOnly)
             : CreateAutoProperty(propertyName, propertyType, visibility, @params.InitOnly);
 
-        if (typeSymbol.IsStatic && !property.Modifiers.Any(SyntaxKind.StaticKeyword))
+        if (ShouldBeStatic(typeSymbol, backingField) && !property.Modifiers.Any(SyntaxKind.StaticKeyword))
         {
             property = property.AddModifiers(SyntaxFactory.Token(SyntaxKind.StaticKeyword));
         }
@@ -192,7 +193,7 @@ public sealed class GeneratePropertyOperation : RefactoringOperationBase<Generat
         }
     }
 
-    internal static void ValidateFieldCanBeWrapped(IFieldSymbol field)
+    internal static void ValidateFieldCanBeWrapped(IFieldSymbol field, bool initOnly)
     {
         if (field.IsConst)
         {
@@ -207,7 +208,40 @@ public sealed class GeneratePropertyOperation : RefactoringOperationBase<Generat
                 ErrorCodes.InvalidSymbolKind,
                 $"Field '{field.Name}' is not a supported target.");
         }
+
+        if (field.IsReadOnly && !initOnly)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidSymbolKind,
+                $"Field '{field.Name}' is readonly and cannot be assigned from a property setter. Use initOnly or wrap a non-readonly field.");
+        }
+
+        if (field.IsReadOnly && field.IsStatic && initOnly)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidSymbolKind,
+                $"Static readonly field '{field.Name}' cannot be assigned from a property accessor.");
+        }
     }
+
+    internal static void ValidateAutoPropertyAccessors(
+        INamedTypeSymbol typeSymbol,
+        bool initOnly,
+        bool hasBackingField)
+    {
+        if (hasBackingField)
+            return;
+
+        if (!initOnly && typeSymbol.IsReadOnly && typeSymbol.TypeKind == TypeKind.Struct)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidSymbolKind,
+                $"Cannot generate a settable auto-property on readonly struct '{typeSymbol.Name}'. Use initOnly.");
+        }
+    }
+
+    internal static bool ShouldBeStatic(INamedTypeSymbol typeSymbol, IFieldSymbol? backingField) =>
+        typeSymbol.IsStatic || backingField is { IsStatic: true };
 
     internal static void ValidateNoNameClash(INamedTypeSymbol typeSymbol, string propertyName)
     {
@@ -245,12 +279,63 @@ public sealed class GeneratePropertyOperation : RefactoringOperationBase<Generat
         return DerivePropertyName(backingField!.Name);
     }
 
-    private static string ResolvePropertyType(GeneratePropertyParams @params, IFieldSymbol? backingField)
+    internal static string ResolvePropertyType(GeneratePropertyParams @params, IFieldSymbol? backingField)
     {
-        if (!string.IsNullOrWhiteSpace(@params.PropertyType))
-            return @params.PropertyType;
+        if (backingField != null)
+        {
+            var fieldType = backingField.Type.ToDisplayString();
+            if (!string.IsNullOrWhiteSpace(@params.PropertyType) &&
+                !PropertyTypeMatchesField(@params.PropertyType, backingField.Type))
+            {
+                throw new RefactoringException(
+                    ErrorCodes.InvalidReturnType,
+                    $"Property type '{@params.PropertyType}' is incompatible with backing field type '{fieldType}'.");
+            }
 
-        return backingField!.Type.ToDisplayString();
+            return fieldType;
+        }
+
+        return @params.PropertyType!;
+    }
+
+    internal static bool PropertyTypeMatchesField(string requestedType, ITypeSymbol fieldType)
+    {
+        requestedType = requestedType.Trim();
+        var candidates = new HashSet<string>(StringComparer.Ordinal)
+        {
+            fieldType.ToDisplayString(),
+            fieldType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat).Replace("global::", "", StringComparison.Ordinal),
+            fieldType.Name
+        };
+
+        if (TryGetSpecialTypeAlias(fieldType.SpecialType, out var alias))
+            candidates.Add(alias);
+
+        return candidates.Contains(requestedType);
+    }
+
+    private static bool TryGetSpecialTypeAlias(SpecialType specialType, out string alias)
+    {
+        alias = specialType switch
+        {
+            SpecialType.System_Boolean => "bool",
+            SpecialType.System_Byte => "byte",
+            SpecialType.System_SByte => "sbyte",
+            SpecialType.System_Int16 => "short",
+            SpecialType.System_UInt16 => "ushort",
+            SpecialType.System_Int32 => "int",
+            SpecialType.System_UInt32 => "uint",
+            SpecialType.System_Int64 => "long",
+            SpecialType.System_UInt64 => "ulong",
+            SpecialType.System_Single => "float",
+            SpecialType.System_Double => "double",
+            SpecialType.System_Decimal => "decimal",
+            SpecialType.System_Char => "char",
+            SpecialType.System_String => "string",
+            SpecialType.System_Object => "object",
+            _ => ""
+        };
+        return alias.Length > 0;
     }
 
     internal static string DerivePropertyName(string fieldName)
@@ -387,12 +472,18 @@ public sealed class GeneratePropertyOperation : RefactoringOperationBase<Generat
         _ => SyntaxFactory.Token(SyntaxKind.PublicKeyword)
     };
 
-    private static bool IsValidIdentifier(string name)
+    internal static bool IsValidIdentifier(string name)
     {
         if (string.IsNullOrWhiteSpace(name))
             return false;
-        if (!char.IsLetter(name[0]) && name[0] != '_')
+
+        if (name.StartsWith('@') && name.Length > 1)
+            return SyntaxFacts.IsValidIdentifier(name);
+
+        if (!SyntaxFacts.IsValidIdentifier(name))
             return false;
-        return name.All(c => char.IsLetterOrDigit(c) || c == '_');
+
+        var keywordKind = SyntaxFacts.GetKeywordKind(name);
+        return keywordKind == SyntaxKind.None || !SyntaxFacts.IsReservedKeyword(keywordKind);
     }
 }

--- a/src/RoslynMcp.Core/Refactoring/Generate/GeneratePropertyOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GeneratePropertyOperation.cs
@@ -152,10 +152,8 @@ public sealed class GeneratePropertyOperation : RefactoringOperationBase<Generat
             ? CreatePropertyWithBackingField(propertyName, propertyType, backingField, visibility, @params.InitOnly)
             : CreateAutoProperty(propertyName, propertyType, visibility, @params.InitOnly);
 
-        if (ShouldBeStatic(typeSymbol, backingField) && !property.Modifiers.Any(SyntaxKind.StaticKeyword))
-        {
-            property = property.AddModifiers(SyntaxFactory.Token(SyntaxKind.StaticKeyword));
-        }
+        if (ShouldBeStatic(typeSymbol, backingField))
+            property = AddStaticModifier(property);
 
         if (@params.Preview)
             return CreatePreviewResult(operationId, @params, propertyName, property);
@@ -242,6 +240,37 @@ public sealed class GeneratePropertyOperation : RefactoringOperationBase<Generat
 
     internal static bool ShouldBeStatic(INamedTypeSymbol typeSymbol, IFieldSymbol? backingField) =>
         typeSymbol.IsStatic || backingField is { IsStatic: true };
+
+    internal static PropertyDeclarationSyntax AddStaticModifier(PropertyDeclarationSyntax property)
+    {
+        if (property.Modifiers.Any(SyntaxKind.StaticKeyword))
+            return property;
+
+        var staticToken = SyntaxFactory.Token(SyntaxKind.StaticKeyword)
+            .WithTrailingTrivia(SyntaxFactory.Space);
+        var modifiers = property.Modifiers;
+        var insertIndex = 0;
+        for (var i = 0; i < modifiers.Count; i++)
+        {
+            if (modifiers[i].IsKind(SyntaxKind.PublicKeyword) ||
+                modifiers[i].IsKind(SyntaxKind.PrivateKeyword) ||
+                modifiers[i].IsKind(SyntaxKind.ProtectedKeyword) ||
+                modifiers[i].IsKind(SyntaxKind.InternalKeyword))
+            {
+                insertIndex = i + 1;
+            }
+        }
+
+        if (insertIndex == 0 && modifiers.Count > 0)
+        {
+            var first = modifiers[0];
+            staticToken = staticToken.WithLeadingTrivia(first.LeadingTrivia);
+            modifiers = modifiers.Replace(first, first.WithLeadingTrivia(SyntaxFactory.TriviaList()));
+            return property.WithModifiers(modifiers.Insert(0, staticToken)).NormalizeWhitespace();
+        }
+
+        return property.WithModifiers(modifiers.Insert(insertIndex, staticToken)).NormalizeWhitespace();
+    }
 
     internal static void ValidateNoNameClash(INamedTypeSymbol typeSymbol, string propertyName)
     {
@@ -478,7 +507,11 @@ public sealed class GeneratePropertyOperation : RefactoringOperationBase<Generat
             return false;
 
         if (name.StartsWith('@') && name.Length > 1)
-            return SyntaxFacts.IsValidIdentifier(name);
+        {
+            var bare = name[1..];
+            return SyntaxFacts.IsValidIdentifier(bare) ||
+                   SyntaxFacts.GetKeywordKind(bare) != SyntaxKind.None;
+        }
 
         if (!SyntaxFacts.IsValidIdentifier(name))
             return false;

--- a/src/RoslynMcp.Server/McpServerHost.cs
+++ b/src/RoslynMcp.Server/McpServerHost.cs
@@ -77,6 +77,7 @@ public sealed class McpServerHost : IAsyncDisposable
         // Code Generation & Formatting Tools
         _toolRegistry.Register(new GenerateEqualsHashCodeTool(workspaceProvider));
         _toolRegistry.Register(new GenerateToStringTool(workspaceProvider));
+        _toolRegistry.Register(new GeneratePropertyTool(workspaceProvider));
         _toolRegistry.Register(new FormatDocumentTool(workspaceProvider));
         _toolRegistry.Register(new AddNullChecksTool(workspaceProvider));
 

--- a/src/RoslynMcp.Server/Tools/GeneratePropertyTool.cs
+++ b/src/RoslynMcp.Server/Tools/GeneratePropertyTool.cs
@@ -1,0 +1,164 @@
+using System.Text.Json;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.Refactoring;
+using RoslynMcp.Core.Refactoring.Generate;
+using RoslynMcp.Core.Workspace;
+using RoslynMcp.Server.Transport;
+
+namespace RoslynMcp.Server.Tools;
+
+/// <summary>
+/// MCP tool handler for generate_property operation.
+/// </summary>
+public sealed class GeneratePropertyTool : IToolHandler
+{
+    private readonly IWorkspaceProvider _workspaceProvider;
+    private readonly JsonSerializerOptions _jsonOptions;
+
+    /// <summary>
+    /// Creates a new generate property tool.
+    /// </summary>
+    public GeneratePropertyTool(IWorkspaceProvider workspaceProvider)
+    {
+        _workspaceProvider = workspaceProvider;
+        _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = false
+        };
+    }
+
+    /// <inheritdoc />
+    public string Name => "generate_property";
+
+    /// <inheritdoc />
+    public string Description =>
+        "Generate a property on a C# type. Creates an auto-property { get; set; }, an init-only property { get; init; }, or a backing-field property { get => field; set => field = value; } when a field is the target.";
+
+    /// <inheritdoc />
+    public object InputSchema => new
+    {
+        type = "object",
+        required = new[] { "solutionPath", "sourceFile", "typeName" },
+        properties = new
+        {
+            solutionPath = new
+            {
+                type = "string",
+                description = "Absolute path to the .sln or .csproj file"
+            },
+            sourceFile = new
+            {
+                type = "string",
+                description = "Absolute path to the source file containing the type"
+            },
+            typeName = new
+            {
+                type = "string",
+                description = "Name of the type to add the property to"
+            },
+            propertyName = new
+            {
+                type = "string",
+                description = "Name of the property to generate. Derived from fieldName when omitted."
+            },
+            propertyType = new
+            {
+                type = "string",
+                description = "C# type of the property. Required for auto-properties; inferred from the field when fieldName is set."
+            },
+            fieldName = new
+            {
+                type = "string",
+                description = "Optional field to wrap with a backing-field property"
+            },
+            visibility = new
+            {
+                type = "string",
+                description = "Accessibility of the generated property",
+                @default = "public"
+            },
+            initOnly = new
+            {
+                type = "boolean",
+                description = "Generate an init-only setter ({ get; init; })",
+                @default = false
+            },
+            preview = new
+            {
+                type = "boolean",
+                description = "Return computed changes without applying",
+                @default = false
+            }
+        },
+        additionalProperties = false
+    };
+
+    /// <inheritdoc />
+    public async Task<ToolResult> ExecuteAsync(JsonElement? arguments, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (arguments == null)
+            {
+                return ToolResult.Error("Arguments required");
+            }
+
+            var args = JsonSerializer.Deserialize<GeneratePropertyArgs>(arguments.Value.GetRawText(), _jsonOptions);
+            if (args == null)
+            {
+                return ToolResult.Error("Failed to parse arguments");
+            }
+
+            using var context = await _workspaceProvider.CreateContextAsync(
+                args.SolutionPath,
+                cancellationToken);
+
+            var operation = new GeneratePropertyOperation(context);
+            var @params = new GeneratePropertyParams
+            {
+                SourceFile = args.SourceFile,
+                TypeName = args.TypeName,
+                PropertyName = args.PropertyName,
+                PropertyType = args.PropertyType,
+                FieldName = args.FieldName,
+                Visibility = args.Visibility,
+                InitOnly = args.InitOnly ?? false,
+                Preview = args.Preview ?? false
+            };
+
+            var result = await operation.ExecuteAsync(@params, cancellationToken);
+
+            var json = JsonSerializer.Serialize(result, _jsonOptions);
+            return result.Success ? ToolResult.Success(json) : ToolResult.Error(json);
+        }
+        catch (RefactoringException ex)
+        {
+            var error = ex.ToError();
+            var json = JsonSerializer.Serialize(new { success = false, error }, _jsonOptions);
+            return ToolResult.Error(json);
+        }
+        catch (Exception ex)
+        {
+            var json = JsonSerializer.Serialize(new
+            {
+                success = false,
+                error = new { code = "INTERNAL_ERROR", message = ex.Message }
+            }, _jsonOptions);
+            return ToolResult.Error(json);
+        }
+    }
+
+    private sealed class GeneratePropertyArgs
+    {
+        public string SolutionPath { get; init; } = "";
+        public string SourceFile { get; init; } = "";
+        public string TypeName { get; init; } = "";
+        public string? PropertyName { get; init; }
+        public string? PropertyType { get; init; }
+        public string? FieldName { get; init; }
+        public string? Visibility { get; init; }
+        public bool? InitOnly { get; init; }
+        public bool? Preview { get; init; }
+    }
+}

--- a/tests/RoslynMcp.Cli.Tests/HelpGeneratorTests.cs
+++ b/tests/RoslynMcp.Cli.Tests/HelpGeneratorTests.cs
@@ -15,11 +15,11 @@ public class HelpGeneratorTests
     }
 
     [Fact]
-    public void GenerateGlobalHelp_Lists50Tools()
+    public void GenerateGlobalHelp_Lists51Tools()
     {
         var registry = ToolRegistry.BuildDefault();
         var help = HelpGenerator.GenerateGlobalHelp(registry);
-        Assert.Contains("Total: 50 tools", help);
+        Assert.Contains("Total: 51 tools", help);
         Assert.Contains("pull-members-up", help);
         Assert.Contains("push-members-down", help);
         Assert.Contains("use-base-type", help);
@@ -28,6 +28,7 @@ public class HelpGeneratorTests
         Assert.Contains("make-static", help);
         Assert.Contains("make-non-static", help);
         Assert.Contains("convert-to-block-body", help);
+        Assert.Contains("generate-property", help);
     }
 
     [Fact]

--- a/tests/RoslynMcp.Cli.Tests/ToolRegistryTests.cs
+++ b/tests/RoslynMcp.Cli.Tests/ToolRegistryTests.cs
@@ -6,11 +6,11 @@ namespace RoslynMcp.Cli.Tests;
 public class ToolRegistryTests
 {
     [Fact]
-    public void BuildDefault_Registers50Tools()
+    public void BuildDefault_Registers51Tools()
     {
         var registry = ToolRegistry.BuildDefault();
         var tools = registry.GetAllTools();
-        Assert.Equal(50, tools.Count);
+        Assert.Equal(51, tools.Count);
     }
 
     [Fact]
@@ -98,6 +98,7 @@ public class ToolRegistryTests
     [InlineData("convert-to-async", "Refactoring")]
     [InlineData("convert-to-block-body", "Refactoring")]
     [InlineData("generate-constructor", "Refactoring")]
+    [InlineData("generate-property", "Refactoring")]
     [InlineData("add-missing-usings", "Refactoring")]
     [InlineData("format-document", "Refactoring")]
     [InlineData("get-symbol-info", "Query")]
@@ -110,11 +111,11 @@ public class ToolRegistryTests
     }
 
     [Fact]
-    public void RefactoringToolCount_Is37()
+    public void RefactoringToolCount_Is38()
     {
         var registry = ToolRegistry.BuildDefault();
         var count = registry.GetAllTools().Count(t => t.Category == "Refactoring");
-        Assert.Equal(37, count);
+        Assert.Equal(38, count);
     }
 
     [Fact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GeneratePropertyOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GeneratePropertyOperationTests.cs
@@ -1,0 +1,465 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using RoslynMcp.Contracts.Errors;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.Refactoring;
+using RoslynMcp.Core.Refactoring.Generate;
+using RoslynMcp.Core.Workspace;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Refactoring.Generate;
+
+/// <summary>
+/// Operation-level tests for <see cref="GeneratePropertyOperation"/>.
+/// </summary>
+public class GeneratePropertyOperationTests
+{
+    #region Input Validation
+
+    [Fact]
+    public void Validate_MissingSourceFile_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            GeneratePropertyOperation.Validate(new GeneratePropertyParams
+            {
+                SourceFile = "",
+                TypeName = "Widget",
+                PropertyName = "Name",
+                PropertyType = "string"
+            }));
+
+        Assert.Equal(ErrorCodes.MissingRequiredParam, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_MissingTypeName_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            GeneratePropertyOperation.Validate(new GeneratePropertyParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                TypeName = "",
+                PropertyName = "Name",
+                PropertyType = "string"
+            }));
+
+        Assert.Equal(ErrorCodes.MissingRequiredParam, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_MissingPropertyNameAndFieldName_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            GeneratePropertyOperation.Validate(new GeneratePropertyParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                TypeName = "Widget",
+                PropertyType = "string"
+            }));
+
+        Assert.Equal(ErrorCodes.MissingRequiredParam, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_MissingPropertyTypeWithoutField_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            GeneratePropertyOperation.Validate(new GeneratePropertyParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                TypeName = "Widget",
+                PropertyName = "Name"
+            }));
+
+        Assert.Equal(ErrorCodes.MissingRequiredParam, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_RelativePath_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            GeneratePropertyOperation.Validate(new GeneratePropertyParams
+            {
+                SourceFile = "Types.cs",
+                TypeName = "Widget",
+                PropertyName = "Name",
+                PropertyType = "string"
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidSourcePath, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_MissingFile_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            GeneratePropertyOperation.Validate(new GeneratePropertyParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                TypeName = "Widget",
+                PropertyName = "Name",
+                PropertyType = "string"
+            }));
+
+        Assert.Equal(ErrorCodes.SourceFileNotFound, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_InvalidVisibility_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            GeneratePropertyOperation.Validate(new GeneratePropertyParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                TypeName = "Widget",
+                PropertyName = "Name",
+                PropertyType = "string",
+                Visibility = "secret"
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidVisibility, ex.ErrorCode);
+    }
+
+    #endregion
+
+    #region P0 Happy Path
+
+    [SkippableFact]
+    public async Task GenerateProperty_AutoProperty_AddsGetSet()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Widget
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new GeneratePropertyOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new GeneratePropertyParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Widget",
+            PropertyName = "Name",
+            PropertyType = "string"
+        });
+
+        Assert.True(result.Success);
+        Assert.False(result.Preview);
+        Assert.NotNull(result.Symbol);
+        Assert.Equal("Name", result.Symbol.Name);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("public string Name { get; set; }", updated);
+    }
+
+    [SkippableFact]
+    public async Task GenerateProperty_InitOnly_AddsGetInit()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Widget
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new GeneratePropertyOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new GeneratePropertyParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Widget",
+            PropertyName = "Id",
+            PropertyType = "int",
+            InitOnly = true
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("public int Id { get; init; }", updated);
+        Assert.DoesNotContain("{ get; set; }", updated);
+    }
+
+    [SkippableFact]
+    public async Task GenerateProperty_BackingField_AddsExpressionAccessors()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Widget
+            {
+                private string _name;
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new GeneratePropertyOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new GeneratePropertyParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Widget",
+            FieldName = "_name"
+        });
+
+        Assert.True(result.Success);
+        Assert.Equal("Name", result.Symbol!.Name);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("private string _name;", updated);
+        Assert.Contains("get => _name;", updated);
+        Assert.Contains("set => _name = value;", updated);
+    }
+
+    [SkippableFact]
+    public async Task GenerateProperty_Preview_DoesNotWriteFiles()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Widget
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new GeneratePropertyOperation(workspace.Context);
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var result = await operation.ExecuteAsync(new GeneratePropertyParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Widget",
+            PropertyName = "Name",
+            PropertyType = "string",
+            Preview = true
+        });
+
+        Assert.True(result.Success);
+        Assert.True(result.Preview);
+        Assert.NotEmpty(result.PendingChanges);
+        Assert.Contains("get; set;", result.PendingChanges[0].AfterSnippet);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    #endregion
+
+    #region Reject Cases
+
+    [SkippableFact]
+    public async Task GenerateProperty_NoSymbol_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Widget
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new GeneratePropertyOperation(workspace.Context);
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new GeneratePropertyParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "Missing",
+                PropertyName = "Name",
+                PropertyType = "string"
+            }));
+
+        Assert.Equal(ErrorCodes.SymbolNotFound, ex.ErrorCode);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [SkippableFact]
+    public async Task GenerateProperty_UnsupportedTarget_Enum_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public enum Status
+            {
+                Ready
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new GeneratePropertyOperation(workspace.Context);
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new GeneratePropertyParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "Status",
+                PropertyName = "Name",
+                PropertyType = "string"
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidSymbolKind, ex.ErrorCode);
+        Assert.Contains("not a supported target", ex.Message);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [SkippableFact]
+    public async Task GenerateProperty_NameClash_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Widget
+            {
+                public string Name { get; set; }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new GeneratePropertyOperation(workspace.Context);
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new GeneratePropertyParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "Widget",
+                PropertyName = "Name",
+                PropertyType = "string"
+            }));
+
+        Assert.Equal(ErrorCodes.NameCollision, ex.ErrorCode);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [Fact]
+    public void GenerateProperty_UneditableDocument_Throws()
+    {
+        var workspace = new AdhocWorkspace();
+        var project = workspace.AddProject("P", LanguageNames.CSharp);
+        var document = workspace.AddDocument(project.Id, "Generated.cs", SourceText.From("class C {}"));
+
+        var ex = Assert.Throws<RefactoringException>(() =>
+            GeneratePropertyOperation.ValidateDocumentIsEditable(document, workspace));
+
+        Assert.Equal(ErrorCodes.DocumentNotEditable, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task GenerateProperty_MissingField_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Widget
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new GeneratePropertyOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new GeneratePropertyParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "Widget",
+                FieldName = "_missing"
+            }));
+
+        Assert.Equal(ErrorCodes.SymbolNotFound, ex.ErrorCode);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static string AbsoluteTestPath() =>
+        Path.Combine(Path.GetTempPath(), "RoslynMcpGeneratePropertyMissing.cs");
+
+    private static string NormalizeNewlines(string text) =>
+        text.Replace("\r\n", "\n", StringComparison.Ordinal);
+
+    private sealed class TempWorkspace : IAsyncDisposable
+    {
+        public required string DirectoryPath { get; init; }
+        public required string ProjectPath { get; init; }
+        public required string SourcePath { get; init; }
+        public required WorkspaceContext Context { get; init; }
+
+        public static async Task<TempWorkspace> CreateAsync(string source, string fileName = "Types.cs")
+        {
+            Skip.IfNot(ModuleInitializer.MsBuildAvailable, ModuleInitializer.MsBuildError ?? "MSBuild not available");
+
+            var directory = Path.Combine(Path.GetTempPath(), "RoslynMcpGenerateProperty_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(directory);
+
+            var projectPath = Path.Combine(directory, "TestApp.csproj");
+            var sourcePath = Path.Combine(directory, fileName);
+
+            await File.WriteAllTextAsync(projectPath, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net9.0</TargetFramework>
+                    <Nullable>enable</Nullable>
+                  </PropertyGroup>
+                </Project>
+                """);
+            await File.WriteAllTextAsync(sourcePath, source);
+
+            try
+            {
+                var provider = new MSBuildWorkspaceProvider();
+                var context = await provider.CreateContextAsync(projectPath);
+                if (context.GetDocumentByPath(sourcePath) == null)
+                {
+                    context.Dispose();
+                    throw new InvalidOperationException($"Workspace loaded but did not include {sourcePath}.");
+                }
+
+                return new TempWorkspace
+                {
+                    DirectoryPath = directory,
+                    ProjectPath = projectPath,
+                    SourcePath = sourcePath,
+                    Context = context
+                };
+            }
+            catch (Exception ex) when (ex is not SkipException)
+            {
+                try
+                {
+                    Directory.Delete(directory, recursive: true);
+                }
+                catch
+                {
+                    // ignore cleanup failures
+                }
+
+                Skip.If(true, $"Workspace load failed: {ex.Message}");
+                throw;
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            Context.Dispose();
+            await Task.Run(() =>
+            {
+                try
+                {
+                    Directory.Delete(DirectoryPath, recursive: true);
+                }
+                catch
+                {
+                    // ignore locked temp files
+                }
+            });
+        }
+    }
+
+    #endregion
+}

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GeneratePropertyOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GeneratePropertyOperationTests.cs
@@ -120,6 +120,45 @@ public class GeneratePropertyOperationTests
         Assert.Equal(ErrorCodes.InvalidVisibility, ex.ErrorCode);
     }
 
+    [Fact]
+    public void Validate_ReservedKeywordPropertyName_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            GeneratePropertyOperation.Validate(new GeneratePropertyParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                TypeName = "Widget",
+                PropertyName = "class",
+                PropertyType = "string"
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidSymbolName, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_NamespaceKeywordPropertyName_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            GeneratePropertyOperation.Validate(new GeneratePropertyParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                TypeName = "Widget",
+                PropertyName = "namespace",
+                PropertyType = "string"
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidSymbolName, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void IsValidIdentifier_ReservedKeyword_IsFalse()
+    {
+        Assert.False(GeneratePropertyOperation.IsValidIdentifier("class"));
+        Assert.False(GeneratePropertyOperation.IsValidIdentifier("namespace"));
+        Assert.True(GeneratePropertyOperation.IsValidIdentifier("Name"));
+        Assert.True(GeneratePropertyOperation.IsValidIdentifier("@class"));
+    }
+
     #endregion
 
     #region P0 Happy Path
@@ -372,6 +411,211 @@ public class GeneratePropertyOperationTests
             }));
 
         Assert.Equal(ErrorCodes.SymbolNotFound, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task GenerateProperty_ReadonlyField_DefaultSetter_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Widget
+            {
+                private readonly string _name;
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new GeneratePropertyOperation(workspace.Context);
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new GeneratePropertyParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "Widget",
+                FieldName = "_name"
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidSymbolKind, ex.ErrorCode);
+        Assert.Contains("readonly", ex.Message);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [SkippableFact]
+    public async Task GenerateProperty_ReadonlyField_InitOnly_Succeeds()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Widget
+            {
+                private readonly string _name;
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new GeneratePropertyOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new GeneratePropertyParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Widget",
+            FieldName = "_name",
+            InitOnly = true
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("get => _name;", updated);
+        Assert.Contains("init => _name = value;", updated);
+        Assert.DoesNotContain("set => _name = value;", updated);
+    }
+
+    [SkippableFact]
+    public async Task GenerateProperty_IncompatibleBackingFieldType_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Widget
+            {
+                private int _count;
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new GeneratePropertyOperation(workspace.Context);
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new GeneratePropertyParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "Widget",
+                FieldName = "_count",
+                PropertyType = "string"
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidReturnType, ex.ErrorCode);
+        Assert.Contains("incompatible", ex.Message);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [SkippableFact]
+    public async Task GenerateProperty_CompatibleBackingFieldType_UsesFieldType()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Widget
+            {
+                private int _count;
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new GeneratePropertyOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new GeneratePropertyParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Widget",
+            FieldName = "_count",
+            PropertyType = "int"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("public int Count", updated);
+        Assert.Contains("get => _count;", updated);
+        Assert.Contains("set => _count = value;", updated);
+    }
+
+    [SkippableFact]
+    public async Task GenerateProperty_ReadonlyStruct_SettableAutoProperty_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public readonly struct Point
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new GeneratePropertyOperation(workspace.Context);
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new GeneratePropertyParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "Point",
+                PropertyName = "X",
+                PropertyType = "int"
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidSymbolKind, ex.ErrorCode);
+        Assert.Contains("readonly struct", ex.Message);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [SkippableFact]
+    public async Task GenerateProperty_ReadonlyStruct_InitOnly_Succeeds()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public readonly struct Point
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new GeneratePropertyOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new GeneratePropertyParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Point",
+            PropertyName = "X",
+            PropertyType = "int",
+            InitOnly = true
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("public int X { get; init; }", updated);
+    }
+
+    [SkippableFact]
+    public async Task GenerateProperty_StaticField_AddsStaticModifier()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Widget
+            {
+                private static string _name;
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new GeneratePropertyOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new GeneratePropertyParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Widget",
+            FieldName = "_name"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("public static string Name", updated);
+        Assert.Contains("get => _name;", updated);
+        Assert.Contains("set => _name = value;", updated);
     }
 
     #endregion

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GeneratePropertyOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GeneratePropertyOperationTests.cs
@@ -239,6 +239,7 @@ public class GeneratePropertyOperationTests
 
         Assert.True(result.Success);
         Assert.True(result.Preview);
+        Assert.NotNull(result.PendingChanges);
         Assert.NotEmpty(result.PendingChanges);
         Assert.Contains("get; set;", result.PendingChanges[0].AfterSnippet);
         Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));

--- a/tests/RoslynMcp.Server.Tests/Tools/GeneratePropertyToolTests.cs
+++ b/tests/RoslynMcp.Server.Tests/Tools/GeneratePropertyToolTests.cs
@@ -1,0 +1,121 @@
+using System.Text.Json;
+using RoslynMcp.Server.Tests.TestHelpers;
+using RoslynMcp.Server.Tools;
+using RoslynMcp.Server.Transport;
+using Xunit;
+
+namespace RoslynMcp.Server.Tests.Tools;
+
+/// <summary>
+/// Unit tests for GeneratePropertyTool.
+/// Tests tool definition and argument validation.
+/// </summary>
+public class GeneratePropertyToolTests
+{
+    private readonly GeneratePropertyTool _tool;
+
+    public GeneratePropertyToolTests()
+    {
+        _tool = new GeneratePropertyTool(new ThrowingWorkspaceProvider());
+    }
+
+    #region GetDefinition Tests
+
+    [Fact]
+    public void GetDefinition_ReturnsCorrectName()
+    {
+        Assert.Equal("generate_property", _tool.Name);
+    }
+
+    [Fact]
+    public void GetDefinition_ReturnsNonEmptyDescription()
+    {
+        Assert.NotNull(_tool.Description);
+        Assert.NotEmpty(_tool.Description);
+    }
+
+    [Fact]
+    public void GetDefinition_ReturnsCorrectSchema()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.Equal("object", root.GetProperty("type").GetString());
+        Assert.True(root.TryGetProperty("properties", out _));
+        Assert.True(root.TryGetProperty("required", out _));
+    }
+
+    [Fact]
+    public void GetDefinition_HasRequiredFields()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var required = doc.RootElement.GetProperty("required");
+
+        var requiredFields = new List<string>();
+        foreach (var item in required.EnumerateArray())
+        {
+            requiredFields.Add(item.GetString()!);
+        }
+
+        Assert.Contains("solutionPath", requiredFields);
+        Assert.Contains("sourceFile", requiredFields);
+        Assert.Contains("typeName", requiredFields);
+    }
+
+    [Fact]
+    public void GetDefinition_HasProperties_ForAllParameters()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var properties = doc.RootElement.GetProperty("properties");
+
+        Assert.True(properties.TryGetProperty("solutionPath", out _));
+        Assert.True(properties.TryGetProperty("sourceFile", out _));
+        Assert.True(properties.TryGetProperty("typeName", out _));
+        Assert.True(properties.TryGetProperty("propertyName", out _));
+        Assert.True(properties.TryGetProperty("propertyType", out _));
+        Assert.True(properties.TryGetProperty("fieldName", out _));
+        Assert.True(properties.TryGetProperty("visibility", out _));
+        Assert.True(properties.TryGetProperty("initOnly", out _));
+        Assert.True(properties.TryGetProperty("preview", out _));
+    }
+
+    #endregion
+
+    #region ExecuteAsync Argument Validation Tests
+
+    [Fact]
+    public async Task ExecuteAsync_NullArguments_ReturnsError()
+    {
+        var result = await _tool.ExecuteAsync(null);
+
+        Assert.True(result.IsError);
+        Assert.Contains("Arguments required", GetResultText(result));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EmptyArguments_ReturnsError()
+    {
+        var args = JsonDocument.Parse("{}").RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static string GetResultText(ToolResult result)
+    {
+        return result.Content.FirstOrDefault()?.Text ?? string.Empty;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds `generate_property` / `GeneratePropertyOperation` as Generate Phase 2 from `Design/Expansion/Phase2/Arch-Generate-Operations.md` (table 1.1, §3.2, §9 Phase 2). Placement is next to the other Generate operations.

Rebased onto current `master` (`c4c9d73`, convert_to_block_body #47, plus make_non_static #45). Both shipped tools and this increment are kept.

A selected type can receive:
- Auto-property: `{ get; set; }`
- Init-only: `{ get; init; }`
- Backing-field form when a field is the target: `{ get => _field; set => _field = value; }`

Preview computes the property and does not write files.

Review fold (Codex P2 TAKEs):
- Reject readonly field + default setter (init-only still allowed on instance readonly fields)
- Always use the backing field type; reject incompatible `propertyType`
- Reject reserved keywords as property names; allow verbatim `@class`
- Reject settable auto-properties on readonly structs (init-only allowed)
- Add `static` when wrapping a static field on a non-static type

## Related Issues

Closes #48

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Test additions or updates

## Testing

- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Manual testing performed (operation + MCP tool + CLI registry tests locally)

P0 coverage plus review-fold tests:
- Happy path: auto-property, init-only, backing-field, preview
- Rejects: no symbol, unsupported target, name clash, uneditable document, missing field
- Readonly field default setter rejected; init-only succeeds
- Incompatible backing-field `propertyType` rejected; compatible type uses the field type
- Reserved keywords `class` / `namespace` rejected; verbatim `@class` accepted
- Readonly struct settable auto-property rejected; init-only succeeds
- Static field on an instance class emits a static property
- MCP + CLI registration; tool count **50 → 51**; refactoring category **37 → 38**

**Test Configuration**:
- OS: Linux
- .NET Version: 9.0.317

## Additional Notes

Follows existing Generate* operation patterns. Out of scope: `generate_method_stub`, `implement_abstract`, encapsulate, undo, a second leftover.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04841a32-31f9-42cb-9dd9-7a4e5b3ea358?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04841a32-31f9-42cb-9dd9-7a4e5b3ea358&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

