### PR TITLE
Add generate_method_stub refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - `make_non_static` — remove the static modifier from a selected static method, rewrite type-name call sites and method-group conversions to an instance receiver (or `this` in the same type), with preview mode and rejects for already-instance methods, missing receivers, extern methods, and uneditable documents
 - `convert_to_block_body` — convert a selected expression-bodied member (`=> expr`) to a block body (`{ return expr; }` or `{ expr; }` as appropriate), including properties and accessors, with preview mode and rejects for missing symbols, already-block bodies, unsupported members, and uneditable documents
 - `generate_property` — generate an auto-property `{ get; set; }`, init-only property `{ get; init; }`, or backing-field property `{ get => field; set => field = value; }` on a selected type, with preview mode and rejects for missing symbols, uneditable documents, unsupported targets, and name clashes
+- `generate_method_stub` — generate a method from an undefined call site, inferring target type, parameters, and return type from usage, with a `throw new NotImplementedException();` body, preview mode, and rejects for missing call sites, existing methods, uneditable or external targets, and uninferable return types
 
 ## [0.4.0] - 2026-02-23
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Let AI assistants like Claude safely refactor your C# codebase using the same Roslyn compiler platform that powers Visual Studio.
 
-Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that exposes **51 Roslyn-powered tools** to AI assistants and other MCP clients. It combines 28 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 8 code conversion tools -- giving your AI deep code intelligence, comprehensive refactoring, and modern C# syntax transformations with full solution-wide reference tracking and preview support.
+Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that exposes **52 Roslyn-powered tools** to AI assistants and other MCP clients. It combines 29 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 8 code conversion tools -- giving your AI deep code intelligence, comprehensive refactoring, and modern C# syntax transformations with full solution-wide reference tracking and preview support.
 
 ---
 
@@ -30,7 +30,7 @@ Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotoc
 
 ## Why RoslynMcpServer?
 
-- **51 tools** -- refactoring, navigation, analysis, generation, and conversion tools, the most comprehensive Roslyn MCP server available
+- **52 tools** -- refactoring, navigation, analysis, generation, and conversion tools, the most comprehensive Roslyn MCP server available
 - **Preview mode on every operation** -- see exactly what will change before applying
 - **Atomic file writes with rollback** -- if any file write fails, all changes are reverted
 - **Solution-wide reference updates** -- renames and moves propagate across your entire solution
@@ -102,7 +102,7 @@ Claude will use the `rename_symbol` tool to rename the class and update every re
 
 ## Standalone CLI
 
-All 51 tools are also available as a standalone CLI for use in scripts, CI/CD pipelines, and terminals without an AI assistant.
+All 52 tools are also available as a standalone CLI for use in scripts, CI/CD pipelines, and terminals without an AI assistant.
 
 ### Install
 
@@ -229,6 +229,7 @@ All tools accept a `solutionPath` parameter (absolute path to a `.sln`, `.slnx`,
 |------|-------------|----------------|
 | `generate_constructor` | Generate a constructor that initializes fields and/or properties of a type. | `sourceFile`, `typeName`, `members`, `addNullChecks` |
 | `generate_property` | Generate a property on a type: auto-property `{ get; set; }`, init-only `{ get; init; }`, or a backing-field form when a field is the target. | `sourceFile`, `typeName`, `propertyName`, `propertyType`, `fieldName`, `visibility`, `initOnly` |
+| `generate_method_stub` | Generate a method from an undefined call site, inferring the signature from usage. Placeholder body is `throw new NotImplementedException();`. | `sourceFile`, `line`, `column`, `methodName`, `returnType`, `visibility`, `generateAsync` |
 | `generate_overrides` | Generate override methods for base class virtual/abstract members. | `sourceFile`, `typeName`, `members`, `callBase` |
 | `implement_interface` | Generate interface member implementations for a type. | `sourceFile`, `typeName`, `interfaceName`, `explicitImplementation`, `members` |
 

--- a/src/RoslynMcp.Cli/ToolRegistry.cs
+++ b/src/RoslynMcp.Cli/ToolRegistry.cs
@@ -47,7 +47,7 @@ public sealed class ToolEntry
 }
 
 /// <summary>
-/// Maps tool names to execution delegates for all 51 Roslyn tools.
+/// Maps tool names to execution delegates for all 52 Roslyn tools.
 /// </summary>
 public sealed class ToolRegistry
 {
@@ -139,7 +139,7 @@ public sealed class ToolRegistry
         _tools.Values.OrderBy(t => t.Category).ThenBy(t => t.Name).ToList();
 
     /// <summary>
-    /// Build the default registry with all 51 tools registered.
+    /// Build the default registry with all 52 tools registered.
     /// </summary>
     public static ToolRegistry BuildDefault()
     {
@@ -207,11 +207,13 @@ public sealed class ToolRegistry
         r.RegisterRefactoring<ConvertToPatternMatchingOperation, ConvertToPatternMatchingParams>(
             "convert-to-pattern-matching", "Convert type checks to pattern matching");
 
-        // ── Refactoring: Generate (7) ─────────────────────────────────
+        // ── Refactoring: Generate (8) ─────────────────────────────────
         r.RegisterRefactoring<GenerateConstructorOperation, GenerateConstructorParams>(
             "generate-constructor", "Generate a constructor from fields/properties");
         r.RegisterRefactoring<GeneratePropertyOperation, GeneratePropertyParams>(
             "generate-property", "Generate a property on a type (auto, init-only, or backing-field)");
+        r.RegisterRefactoring<GenerateMethodStubOperation, GenerateMethodStubParams>(
+            "generate-method-stub", "Generate a method from an undefined call site, inferring the signature from usage");
         r.RegisterRefactoring<GenerateEqualsHashCodeOperation, GenerateEqualsHashCodeParams>(
             "generate-equals-hashcode", "Generate Equals and GetHashCode overrides");
         r.RegisterRefactoring<GenerateOverridesOperation, GenerateOverridesParams>(

--- a/src/RoslynMcp.Contracts/Errors/ErrorCodes.cs
+++ b/src/RoslynMcp.Contracts/Errors/ErrorCodes.cs
@@ -391,6 +391,13 @@ public static class ErrorCodes
     /// <summary>Member already uses a block body.</summary>
     public const string AlreadyBlockBody = "3124";
 
+    // --------------------------------------------
+    // Generate Method Stub Errors (3125)
+    // --------------------------------------------
+
+    /// <summary>Cannot infer a return type from the call-site usage; provide returnType.</summary>
+    public const string CannotInferReturnType = "3125";
+
     // ============================================
     // System Errors (4xxx)
     // ============================================

--- a/src/RoslynMcp.Contracts/Models/GenerateMethodStubParams.cs
+++ b/src/RoslynMcp.Contracts/Models/GenerateMethodStubParams.cs
@@ -1,0 +1,47 @@
+namespace RoslynMcp.Contracts.Models;
+
+/// <summary>
+/// Parameters for the generate_method_stub tool.
+/// </summary>
+public sealed class GenerateMethodStubParams
+{
+    /// <summary>
+    /// Absolute path to the file containing the call site.
+    /// </summary>
+    public required string SourceFile { get; init; }
+
+    /// <summary>
+    /// 1-based line number of the call site.
+    /// </summary>
+    public required int Line { get; init; }
+
+    /// <summary>
+    /// 1-based column number within the method name.
+    /// </summary>
+    public required int Column { get; init; }
+
+    /// <summary>
+    /// Method name override when the name is not inferable from the location.
+    /// </summary>
+    public string? MethodName { get; init; }
+
+    /// <summary>
+    /// Explicit return type override when usage does not constrain the type.
+    /// </summary>
+    public string? ReturnType { get; init; }
+
+    /// <summary>
+    /// Accessibility of the generated method. Default: private on the same type, public on another type.
+    /// </summary>
+    public string? Visibility { get; init; }
+
+    /// <summary>
+    /// Force async method generation (<c>Task</c> / <c>Task&lt;T&gt;</c>). Default: false.
+    /// </summary>
+    public bool GenerateAsync { get; init; }
+
+    /// <summary>
+    /// Return computed changes without applying. Default: false.
+    /// </summary>
+    public bool Preview { get; init; }
+}

--- a/src/RoslynMcp.Core/Refactoring/Generate/GenerateMethodStubOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GenerateMethodStubOperation.cs
@@ -14,7 +14,7 @@ namespace RoslynMcp.Core.Refactoring.Generate;
 /// <summary>
 /// Generates a method declaration from an undefined call site, inferring the
 /// signature from usage. The placeholder body is
-/// <c>throw new NotImplementedException();</c>.
+/// <c>throw new global::System.NotImplementedException();</c>.
 /// </summary>
 public sealed class GenerateMethodStubOperation : RefactoringOperationBase<GenerateMethodStubParams>
 {
@@ -118,7 +118,12 @@ public sealed class GenerateMethodStubOperation : RefactoringOperationBase<Gener
                 $"No method invocation found at line {@params.Line}, column {@params.Column}.");
         }
 
-        var methodName = ResolveMethodName(@params, invocation);
+        ValidateInvocationIsUnresolved(invocation, semanticModel, cancellationToken);
+
+        var invokedName = GetInvokedName(invocation);
+        var methodName = ResolveMethodName(@params, invokedName);
+        var typeParameters = InferTypeParameters(invokedName);
+        var rewriteCallSite = ShouldRewriteCallSite(@params.MethodName, invokedName, methodName);
         var callSiteType = GetEnclosingType(invocation, semanticModel, cancellationToken);
         var target = ResolveTarget(invocation, semanticModel, callSiteType, cancellationToken);
         ValidateTypeCanHostMethod(target.Type);
@@ -131,36 +136,29 @@ public sealed class GenerateMethodStubOperation : RefactoringOperationBase<Gener
         ValidateDocumentIsEditable(targetDocument, Context.Workspace);
 
         var parameters = InferParameters(invocation, semanticModel);
-        ValidateNoCompatibleMethod(target.Type, methodName, parameters);
+        ValidateNoCompatibleMethod(target.Type, methodName, parameters, typeParameters.Count);
 
         var returnType = InferReturnType(invocation, semanticModel, @params, cancellationToken);
         var isAsync = @params.GenerateAsync || IsAwaited(invocation);
         if (isAsync)
             returnType = ToAsyncReturnType(returnType);
 
-        var isStatic = ShouldBeStatic(target, callSiteType, invocation);
+        var isStatic = ShouldBeStatic(target, invocation, semanticModel, cancellationToken);
         var visibility = ResolveVisibility(@params, target.SameTypeAsCaller);
-        var method = CreateMethodStub(methodName, returnType, parameters, visibility, isStatic, isAsync);
+        var method = CreateMethodStub(methodName, returnType, parameters, visibility, isStatic, isAsync, typeParameters);
 
         if (@params.Preview)
-            return CreatePreviewResult(operationId, targetDocument, target.Type.Name, methodName, method);
+            return CreatePreviewResult(operationId, callSiteDocument, targetDocument, target.Type.Name, methodName, method, rewriteCallSite, invokedName);
 
-        var newTypeDecl = InsertMethod(targetDeclaration, method);
-        Solution newSolution;
-        if (targetDocument.Id == callSiteDocument.Id)
-        {
-            var targetInCallSite = (TypeDeclarationSyntax)root.FindNode(targetDeclaration.Span);
-            var newRoot = root.ReplaceNode(targetInCallSite, newTypeDecl);
-            newSolution = callSiteDocument.WithSyntaxRoot(newRoot).Project.Solution;
-        }
-        else
-        {
-            var targetRoot = await targetDocument.GetSyntaxRootAsync(cancellationToken)
-                ?? throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse target file.");
-            var currentDecl = (TypeDeclarationSyntax)targetRoot.FindNode(targetDeclaration.Span);
-            var newRoot = targetRoot.ReplaceNode(currentDecl, newTypeDecl);
-            newSolution = targetDocument.WithSyntaxRoot(newRoot).Project.Solution;
-        }
+        var newSolution = await ApplyChangesAsync(
+            callSiteDocument,
+            root,
+            targetDocument,
+            targetDeclaration,
+            method,
+            rewriteCallSite ? invokedName : null,
+            methodName,
+            cancellationToken);
 
         var commitResult = await CommitChangesAsync(newSolution, cancellationToken);
 
@@ -212,21 +210,56 @@ public sealed class GenerateMethodStubOperation : RefactoringOperationBase<Gener
         };
     }
 
-    private static string ResolveMethodName(GenerateMethodStubParams @params, InvocationExpressionSyntax invocation)
+    internal static void ValidateInvocationIsUnresolved(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        var symbol = semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol;
+        if (symbol != null)
+        {
+            throw new RefactoringException(
+                ErrorCodes.NameCollision,
+                $"The call already resolves to '{symbol.ToDisplayString()}'.");
+        }
+    }
+
+    private static string ResolveMethodName(
+        GenerateMethodStubParams @params,
+        SimpleNameSyntax? invokedName)
     {
         if (!string.IsNullOrWhiteSpace(@params.MethodName))
             return @params.MethodName;
 
-        var name = GetInvokedName(invocation);
-        if (name == null || string.IsNullOrWhiteSpace(name.Identifier.ValueText))
+        if (invokedName == null || string.IsNullOrWhiteSpace(invokedName.Identifier.ValueText))
         {
             throw new RefactoringException(
                 ErrorCodes.MethodNotFound,
                 "No method invocation found at the specified location.");
         }
 
-        return name.Identifier.ValueText;
+        return invokedName.Identifier.ValueText;
     }
+
+    internal static bool ShouldRewriteCallSite(string? requestedName, SimpleNameSyntax? invokedName, string methodName) =>
+        !string.IsNullOrWhiteSpace(requestedName)
+        && invokedName != null
+        && !string.Equals(invokedName.Identifier.ValueText, methodName, StringComparison.Ordinal);
+
+    internal static IReadOnlyList<string> InferTypeParameters(SimpleNameSyntax? name)
+    {
+        if (name is not GenericNameSyntax generic || generic.TypeArgumentList.Arguments.Count == 0)
+            return Array.Empty<string>();
+
+        var names = new List<string>(generic.TypeArgumentList.Arguments.Count);
+        for (var i = 0; i < generic.TypeArgumentList.Arguments.Count; i++)
+            names.Add(i == 0 ? "T" : $"T{i + 1}");
+
+        return names;
+    }
+
+    internal static SimpleNameSyntax RenameInvokedName(SimpleNameSyntax current, string newName) =>
+        current.WithIdentifier(SyntaxFactory.Identifier(newName).WithTriviaFrom(current.Identifier));
 
     private static INamedTypeSymbol GetEnclosingType(
         SyntaxNode node,
@@ -379,7 +412,7 @@ public sealed class GenerateMethodStubOperation : RefactoringOperationBase<Gener
             index++;
             var typeName = InferArgumentType(argument.Expression, semanticModel);
             var name = InferParameterName(argument, index, usedNames);
-            parameters.Add(new InferredParameter(name, typeName));
+            parameters.Add(new InferredParameter(name, typeName, InferRefKind(argument)));
         }
 
         return parameters;
@@ -433,6 +466,12 @@ public sealed class GenerateMethodStubOperation : RefactoringOperationBase<Gener
         {
             candidate = identifier.Identifier.ValueText;
         }
+        else if (Unwrap(argument.Expression) is DeclarationExpressionSyntax declaration
+                 && declaration.Designation is SingleVariableDesignationSyntax single
+                 && IsValidIdentifier(single.Identifier.ValueText))
+        {
+            candidate = single.Identifier.ValueText;
+        }
         else
         {
             candidate = $"arg{index}";
@@ -448,6 +487,14 @@ public sealed class GenerateMethodStubOperation : RefactoringOperationBase<Gener
 
         return name;
     }
+
+    internal static RefKind InferRefKind(ArgumentSyntax argument) => argument.RefKindKeyword.Kind() switch
+    {
+        SyntaxKind.RefKeyword => RefKind.Ref,
+        SyntaxKind.OutKeyword => RefKind.Out,
+        SyntaxKind.InKeyword => RefKind.In,
+        _ => RefKind.None
+    };
 
     private static ExpressionSyntax Unwrap(ExpressionSyntax expression)
     {
@@ -470,11 +517,15 @@ public sealed class GenerateMethodStubOperation : RefactoringOperationBase<Gener
     internal static void ValidateNoCompatibleMethod(
         INamedTypeSymbol typeSymbol,
         string methodName,
-        IReadOnlyList<InferredParameter> parameters)
+        IReadOnlyList<InferredParameter> parameters,
+        int typeParameterCount)
     {
         foreach (var existing in typeSymbol.GetMembers(methodName).OfType<IMethodSymbol>())
         {
             if (existing.MethodKind != MethodKind.Ordinary || existing.IsImplicitlyDeclared)
+                continue;
+
+            if (existing.TypeParameters.Length != typeParameterCount)
                 continue;
 
             if (existing.Parameters.Length != parameters.Count)
@@ -597,46 +648,57 @@ public sealed class GenerateMethodStubOperation : RefactoringOperationBase<Gener
 
     internal static bool ShouldBeStatic(
         TargetResolution target,
-        INamedTypeSymbol enclosingType,
-        InvocationExpressionSyntax invocation)
+        SyntaxNode invocation,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
     {
         if (target.Type.IsStatic || target.ReceiverIsTypeName)
             return true;
 
-        if (target.SameTypeAsCaller && IsInStaticContext(invocation, enclosingType))
-            return true;
-
-        return false;
+        return target.SameTypeAsCaller && IsInStaticContext(invocation, semanticModel, cancellationToken);
     }
 
-    private static bool IsInStaticContext(
+    internal static bool IsInStaticContext(
         SyntaxNode node,
         SemanticModel semanticModel,
         CancellationToken cancellationToken)
     {
-        var member = node.Ancestors().FirstOrDefault(n =>
-            n is MethodDeclarationSyntax or LocalFunctionStatementSyntax
-                or PropertyDeclarationSyntax or AccessorDeclarationSyntax
-                or ConstructorDeclarationSyntax);
-
-        return member switch
-        {
-            MethodDeclarationSyntax method => method.Modifiers.Any(SyntaxKind.StaticKeyword)
-                || semanticModel.GetDeclaredSymbol(method, cancellationToken)?.IsStatic == true,
-            LocalFunctionStatementSyntax local => local.Modifiers.Any(SyntaxKind.StaticKeyword),
-            PropertyDeclarationSyntax property => property.Modifiers.Any(SyntaxKind.StaticKeyword),
-            ConstructorDeclarationSyntax => false,
-            _ => false
-        };
-    }
-
-    private static bool IsInStaticContext(SyntaxNode node, INamedTypeSymbol enclosingType)
-    {
-        if (enclosingType.IsStatic)
+        var enclosingType = node.Ancestors().OfType<TypeDeclarationSyntax>().FirstOrDefault();
+        if (enclosingType?.Modifiers.Any(SyntaxKind.StaticKeyword) == true)
             return true;
 
-        var method = node.Ancestors().OfType<MethodDeclarationSyntax>().FirstOrDefault();
-        return method?.Modifiers.Any(SyntaxKind.StaticKeyword) == true;
+        foreach (var ancestor in node.Ancestors())
+        {
+            switch (ancestor)
+            {
+                case MethodDeclarationSyntax method:
+                    return method.Modifiers.Any(SyntaxKind.StaticKeyword)
+                        || semanticModel.GetDeclaredSymbol(method, cancellationToken)?.IsStatic == true;
+                case LocalFunctionStatementSyntax local:
+                    return local.Modifiers.Any(SyntaxKind.StaticKeyword);
+                case ConstructorDeclarationSyntax constructor:
+                    return constructor.Modifiers.Any(SyntaxKind.StaticKeyword);
+                case PropertyDeclarationSyntax property:
+                    return property.Modifiers.Any(SyntaxKind.StaticKeyword);
+                case EventDeclarationSyntax evt:
+                    return evt.Modifiers.Any(SyntaxKind.StaticKeyword);
+                case AccessorDeclarationSyntax accessor:
+                    return IsContainingMemberStatic(accessor);
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsContainingMemberStatic(AccessorDeclarationSyntax accessor)
+    {
+        return accessor.Parent?.Parent switch
+        {
+            PropertyDeclarationSyntax property => property.Modifiers.Any(SyntaxKind.StaticKeyword),
+            EventDeclarationSyntax evt => evt.Modifiers.Any(SyntaxKind.StaticKeyword),
+            IndexerDeclarationSyntax => false,
+            _ => false
+        };
     }
 
     internal static string ResolveVisibility(GenerateMethodStubParams @params, bool sameTypeAsCaller)
@@ -648,7 +710,7 @@ public sealed class GenerateMethodStubOperation : RefactoringOperationBase<Gener
     }
 
     /// <summary>
-    /// Creates a method stub with a <c>throw new NotImplementedException();</c> body.
+    /// Creates a method stub with a <c>throw new global::System.NotImplementedException();</c> body.
     /// </summary>
     internal static MethodDeclarationSyntax CreateMethodStub(
         string name,
@@ -656,12 +718,11 @@ public sealed class GenerateMethodStubOperation : RefactoringOperationBase<Gener
         IReadOnlyList<InferredParameter> parameters,
         string visibility,
         bool isStatic,
-        bool isAsync)
+        bool isAsync,
+        IReadOnlyList<string>? typeParameters = null)
     {
         var parameterList = SyntaxFactory.ParameterList(
-            SyntaxFactory.SeparatedList(parameters.Select(p =>
-                SyntaxFactory.Parameter(SyntaxFactory.Identifier(p.Name))
-                    .WithType(SyntaxFactory.ParseTypeName(p.TypeName).WithTrailingTrivia(SyntaxFactory.Space)))));
+            SyntaxFactory.SeparatedList(parameters.Select(CreateParameter)));
 
         var modifiers = new List<SyntaxToken>(ParseVisibilityTokens(visibility));
         if (isStatic)
@@ -669,13 +730,41 @@ public sealed class GenerateMethodStubOperation : RefactoringOperationBase<Gener
         if (isAsync)
             modifiers.Add(SyntaxFactory.Token(SyntaxKind.AsyncKeyword).WithTrailingTrivia(SyntaxFactory.Space));
 
-        return SyntaxFactory.MethodDeclaration(
+        var method = SyntaxFactory.MethodDeclaration(
                 SyntaxFactory.ParseTypeName(returnType).WithTrailingTrivia(SyntaxFactory.Space),
                 name)
             .WithModifiers(SyntaxFactory.TokenList(modifiers))
             .WithParameterList(parameterList)
-            .WithBody(CreateThrowNotImplementedBody())
-            .NormalizeWhitespace();
+            .WithBody(CreateThrowNotImplementedBody());
+
+        if (typeParameters is { Count: > 0 })
+        {
+            method = method.WithTypeParameterList(
+                SyntaxFactory.TypeParameterList(
+                    SyntaxFactory.SeparatedList(typeParameters.Select(SyntaxFactory.TypeParameter))));
+        }
+
+        return method.NormalizeWhitespace();
+    }
+
+    private static ParameterSyntax CreateParameter(InferredParameter parameter)
+    {
+        var syntax = SyntaxFactory.Parameter(SyntaxFactory.Identifier(parameter.Name))
+            .WithType(SyntaxFactory.ParseTypeName(parameter.TypeName).WithTrailingTrivia(SyntaxFactory.Space));
+
+        var refKeyword = parameter.RefKind switch
+        {
+            RefKind.Ref => SyntaxKind.RefKeyword,
+            RefKind.Out => SyntaxKind.OutKeyword,
+            RefKind.In => SyntaxKind.InKeyword,
+            _ => SyntaxKind.None
+        };
+
+        if (refKeyword == SyntaxKind.None)
+            return syntax;
+
+        return syntax.WithModifiers(SyntaxFactory.TokenList(
+            SyntaxFactory.Token(refKeyword).WithTrailingTrivia(SyntaxFactory.Space)));
     }
 
     internal static BlockSyntax CreateThrowNotImplementedBody()
@@ -683,7 +772,7 @@ public sealed class GenerateMethodStubOperation : RefactoringOperationBase<Gener
         return SyntaxFactory.Block(
             SyntaxFactory.ThrowStatement(
                 SyntaxFactory.ObjectCreationExpression(
-                    SyntaxFactory.IdentifierName("NotImplementedException"))
+                    SyntaxFactory.ParseTypeName("global::System.NotImplementedException"))
                 .WithArgumentList(SyntaxFactory.ArgumentList())));
     }
 
@@ -700,12 +789,76 @@ public sealed class GenerateMethodStubOperation : RefactoringOperationBase<Gener
         return typeDeclaration.WithMembers(SyntaxFactory.List(members));
     }
 
+    private async Task<Solution> ApplyChangesAsync(
+        Document callSiteDocument,
+        SyntaxNode callSiteRoot,
+        Document targetDocument,
+        TypeDeclarationSyntax targetDeclaration,
+        MethodDeclarationSyntax method,
+        SimpleNameSyntax? invokedNameToRewrite,
+        string methodName,
+        CancellationToken cancellationToken)
+    {
+        if (targetDocument.Id == callSiteDocument.Id)
+        {
+            var targetInCallSite = (TypeDeclarationSyntax)callSiteRoot.FindNode(targetDeclaration.Span);
+            SyntaxNode newRoot;
+            if (invokedNameToRewrite != null && targetInCallSite.FullSpan.Contains(invokedNameToRewrite.Span))
+            {
+                var renamed = RenameInvokedName(invokedNameToRewrite, methodName);
+                var typeWithRename = (TypeDeclarationSyntax)targetInCallSite.ReplaceNode(invokedNameToRewrite, renamed);
+                newRoot = callSiteRoot.ReplaceNode(targetInCallSite, InsertMethod(typeWithRename, method));
+            }
+            else if (invokedNameToRewrite != null)
+            {
+                var renamed = RenameInvokedName(invokedNameToRewrite, methodName);
+                newRoot = callSiteRoot.ReplaceNodes(
+                    new SyntaxNode[] { invokedNameToRewrite, targetInCallSite },
+                    (original, _) => original == invokedNameToRewrite
+                        ? renamed
+                        : InsertMethod(targetInCallSite, method));
+            }
+            else
+            {
+                newRoot = callSiteRoot.ReplaceNode(targetInCallSite, InsertMethod(targetInCallSite, method));
+            }
+
+            return callSiteDocument.WithSyntaxRoot(newRoot).Project.Solution;
+        }
+
+        var targetRoot = await targetDocument.GetSyntaxRootAsync(cancellationToken)
+            ?? throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse target file.");
+        var currentDecl = (TypeDeclarationSyntax)targetRoot.FindNode(targetDeclaration.Span);
+        var newTargetRoot = targetRoot.ReplaceNode(currentDecl, InsertMethod(currentDecl, method));
+        var solution = targetDocument.WithSyntaxRoot(newTargetRoot).Project.Solution;
+
+        if (invokedNameToRewrite == null)
+            return solution;
+
+        var updatedCallSite = solution.GetDocument(callSiteDocument.Id)
+            ?? throw new RefactoringException(ErrorCodes.RoslynError, "Could not locate the call-site document.");
+        var updatedRoot = await updatedCallSite.GetSyntaxRootAsync(cancellationToken)
+            ?? throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse file.");
+        if (updatedRoot.FindNode(invokedNameToRewrite.Span) is not SimpleNameSyntax currentName)
+        {
+            throw new RefactoringException(
+                ErrorCodes.MethodNotFound,
+                "Could not rewrite the call site to the overridden method name.");
+        }
+
+        var rewrittenRoot = updatedRoot.ReplaceNode(currentName, RenameInvokedName(currentName, methodName));
+        return updatedCallSite.WithSyntaxRoot(rewrittenRoot).Project.Solution;
+    }
+
     private static RefactoringResult CreatePreviewResult(
         Guid operationId,
+        Document callSiteDocument,
         Document targetDocument,
         string typeName,
         string methodName,
-        MethodDeclarationSyntax method)
+        MethodDeclarationSyntax method,
+        bool rewriteCallSite,
+        SimpleNameSyntax? invokedName)
     {
         var afterSnippet = method.NormalizeWhitespace().ToFullString();
         var pendingChanges = new List<PendingChange>
@@ -719,6 +872,18 @@ public sealed class GenerateMethodStubOperation : RefactoringOperationBase<Gener
                 AfterSnippet = afterSnippet
             }
         };
+
+        if (rewriteCallSite && invokedName != null)
+        {
+            pendingChanges.Add(new PendingChange
+            {
+                File = callSiteDocument.FilePath ?? invokedName.ToString(),
+                ChangeType = ChangeKind.Modify,
+                Description = $"Rewrite call site '{invokedName.Identifier.ValueText}' to '{methodName}'",
+                BeforeSnippet = invokedName.ToString(),
+                AfterSnippet = RenameInvokedName(invokedName, methodName).ToString()
+            });
+        }
 
         return RefactoringResult.PreviewResult(operationId, pendingChanges);
     }
@@ -812,5 +977,5 @@ public sealed class GenerateMethodStubOperation : RefactoringOperationBase<Gener
         bool SameTypeAsCaller,
         bool ReceiverIsTypeName);
 
-    internal readonly record struct InferredParameter(string Name, string TypeName);
+    internal readonly record struct InferredParameter(string Name, string TypeName, RefKind RefKind);
 }

--- a/src/RoslynMcp.Core/Refactoring/Generate/GenerateMethodStubOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GenerateMethodStubOperation.cs
@@ -1,0 +1,816 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using RoslynMcp.Contracts.Enums;
+using RoslynMcp.Contracts.Errors;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.FileSystem;
+using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Resolution;
+using RoslynMcp.Core.Workspace;
+
+namespace RoslynMcp.Core.Refactoring.Generate;
+
+/// <summary>
+/// Generates a method declaration from an undefined call site, inferring the
+/// signature from usage. The placeholder body is
+/// <c>throw new NotImplementedException();</c>.
+/// </summary>
+public sealed class GenerateMethodStubOperation : RefactoringOperationBase<GenerateMethodStubParams>
+{
+    private static readonly HashSet<string> ValidVisibilities = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "public", "private", "protected", "internal", "protected internal", "private protected"
+    };
+
+    /// <summary>
+    /// Creates a new generate method stub operation.
+    /// </summary>
+    /// <param name="context">Workspace context.</param>
+    public GenerateMethodStubOperation(WorkspaceContext context) : base(context)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override void ValidateParams(GenerateMethodStubParams @params) => Validate(@params);
+
+    /// <summary>
+    /// Validates generate-method-stub parameters. Internal so tests can exercise
+    /// input rules without loading a workspace.
+    /// </summary>
+    internal static void Validate(GenerateMethodStubParams @params)
+    {
+        if (string.IsNullOrWhiteSpace(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "sourceFile is required.");
+
+        if (!PathResolver.IsAbsolutePath(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.InvalidSourcePath, "sourceFile must be an absolute path.");
+
+        if (!PathResolver.IsValidCSharpFilePath(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.InvalidSourcePath, "sourceFile must be a .cs file.");
+
+        if (@params.Line < 1)
+            throw new RefactoringException(ErrorCodes.InvalidLineNumber, "line must be >= 1.");
+
+        if (@params.Column < 1)
+            throw new RefactoringException(ErrorCodes.InvalidColumnNumber, "column must be >= 1.");
+
+        if (@params.MethodName != null && !IsValidIdentifier(@params.MethodName))
+            throw new RefactoringException(ErrorCodes.InvalidSymbolName, $"Invalid method name: {@params.MethodName}");
+
+        if (!string.IsNullOrWhiteSpace(@params.ReturnType) && !IsValidTypeName(@params.ReturnType))
+            throw new RefactoringException(ErrorCodes.InvalidReturnType, $"Invalid return type: {@params.ReturnType}");
+
+        if (!string.IsNullOrWhiteSpace(@params.Visibility) && !ValidVisibilities.Contains(@params.Visibility.Trim()))
+            throw new RefactoringException(ErrorCodes.InvalidVisibility, $"Invalid visibility: {@params.Visibility}");
+
+        if (!File.Exists(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.SourceFileNotFound, $"Source file not found: {@params.SourceFile}");
+    }
+
+    /// <summary>
+    /// Rejects documents that cannot receive source edits.
+    /// </summary>
+    internal static void ValidateDocumentIsEditable(Document document, Microsoft.CodeAnalysis.Workspace workspace)
+    {
+        if (document is SourceGeneratedDocument)
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable (source-generated).");
+        }
+
+        if (string.IsNullOrWhiteSpace(document.FilePath) || !File.Exists(document.FilePath))
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable.");
+        }
+
+        if (!workspace.CanApplyChange(ApplyChangesKind.ChangeDocument))
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable (workspace cannot apply changes).");
+        }
+    }
+
+    /// <inheritdoc />
+    protected override async Task<RefactoringResult> ExecuteCoreAsync(
+        Guid operationId,
+        GenerateMethodStubParams @params,
+        CancellationToken cancellationToken)
+    {
+        var callSiteDocument = GetDocumentOrThrow(@params.SourceFile);
+        ValidateDocumentIsEditable(callSiteDocument, Context.Workspace);
+
+        var root = await callSiteDocument.GetSyntaxRootAsync(cancellationToken);
+        var semanticModel = await callSiteDocument.GetSemanticModelAsync(cancellationToken);
+        if (root == null || semanticModel == null)
+            throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse file.");
+
+        var position = SymbolResolver.GetPosition(root, @params.Line, @params.Column);
+        var invocation = FindInvocationAtPosition(root, position);
+        if (invocation == null)
+        {
+            throw new RefactoringException(
+                ErrorCodes.MethodNotFound,
+                $"No method invocation found at line {@params.Line}, column {@params.Column}.");
+        }
+
+        var methodName = ResolveMethodName(@params, invocation);
+        var callSiteType = GetEnclosingType(invocation, semanticModel, cancellationToken);
+        var target = ResolveTarget(invocation, semanticModel, callSiteType, cancellationToken);
+        ValidateTypeCanHostMethod(target.Type);
+
+        var targetDeclaration = await GetEditableTypeDeclarationAsync(target.Type, cancellationToken);
+        var targetDocument = Context.Solution.GetDocument(targetDeclaration.SyntaxTree)
+            ?? throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Target type '{target.Type.Name}' is not part of the workspace.");
+        ValidateDocumentIsEditable(targetDocument, Context.Workspace);
+
+        var parameters = InferParameters(invocation, semanticModel);
+        ValidateNoCompatibleMethod(target.Type, methodName, parameters);
+
+        var returnType = InferReturnType(invocation, semanticModel, @params, cancellationToken);
+        var isAsync = @params.GenerateAsync || IsAwaited(invocation);
+        if (isAsync)
+            returnType = ToAsyncReturnType(returnType);
+
+        var isStatic = ShouldBeStatic(target, callSiteType, invocation);
+        var visibility = ResolveVisibility(@params, target.SameTypeAsCaller);
+        var method = CreateMethodStub(methodName, returnType, parameters, visibility, isStatic, isAsync);
+
+        if (@params.Preview)
+            return CreatePreviewResult(operationId, targetDocument, target.Type.Name, methodName, method);
+
+        var newTypeDecl = InsertMethod(targetDeclaration, method);
+        Solution newSolution;
+        if (targetDocument.Id == callSiteDocument.Id)
+        {
+            var targetInCallSite = (TypeDeclarationSyntax)root.FindNode(targetDeclaration.Span);
+            var newRoot = root.ReplaceNode(targetInCallSite, newTypeDecl);
+            newSolution = callSiteDocument.WithSyntaxRoot(newRoot).Project.Solution;
+        }
+        else
+        {
+            var targetRoot = await targetDocument.GetSyntaxRootAsync(cancellationToken)
+                ?? throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse target file.");
+            var currentDecl = (TypeDeclarationSyntax)targetRoot.FindNode(targetDeclaration.Span);
+            var newRoot = targetRoot.ReplaceNode(currentDecl, newTypeDecl);
+            newSolution = targetDocument.WithSyntaxRoot(newRoot).Project.Solution;
+        }
+
+        var commitResult = await CommitChangesAsync(newSolution, cancellationToken);
+
+        return RefactoringResult.Succeeded(
+            operationId,
+            new FileChanges
+            {
+                FilesModified = commitResult.FilesModified,
+                FilesCreated = commitResult.FilesCreated,
+                FilesDeleted = commitResult.FilesDeleted
+            },
+            new Contracts.Models.SymbolInfo
+            {
+                Name = methodName,
+                FullyQualifiedName = $"{target.Type.ToDisplayString()}.{methodName}",
+                Kind = Contracts.Enums.SymbolKind.Method
+            },
+            0,
+            0);
+    }
+
+    internal static InvocationExpressionSyntax? FindInvocationAtPosition(SyntaxNode root, int position)
+    {
+        var token = root.FindToken(position);
+        if (token == default)
+            return null;
+
+        foreach (var node in token.Parent?.AncestorsAndSelf() ?? Enumerable.Empty<SyntaxNode>())
+        {
+            if (node is InvocationExpressionSyntax invocation)
+            {
+                var name = GetInvokedName(invocation);
+                if (name != null && name.Span.Start <= position && position <= name.Span.End)
+                    return invocation;
+            }
+        }
+
+        return null;
+    }
+
+    internal static SimpleNameSyntax? GetInvokedName(InvocationExpressionSyntax invocation)
+    {
+        return invocation.Expression switch
+        {
+            SimpleNameSyntax simple => simple,
+            MemberAccessExpressionSyntax member => member.Name,
+            MemberBindingExpressionSyntax binding => binding.Name,
+            _ => null
+        };
+    }
+
+    private static string ResolveMethodName(GenerateMethodStubParams @params, InvocationExpressionSyntax invocation)
+    {
+        if (!string.IsNullOrWhiteSpace(@params.MethodName))
+            return @params.MethodName;
+
+        var name = GetInvokedName(invocation);
+        if (name == null || string.IsNullOrWhiteSpace(name.Identifier.ValueText))
+        {
+            throw new RefactoringException(
+                ErrorCodes.MethodNotFound,
+                "No method invocation found at the specified location.");
+        }
+
+        return name.Identifier.ValueText;
+    }
+
+    private static INamedTypeSymbol GetEnclosingType(
+        SyntaxNode node,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        var typeDecl = node.Ancestors().OfType<TypeDeclarationSyntax>().FirstOrDefault();
+        if (typeDecl == null)
+        {
+            throw new RefactoringException(
+                ErrorCodes.TypeNotFound,
+                "Call site is not inside a type that can host a generated method.");
+        }
+
+        if (semanticModel.GetDeclaredSymbol(typeDecl, cancellationToken) is not INamedTypeSymbol typeSymbol)
+        {
+            throw new RefactoringException(
+                ErrorCodes.TypeNotFound,
+                $"Could not resolve a symbol for type '{typeDecl.Identifier.Text}'.");
+        }
+
+        return typeSymbol;
+    }
+
+    internal static TargetResolution ResolveTarget(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel,
+        INamedTypeSymbol enclosingType,
+        CancellationToken cancellationToken)
+    {
+        switch (invocation.Expression)
+        {
+            case SimpleNameSyntax:
+                return new TargetResolution(enclosingType, SameTypeAsCaller: true, ReceiverIsTypeName: IsInStaticContext(invocation, semanticModel, cancellationToken));
+
+            case MemberAccessExpressionSyntax member:
+                return ResolveReceiver(member.Expression, semanticModel, enclosingType, cancellationToken);
+
+            case MemberBindingExpressionSyntax:
+                if (invocation.Parent is ConditionalAccessExpressionSyntax conditional)
+                    return ResolveReceiver(conditional.Expression, semanticModel, enclosingType, cancellationToken);
+                break;
+        }
+
+        throw new RefactoringException(
+            ErrorCodes.TypeNotFound,
+            "Cannot determine the target type for the method from the call-site receiver.");
+    }
+
+    private static TargetResolution ResolveReceiver(
+        ExpressionSyntax receiver,
+        SemanticModel semanticModel,
+        INamedTypeSymbol enclosingType,
+        CancellationToken cancellationToken)
+    {
+        if (receiver is ThisExpressionSyntax)
+            return new TargetResolution(enclosingType, SameTypeAsCaller: true, ReceiverIsTypeName: false);
+
+        if (receiver is BaseExpressionSyntax)
+        {
+            var baseType = enclosingType.BaseType;
+            if (baseType == null || baseType.SpecialType == SpecialType.System_Object)
+            {
+                throw new RefactoringException(
+                    ErrorCodes.TypeNotFound,
+                    "Cannot determine a target type from the base receiver.");
+            }
+
+            return new TargetResolution(baseType, SameTypeAsCaller: false, ReceiverIsTypeName: false);
+        }
+
+        var symbolInfo = semanticModel.GetSymbolInfo(receiver, cancellationToken);
+        if (symbolInfo.Symbol is INamedTypeSymbol typeSymbol && typeSymbol.TypeKind != TypeKind.Error)
+            return new TargetResolution(typeSymbol, IsSameType(typeSymbol, enclosingType), ReceiverIsTypeName: true);
+
+        if (symbolInfo.Symbol is IAliasSymbol { Target: INamedTypeSymbol aliased } && aliased.TypeKind != TypeKind.Error)
+            return new TargetResolution(aliased, IsSameType(aliased, enclosingType), ReceiverIsTypeName: true);
+
+        var receiverType = semanticModel.GetTypeInfo(receiver, cancellationToken).Type
+            ?? semanticModel.GetTypeInfo(receiver, cancellationToken).ConvertedType;
+
+        var named = UnwrapNamedType(receiverType);
+        if (named == null)
+        {
+            throw new RefactoringException(
+                ErrorCodes.TypeNotFound,
+                "Cannot determine the target type for the method from the call-site receiver.");
+        }
+
+        return new TargetResolution(named, IsSameType(named, enclosingType), ReceiverIsTypeName: false);
+    }
+
+    internal static INamedTypeSymbol? UnwrapNamedType(ITypeSymbol? type)
+    {
+        if (type is INamedTypeSymbol named && named.TypeKind != TypeKind.Error)
+            return named;
+
+        return null;
+    }
+
+    internal static void ValidateTypeCanHostMethod(INamedTypeSymbol typeSymbol)
+    {
+        if (typeSymbol.TypeKind is TypeKind.Enum or TypeKind.Delegate or TypeKind.Interface)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidSymbolKind,
+                $"Type '{typeSymbol.Name}' is not a supported target for generate_method_stub.");
+        }
+    }
+
+    private async Task<TypeDeclarationSyntax> GetEditableTypeDeclarationAsync(
+        INamedTypeSymbol type,
+        CancellationToken cancellationToken)
+    {
+        if (type.Locations.Length == 0 || type.Locations.All(l => !l.IsInSource))
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Target type '{type.Name}' is in an external assembly.");
+        }
+
+        var syntaxRef = type.DeclaringSyntaxReferences.FirstOrDefault();
+        if (syntaxRef == null)
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Target type '{type.Name}' is in an external assembly.");
+        }
+
+        if (await syntaxRef.GetSyntaxAsync(cancellationToken) is not TypeDeclarationSyntax syntax)
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Target type '{type.Name}' is not editable.");
+        }
+
+        return syntax;
+    }
+
+    internal static IReadOnlyList<InferredParameter> InferParameters(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel)
+    {
+        var usedNames = new HashSet<string>(StringComparer.Ordinal);
+        var parameters = new List<InferredParameter>();
+        var index = 0;
+
+        foreach (var argument in invocation.ArgumentList.Arguments)
+        {
+            index++;
+            var typeName = InferArgumentType(argument.Expression, semanticModel);
+            var name = InferParameterName(argument, index, usedNames);
+            parameters.Add(new InferredParameter(name, typeName));
+        }
+
+        return parameters;
+    }
+
+    internal static string InferArgumentType(ExpressionSyntax expression, SemanticModel semanticModel)
+    {
+        var info = semanticModel.GetTypeInfo(expression);
+        var type = info.Type ?? info.ConvertedType;
+        if (type != null && type.TypeKind != TypeKind.Error && type.SpecialType != SpecialType.System_Void)
+            return type.ToDisplayString();
+
+        return InferLiteralFallback(expression);
+    }
+
+    internal static string InferLiteralFallback(ExpressionSyntax expression)
+    {
+        return expression switch
+        {
+            LiteralExpressionSyntax literal when literal.IsKind(SyntaxKind.StringLiteralExpression)
+                || literal.IsKind(SyntaxKind.Utf8StringLiteralExpression) => "string",
+            LiteralExpressionSyntax literal when literal.IsKind(SyntaxKind.CharacterLiteralExpression) => "char",
+            LiteralExpressionSyntax literal when literal.IsKind(SyntaxKind.TrueLiteralExpression)
+                || literal.IsKind(SyntaxKind.FalseLiteralExpression) => "bool",
+            LiteralExpressionSyntax literal when literal.IsKind(SyntaxKind.NumericLiteralExpression) =>
+                InferNumericType(literal.Token.Value),
+            _ => "object"
+        };
+    }
+
+    private static string InferNumericType(object? value) => value switch
+    {
+        float => "float",
+        double => "double",
+        decimal => "decimal",
+        long => "long",
+        ulong => "ulong",
+        uint => "uint",
+        _ => "int"
+    };
+
+    internal static string InferParameterName(ArgumentSyntax argument, int index, HashSet<string> usedNames)
+    {
+        string candidate;
+        if (argument.NameColon != null)
+        {
+            candidate = argument.NameColon.Name.Identifier.ValueText;
+        }
+        else if (Unwrap(argument.Expression) is IdentifierNameSyntax identifier
+                 && IsValidIdentifier(identifier.Identifier.ValueText))
+        {
+            candidate = identifier.Identifier.ValueText;
+        }
+        else
+        {
+            candidate = $"arg{index}";
+        }
+
+        var name = candidate;
+        var suffix = 2;
+        while (!usedNames.Add(name))
+        {
+            name = $"{candidate}{suffix}";
+            suffix++;
+        }
+
+        return name;
+    }
+
+    private static ExpressionSyntax Unwrap(ExpressionSyntax expression)
+    {
+        while (true)
+        {
+            switch (expression)
+            {
+                case ParenthesizedExpressionSyntax paren:
+                    expression = paren.Expression;
+                    continue;
+                case CastExpressionSyntax cast:
+                    expression = cast.Expression;
+                    continue;
+                default:
+                    return expression;
+            }
+        }
+    }
+
+    internal static void ValidateNoCompatibleMethod(
+        INamedTypeSymbol typeSymbol,
+        string methodName,
+        IReadOnlyList<InferredParameter> parameters)
+    {
+        foreach (var existing in typeSymbol.GetMembers(methodName).OfType<IMethodSymbol>())
+        {
+            if (existing.MethodKind != MethodKind.Ordinary || existing.IsImplicitlyDeclared)
+                continue;
+
+            if (existing.Parameters.Length != parameters.Count)
+                continue;
+
+            var matches = true;
+            for (var i = 0; i < parameters.Count; i++)
+            {
+                if (!ParameterTypeMatches(parameters[i].TypeName, existing.Parameters[i].Type))
+                {
+                    matches = false;
+                    break;
+                }
+            }
+
+            if (matches)
+            {
+                throw new RefactoringException(
+                    ErrorCodes.NameCollision,
+                    $"Method '{methodName}' with a compatible signature already exists on '{typeSymbol.Name}'.");
+            }
+        }
+    }
+
+    internal static bool ParameterTypeMatches(string requestedType, ITypeSymbol existingType)
+    {
+        requestedType = requestedType.Trim();
+        var candidates = new HashSet<string>(StringComparer.Ordinal)
+        {
+            existingType.ToDisplayString(),
+            existingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
+                .Replace("global::", "", StringComparison.Ordinal),
+            existingType.Name
+        };
+
+        if (TryGetSpecialTypeAlias(existingType.SpecialType, out var alias))
+            candidates.Add(alias);
+
+        return candidates.Contains(requestedType);
+    }
+
+    internal static string InferReturnType(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel,
+        GenerateMethodStubParams @params,
+        CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrWhiteSpace(@params.ReturnType))
+            return @params.ReturnType.Trim();
+
+        var usage = (SyntaxNode)invocation;
+        if (invocation.Parent is AwaitExpressionSyntax awaitExpr)
+            usage = awaitExpr;
+
+        switch (usage.Parent)
+        {
+            case ExpressionStatementSyntax:
+                return "void";
+
+            case EqualsValueClauseSyntax equals when equals.Parent is VariableDeclaratorSyntax declarator
+                && declarator.Parent is VariableDeclarationSyntax declaration:
+                if (declaration.Type.IsVar)
+                {
+                    throw new RefactoringException(
+                        ErrorCodes.CannotInferReturnType,
+                        "Cannot infer return type; provide explicit returnType.");
+                }
+
+                return declaration.Type.ToString().Trim();
+
+            case AssignmentExpressionSyntax assignment:
+                {
+                    var leftType = semanticModel.GetTypeInfo(assignment.Left, cancellationToken).Type;
+                    if (IsUsableType(leftType))
+                        return leftType!.ToDisplayString();
+                    break;
+                }
+
+            case ReturnStatementSyntax:
+                {
+                    var method = invocation.Ancestors().OfType<MethodDeclarationSyntax>().FirstOrDefault();
+                    if (method != null && !method.ReturnType.IsMissing)
+                        return method.ReturnType.ToString().Trim();
+                    break;
+                }
+        }
+
+        var converted = semanticModel.GetTypeInfo(usage, cancellationToken).ConvertedType;
+        if (IsUsableType(converted))
+            return converted!.ToDisplayString();
+
+        throw new RefactoringException(
+            ErrorCodes.CannotInferReturnType,
+            "Cannot infer return type; provide explicit returnType.");
+    }
+
+    internal static bool IsAwaited(InvocationExpressionSyntax invocation) =>
+        invocation.Parent is AwaitExpressionSyntax;
+
+    internal static string ToAsyncReturnType(string returnType)
+    {
+        var trimmed = returnType.Trim();
+        if (trimmed.Equals("void", StringComparison.Ordinal))
+            return "Task";
+
+        if (IsTaskLike(trimmed))
+            return trimmed;
+
+        return $"Task<{trimmed}>";
+    }
+
+    private static bool IsTaskLike(string typeName)
+    {
+        return typeName.Equals("Task", StringComparison.Ordinal)
+               || typeName.Equals("ValueTask", StringComparison.Ordinal)
+               || typeName.StartsWith("Task<", StringComparison.Ordinal)
+               || typeName.StartsWith("ValueTask<", StringComparison.Ordinal)
+               || typeName.StartsWith("System.Threading.Tasks.Task", StringComparison.Ordinal);
+    }
+
+    internal static bool ShouldBeStatic(
+        TargetResolution target,
+        INamedTypeSymbol enclosingType,
+        InvocationExpressionSyntax invocation)
+    {
+        if (target.Type.IsStatic || target.ReceiverIsTypeName)
+            return true;
+
+        if (target.SameTypeAsCaller && IsInStaticContext(invocation, enclosingType))
+            return true;
+
+        return false;
+    }
+
+    private static bool IsInStaticContext(
+        SyntaxNode node,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        var member = node.Ancestors().FirstOrDefault(n =>
+            n is MethodDeclarationSyntax or LocalFunctionStatementSyntax
+                or PropertyDeclarationSyntax or AccessorDeclarationSyntax
+                or ConstructorDeclarationSyntax);
+
+        return member switch
+        {
+            MethodDeclarationSyntax method => method.Modifiers.Any(SyntaxKind.StaticKeyword)
+                || semanticModel.GetDeclaredSymbol(method, cancellationToken)?.IsStatic == true,
+            LocalFunctionStatementSyntax local => local.Modifiers.Any(SyntaxKind.StaticKeyword),
+            PropertyDeclarationSyntax property => property.Modifiers.Any(SyntaxKind.StaticKeyword),
+            ConstructorDeclarationSyntax => false,
+            _ => false
+        };
+    }
+
+    private static bool IsInStaticContext(SyntaxNode node, INamedTypeSymbol enclosingType)
+    {
+        if (enclosingType.IsStatic)
+            return true;
+
+        var method = node.Ancestors().OfType<MethodDeclarationSyntax>().FirstOrDefault();
+        return method?.Modifiers.Any(SyntaxKind.StaticKeyword) == true;
+    }
+
+    internal static string ResolveVisibility(GenerateMethodStubParams @params, bool sameTypeAsCaller)
+    {
+        if (!string.IsNullOrWhiteSpace(@params.Visibility))
+            return @params.Visibility.Trim();
+
+        return sameTypeAsCaller ? "private" : "public";
+    }
+
+    /// <summary>
+    /// Creates a method stub with a <c>throw new NotImplementedException();</c> body.
+    /// </summary>
+    internal static MethodDeclarationSyntax CreateMethodStub(
+        string name,
+        string returnType,
+        IReadOnlyList<InferredParameter> parameters,
+        string visibility,
+        bool isStatic,
+        bool isAsync)
+    {
+        var parameterList = SyntaxFactory.ParameterList(
+            SyntaxFactory.SeparatedList(parameters.Select(p =>
+                SyntaxFactory.Parameter(SyntaxFactory.Identifier(p.Name))
+                    .WithType(SyntaxFactory.ParseTypeName(p.TypeName).WithTrailingTrivia(SyntaxFactory.Space)))));
+
+        var modifiers = new List<SyntaxToken>(ParseVisibilityTokens(visibility));
+        if (isStatic)
+            modifiers.Add(SyntaxFactory.Token(SyntaxKind.StaticKeyword).WithTrailingTrivia(SyntaxFactory.Space));
+        if (isAsync)
+            modifiers.Add(SyntaxFactory.Token(SyntaxKind.AsyncKeyword).WithTrailingTrivia(SyntaxFactory.Space));
+
+        return SyntaxFactory.MethodDeclaration(
+                SyntaxFactory.ParseTypeName(returnType).WithTrailingTrivia(SyntaxFactory.Space),
+                name)
+            .WithModifiers(SyntaxFactory.TokenList(modifiers))
+            .WithParameterList(parameterList)
+            .WithBody(CreateThrowNotImplementedBody())
+            .NormalizeWhitespace();
+    }
+
+    internal static BlockSyntax CreateThrowNotImplementedBody()
+    {
+        return SyntaxFactory.Block(
+            SyntaxFactory.ThrowStatement(
+                SyntaxFactory.ObjectCreationExpression(
+                    SyntaxFactory.IdentifierName("NotImplementedException"))
+                .WithArgumentList(SyntaxFactory.ArgumentList())));
+    }
+
+    private static TypeDeclarationSyntax InsertMethod(
+        TypeDeclarationSyntax typeDeclaration,
+        MethodDeclarationSyntax method)
+    {
+        var members = typeDeclaration.Members.ToList();
+        members.Add(
+            method
+                .WithLeadingTrivia(SyntaxFactory.CarriageReturnLineFeed, SyntaxFactory.CarriageReturnLineFeed)
+                .WithTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed));
+
+        return typeDeclaration.WithMembers(SyntaxFactory.List(members));
+    }
+
+    private static RefactoringResult CreatePreviewResult(
+        Guid operationId,
+        Document targetDocument,
+        string typeName,
+        string methodName,
+        MethodDeclarationSyntax method)
+    {
+        var afterSnippet = method.NormalizeWhitespace().ToFullString();
+        var pendingChanges = new List<PendingChange>
+        {
+            new()
+            {
+                File = targetDocument.FilePath ?? typeName,
+                ChangeType = ChangeKind.Modify,
+                Description = $"Generate method stub '{methodName}' on {typeName}",
+                BeforeSnippet = $"// Type '{typeName}' (no method '{methodName}')",
+                AfterSnippet = afterSnippet
+            }
+        };
+
+        return RefactoringResult.PreviewResult(operationId, pendingChanges);
+    }
+
+    private static IEnumerable<SyntaxToken> ParseVisibilityTokens(string visibility)
+    {
+        var tokens = visibility
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(ParseVisibilityKeyword)
+            .ToList();
+
+        if (tokens.Count == 0)
+            tokens.Add(SyntaxFactory.Token(SyntaxKind.PrivateKeyword));
+
+        return tokens.Select(t => t.WithTrailingTrivia(SyntaxFactory.Space));
+    }
+
+    private static SyntaxToken ParseVisibilityKeyword(string keyword) => keyword.ToLowerInvariant() switch
+    {
+        "public" => SyntaxFactory.Token(SyntaxKind.PublicKeyword),
+        "private" => SyntaxFactory.Token(SyntaxKind.PrivateKeyword),
+        "protected" => SyntaxFactory.Token(SyntaxKind.ProtectedKeyword),
+        "internal" => SyntaxFactory.Token(SyntaxKind.InternalKeyword),
+        _ => SyntaxFactory.Token(SyntaxKind.PrivateKeyword)
+    };
+
+    internal static bool IsValidIdentifier(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return false;
+
+        if (name.StartsWith('@') && name.Length > 1)
+        {
+            var bare = name[1..];
+            return SyntaxFacts.IsValidIdentifier(bare) ||
+                   SyntaxFacts.GetKeywordKind(bare) != SyntaxKind.None;
+        }
+
+        if (!SyntaxFacts.IsValidIdentifier(name))
+            return false;
+
+        var keywordKind = SyntaxFacts.GetKeywordKind(name);
+        return keywordKind == SyntaxKind.None || !SyntaxFacts.IsReservedKeyword(keywordKind);
+    }
+
+    internal static bool IsValidTypeName(string typeName)
+    {
+        if (string.IsNullOrWhiteSpace(typeName))
+            return false;
+
+        var parsed = SyntaxFactory.ParseTypeName(typeName.Trim());
+        return parsed is not IdentifierNameSyntax { IsMissing: true }
+               && !parsed.ContainsDiagnostics;
+    }
+
+    private static bool TryGetSpecialTypeAlias(SpecialType specialType, out string alias)
+    {
+        alias = specialType switch
+        {
+            SpecialType.System_Boolean => "bool",
+            SpecialType.System_Byte => "byte",
+            SpecialType.System_SByte => "sbyte",
+            SpecialType.System_Int16 => "short",
+            SpecialType.System_UInt16 => "ushort",
+            SpecialType.System_Int32 => "int",
+            SpecialType.System_UInt32 => "uint",
+            SpecialType.System_Int64 => "long",
+            SpecialType.System_UInt64 => "ulong",
+            SpecialType.System_Single => "float",
+            SpecialType.System_Double => "double",
+            SpecialType.System_Decimal => "decimal",
+            SpecialType.System_Char => "char",
+            SpecialType.System_IntPtr => "nint",
+            SpecialType.System_UIntPtr => "nuint",
+            SpecialType.System_String => "string",
+            SpecialType.System_Object => "object",
+            SpecialType.System_Void => "void",
+            _ => ""
+        };
+        return alias.Length > 0;
+    }
+
+    private static bool IsUsableType(ITypeSymbol? type) =>
+        type != null && type.TypeKind != TypeKind.Error && type.SpecialType != SpecialType.System_Void;
+
+    private static bool IsSameType(INamedTypeSymbol left, INamedTypeSymbol right) =>
+        SymbolEqualityComparer.Default.Equals(left.OriginalDefinition, right.OriginalDefinition);
+
+    internal readonly record struct TargetResolution(
+        INamedTypeSymbol Type,
+        bool SameTypeAsCaller,
+        bool ReceiverIsTypeName);
+
+    internal readonly record struct InferredParameter(string Name, string TypeName);
+}

--- a/src/RoslynMcp.Server/McpServerHost.cs
+++ b/src/RoslynMcp.Server/McpServerHost.cs
@@ -78,6 +78,7 @@ public sealed class McpServerHost : IAsyncDisposable
         _toolRegistry.Register(new GenerateEqualsHashCodeTool(workspaceProvider));
         _toolRegistry.Register(new GenerateToStringTool(workspaceProvider));
         _toolRegistry.Register(new GeneratePropertyTool(workspaceProvider));
+        _toolRegistry.Register(new GenerateMethodStubTool(workspaceProvider));
         _toolRegistry.Register(new FormatDocumentTool(workspaceProvider));
         _toolRegistry.Register(new AddNullChecksTool(workspaceProvider));
 

--- a/src/RoslynMcp.Server/Tools/GenerateMethodStubTool.cs
+++ b/src/RoslynMcp.Server/Tools/GenerateMethodStubTool.cs
@@ -1,0 +1,166 @@
+using System.Text.Json;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.Refactoring;
+using RoslynMcp.Core.Refactoring.Generate;
+using RoslynMcp.Core.Workspace;
+using RoslynMcp.Server.Transport;
+
+namespace RoslynMcp.Server.Tools;
+
+/// <summary>
+/// MCP tool handler for generate_method_stub operation.
+/// </summary>
+public sealed class GenerateMethodStubTool : IToolHandler
+{
+    private readonly IWorkspaceProvider _workspaceProvider;
+    private readonly JsonSerializerOptions _jsonOptions;
+
+    /// <summary>
+    /// Creates a new generate method stub tool.
+    /// </summary>
+    public GenerateMethodStubTool(IWorkspaceProvider workspaceProvider)
+    {
+        _workspaceProvider = workspaceProvider;
+        _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = false
+        };
+    }
+
+    /// <inheritdoc />
+    public string Name => "generate_method_stub";
+
+    /// <inheritdoc />
+    public string Description =>
+        "Generate a method from an undefined call site, inferring the signature from usage. Placeholder body is throw new NotImplementedException();";
+
+    /// <inheritdoc />
+    public object InputSchema => new
+    {
+        type = "object",
+        required = new[] { "solutionPath", "sourceFile", "line", "column" },
+        properties = new
+        {
+            solutionPath = new
+            {
+                type = "string",
+                description = "Absolute path to the .sln or .csproj file"
+            },
+            sourceFile = new
+            {
+                type = "string",
+                description = "Absolute path to the file containing the call site"
+            },
+            line = new
+            {
+                type = "integer",
+                description = "1-based line number of the call site",
+                minimum = 1
+            },
+            column = new
+            {
+                type = "integer",
+                description = "1-based column number within the method name",
+                minimum = 1
+            },
+            methodName = new
+            {
+                type = "string",
+                description = "Method name override when not inferable from the location"
+            },
+            returnType = new
+            {
+                type = "string",
+                description = "Explicit return type override"
+            },
+            visibility = new
+            {
+                type = "string",
+                description = "Access modifier for the generated method",
+                @default = "private"
+            },
+            generateAsync = new
+            {
+                type = "boolean",
+                description = "Force async method generation",
+                @default = false
+            },
+            preview = new
+            {
+                type = "boolean",
+                description = "Return computed changes without applying",
+                @default = false
+            }
+        },
+        additionalProperties = false
+    };
+
+    /// <inheritdoc />
+    public async Task<ToolResult> ExecuteAsync(JsonElement? arguments, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (arguments == null)
+            {
+                return ToolResult.Error("Arguments required");
+            }
+
+            var args = JsonSerializer.Deserialize<GenerateMethodStubArgs>(arguments.Value.GetRawText(), _jsonOptions);
+            if (args == null)
+            {
+                return ToolResult.Error("Failed to parse arguments");
+            }
+
+            using var context = await _workspaceProvider.CreateContextAsync(
+                args.SolutionPath,
+                cancellationToken);
+
+            var operation = new GenerateMethodStubOperation(context);
+            var @params = new GenerateMethodStubParams
+            {
+                SourceFile = args.SourceFile,
+                Line = args.Line,
+                Column = args.Column,
+                MethodName = args.MethodName,
+                ReturnType = args.ReturnType,
+                Visibility = args.Visibility,
+                GenerateAsync = args.GenerateAsync ?? false,
+                Preview = args.Preview ?? false
+            };
+
+            var result = await operation.ExecuteAsync(@params, cancellationToken);
+
+            var json = JsonSerializer.Serialize(result, _jsonOptions);
+            return result.Success ? ToolResult.Success(json) : ToolResult.Error(json);
+        }
+        catch (RefactoringException ex)
+        {
+            var error = ex.ToError();
+            var json = JsonSerializer.Serialize(new { success = false, error }, _jsonOptions);
+            return ToolResult.Error(json);
+        }
+        catch (Exception ex)
+        {
+            var json = JsonSerializer.Serialize(new
+            {
+                success = false,
+                error = new { code = "INTERNAL_ERROR", message = ex.Message }
+            }, _jsonOptions);
+            return ToolResult.Error(json);
+        }
+    }
+
+    private sealed class GenerateMethodStubArgs
+    {
+        public string SolutionPath { get; init; } = "";
+        public string SourceFile { get; init; } = "";
+        public int Line { get; init; }
+        public int Column { get; init; }
+        public string? MethodName { get; init; }
+        public string? ReturnType { get; init; }
+        public string? Visibility { get; init; }
+        public bool? GenerateAsync { get; init; }
+        public bool? Preview { get; init; }
+    }
+}

--- a/tests/RoslynMcp.Cli.Tests/HelpGeneratorTests.cs
+++ b/tests/RoslynMcp.Cli.Tests/HelpGeneratorTests.cs
@@ -15,11 +15,11 @@ public class HelpGeneratorTests
     }
 
     [Fact]
-    public void GenerateGlobalHelp_Lists51Tools()
+    public void GenerateGlobalHelp_Lists52Tools()
     {
         var registry = ToolRegistry.BuildDefault();
         var help = HelpGenerator.GenerateGlobalHelp(registry);
-        Assert.Contains("Total: 51 tools", help);
+        Assert.Contains("Total: 52 tools", help);
         Assert.Contains("pull-members-up", help);
         Assert.Contains("push-members-down", help);
         Assert.Contains("use-base-type", help);
@@ -29,6 +29,7 @@ public class HelpGeneratorTests
         Assert.Contains("make-non-static", help);
         Assert.Contains("convert-to-block-body", help);
         Assert.Contains("generate-property", help);
+        Assert.Contains("generate-method-stub", help);
     }
 
     [Fact]

--- a/tests/RoslynMcp.Cli.Tests/ToolRegistryTests.cs
+++ b/tests/RoslynMcp.Cli.Tests/ToolRegistryTests.cs
@@ -6,11 +6,11 @@ namespace RoslynMcp.Cli.Tests;
 public class ToolRegistryTests
 {
     [Fact]
-    public void BuildDefault_Registers51Tools()
+    public void BuildDefault_Registers52Tools()
     {
         var registry = ToolRegistry.BuildDefault();
         var tools = registry.GetAllTools();
-        Assert.Equal(51, tools.Count);
+        Assert.Equal(52, tools.Count);
     }
 
     [Fact]
@@ -99,6 +99,7 @@ public class ToolRegistryTests
     [InlineData("convert-to-block-body", "Refactoring")]
     [InlineData("generate-constructor", "Refactoring")]
     [InlineData("generate-property", "Refactoring")]
+    [InlineData("generate-method-stub", "Refactoring")]
     [InlineData("add-missing-usings", "Refactoring")]
     [InlineData("format-document", "Refactoring")]
     [InlineData("get-symbol-info", "Query")]
@@ -111,11 +112,11 @@ public class ToolRegistryTests
     }
 
     [Fact]
-    public void RefactoringToolCount_Is38()
+    public void RefactoringToolCount_Is39()
     {
         var registry = ToolRegistry.BuildDefault();
         var count = registry.GetAllTools().Count(t => t.Category == "Refactoring");
-        Assert.Equal(38, count);
+        Assert.Equal(39, count);
     }
 
     [Fact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GenerateMethodStubOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GenerateMethodStubOperationTests.cs
@@ -1,0 +1,717 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+using RoslynMcp.Contracts.Errors;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.Refactoring;
+using RoslynMcp.Core.Refactoring.Generate;
+using RoslynMcp.Core.Workspace;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Refactoring.Generate;
+
+/// <summary>
+/// Operation-level tests for <see cref="GenerateMethodStubOperation"/>.
+/// </summary>
+public class GenerateMethodStubOperationTests
+{
+    #region Input Validation
+
+    [Fact]
+    public void Validate_MissingSourceFile_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            GenerateMethodStubOperation.Validate(new GenerateMethodStubParams
+            {
+                SourceFile = "",
+                Line = 1,
+                Column = 1
+            }));
+
+        Assert.Equal(ErrorCodes.MissingRequiredParam, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_RelativePath_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            GenerateMethodStubOperation.Validate(new GenerateMethodStubParams
+            {
+                SourceFile = "Types.cs",
+                Line = 1,
+                Column = 1
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidSourcePath, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_InvalidLine_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            GenerateMethodStubOperation.Validate(new GenerateMethodStubParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                Line = 0,
+                Column = 1
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidLineNumber, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_InvalidColumn_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            GenerateMethodStubOperation.Validate(new GenerateMethodStubParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                Line = 1,
+                Column = 0
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidColumnNumber, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_MissingFile_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            GenerateMethodStubOperation.Validate(new GenerateMethodStubParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                Line = 1,
+                Column = 1
+            }));
+
+        Assert.Equal(ErrorCodes.SourceFileNotFound, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_InvalidVisibility_Throws()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "RoslynMcpGenerateMethodStubVisibility.cs");
+        File.WriteAllText(path, "class C {}");
+        try
+        {
+            var ex = Assert.Throws<RefactoringException>(() =>
+                GenerateMethodStubOperation.Validate(new GenerateMethodStubParams
+                {
+                    SourceFile = path,
+                    Line = 1,
+                    Column = 1,
+                    Visibility = "secret"
+                }));
+
+            Assert.Equal(ErrorCodes.InvalidVisibility, ex.ErrorCode);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Validate_ReservedKeywordMethodName_Throws()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "RoslynMcpGenerateMethodStubKeyword.cs");
+        File.WriteAllText(path, "class C {}");
+        try
+        {
+            var ex = Assert.Throws<RefactoringException>(() =>
+                GenerateMethodStubOperation.Validate(new GenerateMethodStubParams
+                {
+                    SourceFile = path,
+                    Line = 1,
+                    Column = 1,
+                    MethodName = "class"
+                }));
+
+            Assert.Equal(ErrorCodes.InvalidSymbolName, ex.ErrorCode);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void IsValidIdentifier_ReservedKeyword_IsFalse()
+    {
+        Assert.False(GenerateMethodStubOperation.IsValidIdentifier("class"));
+        Assert.False(GenerateMethodStubOperation.IsValidIdentifier("namespace"));
+        Assert.True(GenerateMethodStubOperation.IsValidIdentifier("DoWork"));
+        Assert.True(GenerateMethodStubOperation.IsValidIdentifier("@class"));
+    }
+
+    #endregion
+
+    #region P0 Happy Path
+
+    [SkippableFact]
+    public async Task GenerateMethodStub_VoidOnSameClass_AddsPrivateMethod()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Widget
+            {
+                public void Run()
+                {
+                    DoWork();
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var (line, column) = FindIdentifier(source, "DoWork");
+        var operation = new GenerateMethodStubOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new GenerateMethodStubParams
+        {
+            SourceFile = workspace.SourcePath,
+            Line = line,
+            Column = column
+        });
+
+        Assert.True(result.Success);
+        Assert.False(result.Preview);
+        Assert.NotNull(result.Symbol);
+        Assert.Equal("DoWork", result.Symbol.Name);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("private void DoWork()", updated);
+        Assert.Contains("throw new NotImplementedException();", updated);
+    }
+
+    [SkippableFact]
+    public async Task GenerateMethodStub_Assignment_InfersReturnType()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Widget
+            {
+                public void Run()
+                {
+                    int value = Compute();
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var (line, column) = FindIdentifier(source, "Compute");
+        var operation = new GenerateMethodStubOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new GenerateMethodStubParams
+        {
+            SourceFile = workspace.SourcePath,
+            Line = line,
+            Column = column
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("private int Compute()", updated);
+        Assert.Contains("throw new NotImplementedException();", updated);
+    }
+
+    [SkippableFact]
+    public async Task GenerateMethodStub_Parameters_InfersArgumentTypesAndNames()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Widget
+            {
+                public void Run(string name)
+                {
+                    Process(name, 42);
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var (line, column) = FindIdentifier(source, "Process");
+        var operation = new GenerateMethodStubOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new GenerateMethodStubParams
+        {
+            SourceFile = workspace.SourcePath,
+            Line = line,
+            Column = column
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("private void Process(string name, int arg2)", updated);
+        Assert.Contains("throw new NotImplementedException();", updated);
+    }
+
+    [SkippableFact]
+    public async Task GenerateMethodStub_MethodOnOtherType_AddsPublicMethod()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Caller
+            {
+                public void Run(Processor processor)
+                {
+                    processor.Transform();
+                }
+            }
+
+            public class Processor
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var (line, column) = FindIdentifier(source, "Transform");
+        var operation = new GenerateMethodStubOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new GenerateMethodStubParams
+        {
+            SourceFile = workspace.SourcePath,
+            Line = line,
+            Column = column
+        });
+
+        Assert.True(result.Success);
+        Assert.Equal("Transform", result.Symbol!.Name);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("public void Transform()", updated);
+        Assert.Contains("class Processor", updated);
+        Assert.Contains("throw new NotImplementedException();", updated);
+    }
+
+    [SkippableFact]
+    public async Task GenerateMethodStub_StaticTypeCall_AddsStaticMethod()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Widget
+            {
+                public void Run()
+                {
+                    Helper.Compute(1);
+                }
+            }
+
+            public class Helper
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var (line, column) = FindIdentifier(source, "Compute");
+        var operation = new GenerateMethodStubOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new GenerateMethodStubParams
+        {
+            SourceFile = workspace.SourcePath,
+            Line = line,
+            Column = column
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("public static void Compute(int arg1)", updated);
+        Assert.Contains("throw new NotImplementedException();", updated);
+    }
+
+    [SkippableFact]
+    public async Task GenerateMethodStub_ThisReceiver_AddsPrivateMethodOnSameClass()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Widget
+            {
+                public void Run()
+                {
+                    this.DoWork();
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var (line, column) = FindIdentifier(source, "DoWork");
+        var operation = new GenerateMethodStubOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new GenerateMethodStubParams
+        {
+            SourceFile = workspace.SourcePath,
+            Line = line,
+            Column = column
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("private void DoWork()", updated);
+    }
+
+    [SkippableFact]
+    public async Task GenerateMethodStub_Preview_DoesNotWriteFiles()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Widget
+            {
+                public void Run()
+                {
+                    DoWork();
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var (line, column) = FindIdentifier(source, "DoWork");
+        var operation = new GenerateMethodStubOperation(workspace.Context);
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var result = await operation.ExecuteAsync(new GenerateMethodStubParams
+        {
+            SourceFile = workspace.SourcePath,
+            Line = line,
+            Column = column,
+            Preview = true
+        });
+
+        Assert.True(result.Success);
+        Assert.True(result.Preview);
+        Assert.NotNull(result.PendingChanges);
+        Assert.NotEmpty(result.PendingChanges);
+        Assert.Contains("DoWork", result.PendingChanges[0].AfterSnippet);
+        Assert.Contains("NotImplementedException", result.PendingChanges[0].AfterSnippet);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [SkippableFact]
+    public async Task GenerateMethodStub_ExplicitReturnType_OverridesInference()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Widget
+            {
+                public void Run()
+                {
+                    DoWork();
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var (line, column) = FindIdentifier(source, "DoWork");
+        var operation = new GenerateMethodStubOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new GenerateMethodStubParams
+        {
+            SourceFile = workspace.SourcePath,
+            Line = line,
+            Column = column,
+            ReturnType = "string"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("private string DoWork()", updated);
+    }
+
+    #endregion
+
+    #region Reject Cases
+
+    [SkippableFact]
+    public async Task GenerateMethodStub_NoCallSite_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Widget
+            {
+                public void Run()
+                {
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var (line, column) = FindIdentifier(source, "Widget");
+        var operation = new GenerateMethodStubOperation(workspace.Context);
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new GenerateMethodStubParams
+            {
+                SourceFile = workspace.SourcePath,
+                Line = line,
+                Column = column
+            }));
+
+        Assert.Equal(ErrorCodes.MethodNotFound, ex.ErrorCode);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [SkippableFact]
+    public async Task GenerateMethodStub_MethodAlreadyExists_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Widget
+            {
+                public void Run()
+                {
+                    DoWork();
+                }
+
+                private void DoWork()
+                {
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var (line, column) = FindIdentifier(source, "DoWork");
+        var operation = new GenerateMethodStubOperation(workspace.Context);
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new GenerateMethodStubParams
+            {
+                SourceFile = workspace.SourcePath,
+                Line = line,
+                Column = column
+            }));
+
+        Assert.Equal(ErrorCodes.NameCollision, ex.ErrorCode);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [SkippableFact]
+    public async Task GenerateMethodStub_CannotInferReturnType_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Widget
+            {
+                public void Run()
+                {
+                    var value = Mystery();
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var (line, column) = FindIdentifier(source, "Mystery");
+        var operation = new GenerateMethodStubOperation(workspace.Context);
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new GenerateMethodStubParams
+            {
+                SourceFile = workspace.SourcePath,
+                Line = line,
+                Column = column
+            }));
+
+        Assert.Equal(ErrorCodes.CannotInferReturnType, ex.ErrorCode);
+        Assert.Contains("returnType", ex.Message);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [SkippableFact]
+    public async Task GenerateMethodStub_ExternalTarget_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Widget
+            {
+                public void Run()
+                {
+                    "hello".Missing();
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var (line, column) = FindIdentifier(source, "Missing");
+        var operation = new GenerateMethodStubOperation(workspace.Context);
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new GenerateMethodStubParams
+            {
+                SourceFile = workspace.SourcePath,
+                Line = line,
+                Column = column
+            }));
+
+        Assert.Equal(ErrorCodes.DocumentNotEditable, ex.ErrorCode);
+        Assert.Contains("external", ex.Message);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [Fact]
+    public void GenerateMethodStub_UneditableDocument_Throws()
+    {
+        var workspace = new AdhocWorkspace();
+        var project = workspace.AddProject("P", LanguageNames.CSharp);
+        var document = workspace.AddDocument(project.Id, "Generated.cs", SourceText.From("class C {}"));
+
+        var ex = Assert.Throws<RefactoringException>(() =>
+            GenerateMethodStubOperation.ValidateDocumentIsEditable(document, workspace));
+
+        Assert.Equal(ErrorCodes.DocumentNotEditable, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task GenerateMethodStub_CannotInferReturnType_ExplicitTypeSucceeds()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Widget
+            {
+                public void Run()
+                {
+                    var value = Mystery();
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var (line, column) = FindIdentifier(source, "Mystery");
+        var operation = new GenerateMethodStubOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new GenerateMethodStubParams
+        {
+            SourceFile = workspace.SourcePath,
+            Line = line,
+            Column = column,
+            ReturnType = "int"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("private int Mystery()", updated);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static string AbsoluteTestPath() =>
+        Path.Combine(Path.GetTempPath(), "RoslynMcpGenerateMethodStubMissing.cs");
+
+    private static string NormalizeNewlines(string text) =>
+        text.Replace("\r\n", "\n", StringComparison.Ordinal);
+
+    private static (int Line, int Column) FindIdentifier(string source, string name)
+    {
+        var normalized = source.Replace("\r\n", "\n", StringComparison.Ordinal);
+        var lines = normalized.Split('\n');
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var idx = 0;
+            while ((idx = lines[i].IndexOf(name, idx, StringComparison.Ordinal)) >= 0)
+            {
+                var beforeOk = idx == 0 || !SyntaxFacts.IsIdentifierPartCharacter(lines[i][idx - 1]);
+                var after = idx + name.Length;
+                var afterOk = after >= lines[i].Length || !SyntaxFacts.IsIdentifierPartCharacter(lines[i][after]);
+                if (beforeOk && afterOk)
+                    return (i + 1, idx + 1);
+
+                idx += name.Length;
+            }
+        }
+
+        throw new InvalidOperationException($"Identifier '{name}' not found in source.");
+    }
+
+    private sealed class TempWorkspace : IAsyncDisposable
+    {
+        public required string DirectoryPath { get; init; }
+        public required string ProjectPath { get; init; }
+        public required string SourcePath { get; init; }
+        public required WorkspaceContext Context { get; init; }
+
+        public static async Task<TempWorkspace> CreateAsync(string source, string fileName = "Types.cs")
+        {
+            Skip.IfNot(ModuleInitializer.MsBuildAvailable, ModuleInitializer.MsBuildError ?? "MSBuild not available");
+
+            var directory = Path.Combine(Path.GetTempPath(), "RoslynMcpGenerateMethodStub_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(directory);
+
+            var projectPath = Path.Combine(directory, "TestApp.csproj");
+            var sourcePath = Path.Combine(directory, fileName);
+
+            await File.WriteAllTextAsync(projectPath, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net9.0</TargetFramework>
+                    <Nullable>enable</Nullable>
+                  </PropertyGroup>
+                </Project>
+                """);
+            await File.WriteAllTextAsync(sourcePath, source);
+
+            try
+            {
+                var provider = new MSBuildWorkspaceProvider();
+                var context = await provider.CreateContextAsync(projectPath);
+                if (context.GetDocumentByPath(sourcePath) == null)
+                {
+                    context.Dispose();
+                    throw new InvalidOperationException($"Workspace loaded but did not include {sourcePath}.");
+                }
+
+                return new TempWorkspace
+                {
+                    DirectoryPath = directory,
+                    ProjectPath = projectPath,
+                    SourcePath = sourcePath,
+                    Context = context
+                };
+            }
+            catch (Exception ex) when (ex is not SkipException)
+            {
+                try
+                {
+                    Directory.Delete(directory, recursive: true);
+                }
+                catch
+                {
+                    // ignore cleanup failures
+                }
+
+                Skip.If(true, $"Workspace load failed: {ex.Message}");
+                throw;
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            Context.Dispose();
+            await Task.Run(() =>
+            {
+                try
+                {
+                    Directory.Delete(DirectoryPath, recursive: true);
+                }
+                catch
+                {
+                    // ignore locked temp files
+                }
+            });
+        }
+    }
+
+    #endregion
+}

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GenerateMethodStubOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GenerateMethodStubOperationTests.cs
@@ -180,7 +180,7 @@ public class GenerateMethodStubOperationTests
         Assert.Equal("DoWork", result.Symbol.Name);
         var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
         Assert.Contains("private void DoWork()", updated);
-        Assert.Contains("throw new NotImplementedException();", updated);
+        Assert.Contains("throw new global::System.NotImplementedException();", updated);
     }
 
     [SkippableFact]
@@ -212,7 +212,7 @@ public class GenerateMethodStubOperationTests
         Assert.True(result.Success);
         var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
         Assert.Contains("private int Compute()", updated);
-        Assert.Contains("throw new NotImplementedException();", updated);
+        Assert.Contains("throw new global::System.NotImplementedException();", updated);
     }
 
     [SkippableFact]
@@ -244,7 +244,7 @@ public class GenerateMethodStubOperationTests
         Assert.True(result.Success);
         var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
         Assert.Contains("private void Process(string name, int arg2)", updated);
-        Assert.Contains("throw new NotImplementedException();", updated);
+        Assert.Contains("throw new global::System.NotImplementedException();", updated);
     }
 
     [SkippableFact]
@@ -282,7 +282,7 @@ public class GenerateMethodStubOperationTests
         var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
         Assert.Contains("public void Transform()", updated);
         Assert.Contains("class Processor", updated);
-        Assert.Contains("throw new NotImplementedException();", updated);
+        Assert.Contains("throw new global::System.NotImplementedException();", updated);
     }
 
     [SkippableFact]
@@ -318,7 +318,7 @@ public class GenerateMethodStubOperationTests
         Assert.True(result.Success);
         var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
         Assert.Contains("public static void Compute(int arg1)", updated);
-        Assert.Contains("throw new NotImplementedException();", updated);
+        Assert.Contains("throw new global::System.NotImplementedException();", updated);
     }
 
     [SkippableFact]
@@ -601,6 +601,318 @@ public class GenerateMethodStubOperationTests
         Assert.True(result.Success);
         var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
         Assert.Contains("private int Mystery()", updated);
+    }
+
+    #endregion
+
+    #region Review Fold
+
+    [SkippableFact]
+    public async Task GenerateMethodStub_AlreadyResolvedImplicitConversion_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Widget
+            {
+                public void Run()
+                {
+                    M(1);
+                }
+
+                private void M(long value)
+                {
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var (line, column) = FindIdentifier(source, "M");
+        var operation = new GenerateMethodStubOperation(workspace.Context);
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new GenerateMethodStubParams
+            {
+                SourceFile = workspace.SourcePath,
+                Line = line,
+                Column = column
+            }));
+
+        Assert.Equal(ErrorCodes.NameCollision, ex.ErrorCode);
+        Assert.Contains("already resolves", ex.Message);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [SkippableFact]
+    public async Task GenerateMethodStub_AlreadyResolvedOptionalParameter_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Widget
+            {
+                public void Run()
+                {
+                    M();
+                }
+
+                private void M(int value = 0)
+                {
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var (line, column) = FindIdentifier(source, "M");
+        var operation = new GenerateMethodStubOperation(workspace.Context);
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new GenerateMethodStubParams
+            {
+                SourceFile = workspace.SourcePath,
+                Line = line,
+                Column = column
+            }));
+
+        Assert.Equal(ErrorCodes.NameCollision, ex.ErrorCode);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [SkippableFact]
+    public async Task GenerateMethodStub_RefParameter_PreservesRefKind()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Widget
+            {
+                public void Run()
+                {
+                    int value = 1;
+                    Process(ref value);
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var (line, column) = FindIdentifier(source, "Process");
+        var operation = new GenerateMethodStubOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new GenerateMethodStubParams
+        {
+            SourceFile = workspace.SourcePath,
+            Line = line,
+            Column = column
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("private void Process(ref int value)", updated);
+        Assert.Contains("throw new global::System.NotImplementedException();", updated);
+    }
+
+    [SkippableFact]
+    public async Task GenerateMethodStub_OutAndInParameters_PreserveRefKind()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Widget
+            {
+                public void Run()
+                {
+                    int value = 1;
+                    Combine(in value, out int result);
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var (line, column) = FindIdentifier(source, "Combine");
+        var operation = new GenerateMethodStubOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new GenerateMethodStubParams
+        {
+            SourceFile = workspace.SourcePath,
+            Line = line,
+            Column = column
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("private void Combine(in int value, out int result)", updated);
+    }
+
+    [SkippableFact]
+    public async Task GenerateMethodStub_GenericInvocation_PreservesTypeParameters()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Widget
+            {
+                public void Run()
+                {
+                    Missing<int, string>();
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var (line, column) = FindIdentifier(source, "Missing");
+        var operation = new GenerateMethodStubOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new GenerateMethodStubParams
+        {
+            SourceFile = workspace.SourcePath,
+            Line = line,
+            Column = column
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("private void Missing<T, T2>()", updated);
+        Assert.Contains("Missing<int, string>();", updated);
+    }
+
+    [SkippableFact]
+    public async Task GenerateMethodStub_StaticConstructor_GeneratesStaticMethod()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Widget
+            {
+                static Widget()
+                {
+                    DoWork();
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var (line, column) = FindIdentifier(source, "DoWork");
+        var operation = new GenerateMethodStubOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new GenerateMethodStubParams
+        {
+            SourceFile = workspace.SourcePath,
+            Line = line,
+            Column = column
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("private static void DoWork()", updated);
+    }
+
+    [SkippableFact]
+    public async Task GenerateMethodStub_StaticPropertyAccessor_GeneratesStaticMethod()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Widget
+            {
+                public static int Value
+                {
+                    get
+                    {
+                        Init();
+                        return 0;
+                    }
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var (line, column) = FindIdentifier(source, "Init");
+        var operation = new GenerateMethodStubOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new GenerateMethodStubParams
+        {
+            SourceFile = workspace.SourcePath,
+            Line = line,
+            Column = column
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("private static void Init()", updated);
+    }
+
+    [SkippableFact]
+    public async Task GenerateMethodStub_MethodNameOverride_RewritesCallSite()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Widget
+            {
+                public void Run()
+                {
+                    DoWork();
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var (line, column) = FindIdentifier(source, "DoWork");
+        var operation = new GenerateMethodStubOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new GenerateMethodStubParams
+        {
+            SourceFile = workspace.SourcePath,
+            Line = line,
+            Column = column,
+            MethodName = "Execute"
+        });
+
+        Assert.True(result.Success);
+        Assert.Equal("Execute", result.Symbol!.Name);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("Execute();", updated);
+        Assert.DoesNotContain("DoWork();", updated);
+        Assert.Contains("private void Execute()", updated);
+        Assert.DoesNotContain("private void DoWork()", updated);
+    }
+
+    [SkippableFact]
+    public async Task GenerateMethodStub_MethodNameOverride_PreviewRewritesCallSiteWithoutWriting()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Widget
+            {
+                public void Run()
+                {
+                    DoWork();
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var (line, column) = FindIdentifier(source, "DoWork");
+        var operation = new GenerateMethodStubOperation(workspace.Context);
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var result = await operation.ExecuteAsync(new GenerateMethodStubParams
+        {
+            SourceFile = workspace.SourcePath,
+            Line = line,
+            Column = column,
+            MethodName = "Execute",
+            Preview = true
+        });
+
+        Assert.True(result.Success);
+        Assert.True(result.Preview);
+        Assert.NotNull(result.PendingChanges);
+        Assert.Contains(result.PendingChanges, change => change.AfterSnippet?.Contains("Execute") == true);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
     }
 
     #endregion

--- a/tests/RoslynMcp.Server.Tests/Tools/GenerateMethodStubToolTests.cs
+++ b/tests/RoslynMcp.Server.Tests/Tools/GenerateMethodStubToolTests.cs
@@ -1,0 +1,122 @@
+using System.Text.Json;
+using RoslynMcp.Server.Tests.TestHelpers;
+using RoslynMcp.Server.Tools;
+using RoslynMcp.Server.Transport;
+using Xunit;
+
+namespace RoslynMcp.Server.Tests.Tools;
+
+/// <summary>
+/// Unit tests for GenerateMethodStubTool.
+/// Tests tool definition and argument validation.
+/// </summary>
+public class GenerateMethodStubToolTests
+{
+    private readonly GenerateMethodStubTool _tool;
+
+    public GenerateMethodStubToolTests()
+    {
+        _tool = new GenerateMethodStubTool(new ThrowingWorkspaceProvider());
+    }
+
+    #region GetDefinition Tests
+
+    [Fact]
+    public void GetDefinition_ReturnsCorrectName()
+    {
+        Assert.Equal("generate_method_stub", _tool.Name);
+    }
+
+    [Fact]
+    public void GetDefinition_ReturnsNonEmptyDescription()
+    {
+        Assert.NotNull(_tool.Description);
+        Assert.NotEmpty(_tool.Description);
+    }
+
+    [Fact]
+    public void GetDefinition_ReturnsCorrectSchema()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.Equal("object", root.GetProperty("type").GetString());
+        Assert.True(root.TryGetProperty("properties", out _));
+        Assert.True(root.TryGetProperty("required", out _));
+    }
+
+    [Fact]
+    public void GetDefinition_HasRequiredFields()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var required = doc.RootElement.GetProperty("required");
+
+        var requiredFields = new List<string>();
+        foreach (var item in required.EnumerateArray())
+        {
+            requiredFields.Add(item.GetString()!);
+        }
+
+        Assert.Contains("solutionPath", requiredFields);
+        Assert.Contains("sourceFile", requiredFields);
+        Assert.Contains("line", requiredFields);
+        Assert.Contains("column", requiredFields);
+    }
+
+    [Fact]
+    public void GetDefinition_HasProperties_ForAllParameters()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var properties = doc.RootElement.GetProperty("properties");
+
+        Assert.True(properties.TryGetProperty("solutionPath", out _));
+        Assert.True(properties.TryGetProperty("sourceFile", out _));
+        Assert.True(properties.TryGetProperty("line", out _));
+        Assert.True(properties.TryGetProperty("column", out _));
+        Assert.True(properties.TryGetProperty("methodName", out _));
+        Assert.True(properties.TryGetProperty("returnType", out _));
+        Assert.True(properties.TryGetProperty("visibility", out _));
+        Assert.True(properties.TryGetProperty("generateAsync", out _));
+        Assert.True(properties.TryGetProperty("preview", out _));
+    }
+
+    #endregion
+
+    #region ExecuteAsync Argument Validation Tests
+
+    [Fact]
+    public async Task ExecuteAsync_NullArguments_ReturnsError()
+    {
+        var result = await _tool.ExecuteAsync(null);
+
+        Assert.True(result.IsError);
+        Assert.Contains("Arguments required", GetResultText(result));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EmptyArguments_ReturnsError()
+    {
+        var args = JsonDocument.Parse("{}").RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static string GetResultText(ToolResult result)
+    {
+        return result.Content.FirstOrDefault()?.Text ?? string.Empty;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds `generate_method_stub` / `GenerateMethodStubOperation` as Generate Phase 2 from `Design/Expansion/Phase2/Arch-Generate-Operations.md` (table 1.1, §9 Phase 2) and `Design/Expansion/Phase2/BA-Generate-Operations.md` (§3 UC-GEN-03). Placement is next to the other Generate operations.

Started from current `master` (`d10889e`, generate_property #49) so this increment does not conflict with that work.

A selected undefined call site can generate a method stub that:
- Infers the target type from the receiver (`this` / implicit → same class, private by default; other type; static `Type.Method()`)
- Infers parameter types from arguments and the return type from usage
- Uses a placeholder body: `throw new global::System.NotImplementedException();`

Preview computes the method and does not write files.

Rejects:
- No call site at the location
- Method with a compatible signature already exists
- Call that already resolves (implicit conversion, optional/`params`)
- Uneditable document
- Cannot infer return type (unless `returnType` is provided)
- External / uneditable target type

Review fold (Codex TAKEs):
- Reject invocations that already bind, so a new throwing overload cannot steal resolution (`M(1)` when `M(long)` exists)
- Fully qualify `global::System.NotImplementedException`
- Preserve `ref` / `in` / `out` on inferred parameters
- Preserve generic arity and type-parameter list (`Missing<int, string>()` → `Missing<T, T2>()`)
- Static constructors and static property/event accessors generate static methods
- `methodName` override rewrites the call site (preview included) so the original name is not left undefined

## Related Issues

Closes #50

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Test additions or updates

## Testing

- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Manual testing performed (operation + MCP tool + CLI registry tests locally)

P0 coverage plus review-fold tests:
- Happy path: void method on same class, returning method from assignment, parameters from arguments, method on another type, static `Type.Method()`, explicit `this`, preview, explicit `returnType`
- Rejects: no call site, method already exists, already-resolved implicit conversion / optional parameter, cannot infer return type (`var`), uneditable document, external target (`string.Missing()`)
- Explicit `returnType` recovers the `var` case
- `ref` / `in` / `out` parameters preserved
- Generic invocation keeps type parameters
- Static constructor and static property accessor emit static methods
- `methodName` override rewrites the call site; preview does not write files
- MCP + CLI registration; tool count **51 → 52**; refactoring category **38 → 39**

Local results on Linux / .NET 9.0.317:
- GenerateMethodStub operation tests: 31 passed
- GenerateMethodStub MCP tool tests: 7 passed
- Full suite (pre-review-fold): 1035 passed (Core 520, Server 414, CLI 101), 0 failed

**Test Configuration**:
- OS: Linux
- .NET Version: 9.0.317

## Additional Notes

Follows existing Generate* operation patterns (`GeneratePropertyOperation`, `GenerateConstructorOperation`). Out of scope: `implement_abstract`, encapsulate, undo, Bank of America STAR, a second leftover.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab614b4d-5120-4737-8a33-01dc1d319933?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab614b4d-5120-4737-8a33-01dc1d319933&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

