### PR TITLE
Add implement_abstract refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - `convert_to_block_body` — convert a selected expression-bodied member (`=> expr`) to a block body (`{ return expr; }` or `{ expr; }` as appropriate), including properties and accessors, with preview mode and rejects for missing symbols, already-block bodies, unsupported members, and uneditable documents
 - `generate_property` — generate an auto-property `{ get; set; }`, init-only property `{ get; init; }`, or backing-field property `{ get => field; set => field = value; }` on a selected type, with preview mode and rejects for missing symbols, uneditable documents, unsupported targets, and name clashes
 - `generate_method_stub` — generate a method from an undefined call site, inferring target type, parameters, and return type from usage, with a `throw new NotImplementedException();` body, preview mode, and rejects for missing call sites, existing methods, uneditable or external targets, and uninferable return types
+- `implement_abstract` — generate implementation stubs for unimplemented abstract methods and properties inherited by a selected class, with a `throw new NotImplementedException();` body, preview mode, and rejects for missing symbols, no unimplemented abstract members, uneditable documents, and unsupported targets
 
 ## [0.4.0] - 2026-02-23
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Let AI assistants like Claude safely refactor your C# codebase using the same Roslyn compiler platform that powers Visual Studio.
 
-Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that exposes **52 Roslyn-powered tools** to AI assistants and other MCP clients. It combines 29 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 8 code conversion tools -- giving your AI deep code intelligence, comprehensive refactoring, and modern C# syntax transformations with full solution-wide reference tracking and preview support.
+Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that exposes **53 Roslyn-powered tools** to AI assistants and other MCP clients. It combines 29 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 5 code generation tools, and 8 code conversion tools -- giving your AI deep code intelligence, comprehensive refactoring, and modern C# syntax transformations with full solution-wide reference tracking and preview support.
 
 ---
 
@@ -30,7 +30,7 @@ Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotoc
 
 ## Why RoslynMcpServer?
 
-- **52 tools** -- refactoring, navigation, analysis, generation, and conversion tools, the most comprehensive Roslyn MCP server available
+- **53 tools** -- refactoring, navigation, analysis, generation, and conversion tools, the most comprehensive Roslyn MCP server available
 - **Preview mode on every operation** -- see exactly what will change before applying
 - **Atomic file writes with rollback** -- if any file write fails, all changes are reverted
 - **Solution-wide reference updates** -- renames and moves propagate across your entire solution
@@ -102,7 +102,7 @@ Claude will use the `rename_symbol` tool to rename the class and update every re
 
 ## Standalone CLI
 
-All 52 tools are also available as a standalone CLI for use in scripts, CI/CD pipelines, and terminals without an AI assistant.
+All 53 tools are also available as a standalone CLI for use in scripts, CI/CD pipelines, and terminals without an AI assistant.
 
 ### Install
 
@@ -232,6 +232,7 @@ All tools accept a `solutionPath` parameter (absolute path to a `.sln`, `.slnx`,
 | `generate_method_stub` | Generate a method from an undefined call site, inferring the signature from usage. Placeholder body is `throw new NotImplementedException();`. | `sourceFile`, `line`, `column`, `methodName`, `returnType`, `visibility`, `generateAsync` |
 | `generate_overrides` | Generate override methods for base class virtual/abstract members. | `sourceFile`, `typeName`, `members`, `callBase` |
 | `implement_interface` | Generate interface member implementations for a type. | `sourceFile`, `typeName`, `interfaceName`, `explicitImplementation`, `members` |
+| `implement_abstract` | Generate implementation stubs for unimplemented abstract members inherited by a selected class. Placeholder body is `throw new NotImplementedException();`. | `sourceFile`, `typeName`, `members` |
 
 ### Convert
 

--- a/src/RoslynMcp.Cli/ToolRegistry.cs
+++ b/src/RoslynMcp.Cli/ToolRegistry.cs
@@ -47,7 +47,7 @@ public sealed class ToolEntry
 }
 
 /// <summary>
-/// Maps tool names to execution delegates for all 52 Roslyn tools.
+/// Maps tool names to execution delegates for all 53 Roslyn tools.
 /// </summary>
 public sealed class ToolRegistry
 {
@@ -139,7 +139,7 @@ public sealed class ToolRegistry
         _tools.Values.OrderBy(t => t.Category).ThenBy(t => t.Name).ToList();
 
     /// <summary>
-    /// Build the default registry with all 52 tools registered.
+    /// Build the default registry with all 53 tools registered.
     /// </summary>
     public static ToolRegistry BuildDefault()
     {
@@ -207,7 +207,7 @@ public sealed class ToolRegistry
         r.RegisterRefactoring<ConvertToPatternMatchingOperation, ConvertToPatternMatchingParams>(
             "convert-to-pattern-matching", "Convert type checks to pattern matching");
 
-        // ── Refactoring: Generate (8) ─────────────────────────────────
+        // ── Refactoring: Generate (9) ─────────────────────────────────
         r.RegisterRefactoring<GenerateConstructorOperation, GenerateConstructorParams>(
             "generate-constructor", "Generate a constructor from fields/properties");
         r.RegisterRefactoring<GeneratePropertyOperation, GeneratePropertyParams>(
@@ -222,6 +222,8 @@ public sealed class ToolRegistry
             "generate-tostring", "Generate a ToString override");
         r.RegisterRefactoring<ImplementInterfaceOperation, ImplementInterfaceParams>(
             "implement-interface", "Generate implementation stubs for an interface");
+        r.RegisterRefactoring<ImplementAbstractOperation, ImplementAbstractParams>(
+            "implement-abstract", "Generate implementation stubs for unimplemented abstract members inherited by a class");
         r.RegisterRefactoring<AddNullChecksOperation, AddNullChecksParams>(
             "add-null-checks", "Add null checks to method parameters");
 

--- a/src/RoslynMcp.Contracts/Enums/RefactoringKind.cs
+++ b/src/RoslynMcp.Contracts/Enums/RefactoringKind.cs
@@ -79,6 +79,9 @@ public enum RefactoringKind
     /// <summary>Implement interface members.</summary>
     ImplementInterface,
 
+    /// <summary>Implement inherited abstract members.</summary>
+    ImplementAbstract,
+
     // Organize Operations
     /// <summary>Sort using directives.</summary>
     SortUsings,

--- a/src/RoslynMcp.Contracts/Errors/ErrorCodes.cs
+++ b/src/RoslynMcp.Contracts/Errors/ErrorCodes.cs
@@ -398,6 +398,9 @@ public static class ErrorCodes
     /// <summary>Cannot infer a return type from the call-site usage; provide returnType.</summary>
     public const string CannotInferReturnType = "3125";
 
+    /// <summary>No unimplemented abstract members remain on the selected type.</summary>
+    public const string NoUnimplementedAbstractMembers = "3126";
+
     // ============================================
     // System Errors (4xxx)
     // ============================================

--- a/src/RoslynMcp.Contracts/Models/ImplementAbstractParams.cs
+++ b/src/RoslynMcp.Contracts/Models/ImplementAbstractParams.cs
@@ -1,0 +1,27 @@
+namespace RoslynMcp.Contracts.Models;
+
+/// <summary>
+/// Parameters for the implement_abstract tool.
+/// </summary>
+public sealed class ImplementAbstractParams
+{
+    /// <summary>
+    /// Absolute path to the source file containing the type.
+    /// </summary>
+    public required string SourceFile { get; init; }
+
+    /// <summary>
+    /// Name of the class to implement inherited abstract members on.
+    /// </summary>
+    public required string TypeName { get; init; }
+
+    /// <summary>
+    /// Names of specific abstract members to implement. If null, implements all missing members.
+    /// </summary>
+    public IReadOnlyList<string>? Members { get; init; }
+
+    /// <summary>
+    /// Return computed changes without applying. Default: false.
+    /// </summary>
+    public bool Preview { get; init; }
+}

--- a/src/RoslynMcp.Core/Refactoring/Generate/ImplementAbstractOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/ImplementAbstractOperation.cs
@@ -182,6 +182,7 @@ public sealed class ImplementAbstractOperation : RefactoringOperationBase<Implem
             MemberDeclarationSyntax? impl = member switch
             {
                 IMethodSymbol method => CreateMethodStub(method),
+                IPropertySymbol { IsIndexer: true } indexer => CreateIndexerStub(indexer),
                 IPropertySymbol property => CreatePropertyStub(property),
                 _ => null
             };
@@ -201,7 +202,7 @@ public sealed class ImplementAbstractOperation : RefactoringOperationBase<Implem
     {
         var parameters = method.Parameters.Select(CreateParameter);
         var methodDecl = SyntaxFactory.MethodDeclaration(
-                SyntaxFactory.ParseTypeName(method.ReturnType.ToDisplayString()).WithTrailingTrivia(SyntaxFactory.Space),
+                CreateMemberType(method.ReturnType, method.ReturnsByRef, method.ReturnsByRefReadonly),
                 method.Name)
             .WithModifiers(CreateOverrideModifiers(method.DeclaredAccessibility))
             .WithParameterList(SyntaxFactory.ParameterList(SyntaxFactory.SeparatedList(parameters)))
@@ -220,31 +221,105 @@ public sealed class ImplementAbstractOperation : RefactoringOperationBase<Implem
     /// <summary>
     /// Creates an override property stub whose accessors throw
     /// <c>new global::System.NotImplementedException()</c>.
+    /// Preserves init setters, accessor-specific accessibility, and required.
     /// </summary>
     internal static PropertyDeclarationSyntax CreatePropertyStub(IPropertySymbol property)
+    {
+        return SyntaxFactory.PropertyDeclaration(
+                CreateMemberType(property.Type, property.ReturnsByRef, property.ReturnsByRefReadonly),
+                property.Name)
+            .WithModifiers(CreateOverrideModifiers(property.DeclaredAccessibility, property.IsRequired))
+            .WithAccessorList(SyntaxFactory.AccessorList(SyntaxFactory.List(CreateAccessors(property))))
+            .NormalizeWhitespace();
+    }
+
+    /// <summary>
+    /// Creates an override indexer stub whose accessors throw
+    /// <c>new global::System.NotImplementedException()</c>.
+    /// </summary>
+    internal static IndexerDeclarationSyntax CreateIndexerStub(IPropertySymbol indexer)
+    {
+        var parameters = indexer.Parameters.Select(CreateParameter);
+        return SyntaxFactory.IndexerDeclaration(
+                CreateMemberType(indexer.Type, indexer.ReturnsByRef, indexer.ReturnsByRefReadonly))
+            .WithModifiers(CreateOverrideModifiers(indexer.DeclaredAccessibility, indexer.IsRequired))
+            .WithParameterList(SyntaxFactory.BracketedParameterList(SyntaxFactory.SeparatedList(parameters)))
+            .WithAccessorList(SyntaxFactory.AccessorList(SyntaxFactory.List(CreateAccessors(indexer))))
+            .NormalizeWhitespace();
+    }
+
+    private static List<AccessorDeclarationSyntax> CreateAccessors(IPropertySymbol property)
     {
         var accessors = new List<AccessorDeclarationSyntax>();
 
         if (property.GetMethod != null)
         {
-            accessors.Add(
-                SyntaxFactory.AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
-                    .WithBody(CreateThrowNotImplementedBody()));
+            accessors.Add(CreateAccessor(
+                property.GetMethod,
+                property.DeclaredAccessibility,
+                SyntaxKind.GetAccessorDeclaration));
         }
 
         if (property.SetMethod != null)
         {
-            accessors.Add(
-                SyntaxFactory.AccessorDeclaration(SyntaxKind.SetAccessorDeclaration)
-                    .WithBody(CreateThrowNotImplementedBody()));
+            var kind = property.SetMethod.IsInitOnly
+                ? SyntaxKind.InitAccessorDeclaration
+                : SyntaxKind.SetAccessorDeclaration;
+            accessors.Add(CreateAccessor(property.SetMethod, property.DeclaredAccessibility, kind));
         }
 
-        return SyntaxFactory.PropertyDeclaration(
-                SyntaxFactory.ParseTypeName(property.Type.ToDisplayString()).WithTrailingTrivia(SyntaxFactory.Space),
-                property.Name)
-            .WithModifiers(CreateOverrideModifiers(property.DeclaredAccessibility))
-            .WithAccessorList(SyntaxFactory.AccessorList(SyntaxFactory.List(accessors)))
-            .NormalizeWhitespace();
+        return accessors;
+    }
+
+    private static AccessorDeclarationSyntax CreateAccessor(
+        IMethodSymbol accessor,
+        Accessibility propertyAccessibility,
+        SyntaxKind kind)
+    {
+        var declaration = SyntaxFactory.AccessorDeclaration(kind)
+            .WithBody(CreateThrowNotImplementedBody());
+
+        var modifiers = CreateAccessorModifiers(accessor.DeclaredAccessibility, propertyAccessibility);
+        if (modifiers.Count > 0)
+            declaration = declaration.WithModifiers(modifiers);
+
+        return declaration;
+    }
+
+    private static SyntaxTokenList CreateAccessorModifiers(
+        Accessibility accessorAccessibility,
+        Accessibility propertyAccessibility)
+    {
+        if (accessorAccessibility == Accessibility.NotApplicable
+            || accessorAccessibility == propertyAccessibility)
+        {
+            return default;
+        }
+
+        return SyntaxFactory.TokenList(ParseAccessibility(accessorAccessibility));
+    }
+
+    private static TypeSyntax CreateMemberType(ITypeSymbol type, bool returnsByRef, bool returnsByRefReadonly)
+    {
+        var inner = SyntaxFactory.ParseTypeName(type.ToDisplayString());
+        if (returnsByRefReadonly)
+        {
+            return SyntaxFactory.RefType(
+                    SyntaxFactory.Token(SyntaxKind.RefKeyword).WithTrailingTrivia(SyntaxFactory.Space),
+                    SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword).WithTrailingTrivia(SyntaxFactory.Space),
+                    inner)
+                .WithTrailingTrivia(SyntaxFactory.Space);
+        }
+
+        if (returnsByRef)
+        {
+            return SyntaxFactory.RefType(
+                    SyntaxFactory.Token(SyntaxKind.RefKeyword).WithTrailingTrivia(SyntaxFactory.Space),
+                    inner)
+                .WithTrailingTrivia(SyntaxFactory.Space);
+        }
+
+        return inner.WithTrailingTrivia(SyntaxFactory.Space);
     }
 
     internal static BlockSyntax CreateThrowNotImplementedBody()
@@ -276,11 +351,13 @@ public sealed class ImplementAbstractOperation : RefactoringOperationBase<Implem
             SyntaxFactory.Token(refKeyword).WithTrailingTrivia(SyntaxFactory.Space)));
     }
 
-    private static SyntaxTokenList CreateOverrideModifiers(Accessibility accessibility)
+    private static SyntaxTokenList CreateOverrideModifiers(Accessibility accessibility, bool isRequired = false)
     {
         var tokens = new List<SyntaxToken>();
         tokens.AddRange(ParseAccessibility(accessibility));
         tokens.Add(SyntaxFactory.Token(SyntaxKind.OverrideKeyword).WithTrailingTrivia(SyntaxFactory.Space));
+        if (isRequired)
+            tokens.Add(SyntaxFactory.Token(SyntaxKind.RequiredKeyword).WithTrailingTrivia(SyntaxFactory.Space));
         return SyntaxFactory.TokenList(tokens);
     }
 

--- a/src/RoslynMcp.Core/Refactoring/Generate/ImplementAbstractOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/ImplementAbstractOperation.cs
@@ -1,0 +1,356 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using RoslynMcp.Contracts.Enums;
+using RoslynMcp.Contracts.Errors;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.FileSystem;
+using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Resolution;
+using RoslynMcp.Core.Workspace;
+
+namespace RoslynMcp.Core.Refactoring.Generate;
+
+/// <summary>
+/// Generates implementation stubs for unimplemented abstract members inherited
+/// by a selected class. Placeholder bodies are
+/// <c>throw new global::System.NotImplementedException();</c>.
+/// </summary>
+public sealed class ImplementAbstractOperation : RefactoringOperationBase<ImplementAbstractParams>
+{
+    /// <summary>
+    /// Creates a new implement abstract operation.
+    /// </summary>
+    /// <param name="context">Workspace context.</param>
+    public ImplementAbstractOperation(WorkspaceContext context) : base(context)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override void ValidateParams(ImplementAbstractParams @params) => Validate(@params);
+
+    /// <summary>
+    /// Validates implement-abstract parameters. Internal so tests can exercise
+    /// input rules without loading a workspace.
+    /// </summary>
+    internal static void Validate(ImplementAbstractParams @params)
+    {
+        if (string.IsNullOrWhiteSpace(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "sourceFile is required.");
+
+        if (string.IsNullOrWhiteSpace(@params.TypeName))
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "typeName is required.");
+
+        if (!PathResolver.IsAbsolutePath(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.InvalidSourcePath, "sourceFile must be an absolute path.");
+
+        if (!PathResolver.IsValidCSharpFilePath(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.InvalidSourcePath, "sourceFile must be a .cs file.");
+
+        if (!File.Exists(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.SourceFileNotFound, $"Source file not found: {@params.SourceFile}");
+    }
+
+    /// <summary>
+    /// Rejects documents that cannot receive source edits.
+    /// </summary>
+    internal static void ValidateDocumentIsEditable(Document document, Microsoft.CodeAnalysis.Workspace workspace)
+    {
+        if (document is SourceGeneratedDocument)
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable (source-generated).");
+        }
+
+        if (string.IsNullOrWhiteSpace(document.FilePath) || !File.Exists(document.FilePath))
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable.");
+        }
+
+        if (!workspace.CanApplyChange(ApplyChangesKind.ChangeDocument))
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable (workspace cannot apply changes).");
+        }
+    }
+
+    /// <inheritdoc />
+    protected override async Task<RefactoringResult> ExecuteCoreAsync(
+        Guid operationId,
+        ImplementAbstractParams @params,
+        CancellationToken cancellationToken)
+    {
+        var document = GetDocumentOrThrow(@params.SourceFile);
+        ValidateDocumentIsEditable(document, Context.Workspace);
+
+        var root = await document.GetSyntaxRootAsync(cancellationToken);
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken);
+        if (root == null || semanticModel == null)
+            throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse file.");
+
+        var typeDecl = root.DescendantNodes()
+            .OfType<BaseTypeDeclarationSyntax>()
+            .FirstOrDefault(t => t.Identifier.Text == @params.TypeName);
+
+        if (typeDecl == null)
+        {
+            throw new RefactoringException(
+                ErrorCodes.SymbolNotFound,
+                $"No type named '{@params.TypeName}' found in the source file.");
+        }
+
+        if (semanticModel.GetDeclaredSymbol(typeDecl, cancellationToken) is not INamedTypeSymbol typeSymbol)
+        {
+            throw new RefactoringException(
+                ErrorCodes.SymbolNotFound,
+                $"Could not resolve a symbol for type '{@params.TypeName}'.");
+        }
+
+        ValidateTypeCanHostAbstractImplementations(typeSymbol);
+
+        if (typeDecl is not TypeDeclarationSyntax hostTypeDecl)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidSymbolKind,
+                $"Type '{typeSymbol.Name}' is not a supported target for implement_abstract.");
+        }
+
+        var unimplemented = MemberAnalyzer.GetUnimplementedAbstractMembers(typeSymbol).ToList();
+
+        if (@params.Members != null && @params.Members.Count > 0)
+        {
+            var requested = new HashSet<string>(@params.Members, StringComparer.Ordinal);
+            unimplemented = unimplemented.Where(m => requested.Contains(m.Name)).ToList();
+        }
+
+        if (unimplemented.Count == 0)
+        {
+            throw new RefactoringException(
+                ErrorCodes.NoUnimplementedAbstractMembers,
+                $"Type '{typeSymbol.Name}' has no unimplemented abstract members.");
+        }
+
+        var implementations = GenerateImplementations(unimplemented);
+
+        if (@params.Preview)
+            return CreatePreviewResult(operationId, @params, unimplemented, implementations);
+
+        var newTypeDeclaration = AddMembers(hostTypeDecl, implementations);
+        var newRoot = root.ReplaceNode(hostTypeDecl, newTypeDeclaration);
+        var newDocument = document.WithSyntaxRoot(newRoot);
+        var commitResult = await CommitChangesAsync(newDocument.Project.Solution, cancellationToken);
+
+        return RefactoringResult.Succeeded(
+            operationId,
+            new FileChanges
+            {
+                FilesModified = commitResult.FilesModified,
+                FilesCreated = commitResult.FilesCreated,
+                FilesDeleted = commitResult.FilesDeleted
+            },
+            new Contracts.Models.SymbolInfo
+            {
+                Name = @params.TypeName,
+                FullyQualifiedName = typeSymbol.ToDisplayString(),
+                Kind = Contracts.Enums.SymbolKind.Class
+            },
+            0,
+            0);
+    }
+
+    internal static void ValidateTypeCanHostAbstractImplementations(INamedTypeSymbol typeSymbol)
+    {
+        if (typeSymbol.IsStatic
+            || typeSymbol.TypeKind is TypeKind.Enum or TypeKind.Delegate or TypeKind.Interface or TypeKind.Struct)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidSymbolKind,
+                $"Type '{typeSymbol.Name}' is not a supported target for implement_abstract.");
+        }
+    }
+
+    private static List<MemberDeclarationSyntax> GenerateImplementations(List<ISymbol> members)
+    {
+        var implementations = new List<MemberDeclarationSyntax>();
+
+        foreach (var member in members)
+        {
+            MemberDeclarationSyntax? impl = member switch
+            {
+                IMethodSymbol method => CreateMethodStub(method),
+                IPropertySymbol property => CreatePropertyStub(property),
+                _ => null
+            };
+
+            if (impl != null)
+                implementations.Add(impl);
+        }
+
+        return implementations;
+    }
+
+    /// <summary>
+    /// Creates an override method stub with a
+    /// <c>throw new global::System.NotImplementedException();</c> body.
+    /// </summary>
+    internal static MethodDeclarationSyntax CreateMethodStub(IMethodSymbol method)
+    {
+        var parameters = method.Parameters.Select(CreateParameter);
+        var methodDecl = SyntaxFactory.MethodDeclaration(
+                SyntaxFactory.ParseTypeName(method.ReturnType.ToDisplayString()).WithTrailingTrivia(SyntaxFactory.Space),
+                method.Name)
+            .WithModifiers(CreateOverrideModifiers(method.DeclaredAccessibility))
+            .WithParameterList(SyntaxFactory.ParameterList(SyntaxFactory.SeparatedList(parameters)))
+            .WithBody(CreateThrowNotImplementedBody());
+
+        if (method.TypeParameters.Length > 0)
+        {
+            methodDecl = methodDecl.WithTypeParameterList(
+                SyntaxFactory.TypeParameterList(
+                    SyntaxFactory.SeparatedList(method.TypeParameters.Select(tp => SyntaxFactory.TypeParameter(tp.Name)))));
+        }
+
+        return methodDecl.NormalizeWhitespace();
+    }
+
+    /// <summary>
+    /// Creates an override property stub whose accessors throw
+    /// <c>new global::System.NotImplementedException()</c>.
+    /// </summary>
+    internal static PropertyDeclarationSyntax CreatePropertyStub(IPropertySymbol property)
+    {
+        var accessors = new List<AccessorDeclarationSyntax>();
+
+        if (property.GetMethod != null)
+        {
+            accessors.Add(
+                SyntaxFactory.AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
+                    .WithBody(CreateThrowNotImplementedBody()));
+        }
+
+        if (property.SetMethod != null)
+        {
+            accessors.Add(
+                SyntaxFactory.AccessorDeclaration(SyntaxKind.SetAccessorDeclaration)
+                    .WithBody(CreateThrowNotImplementedBody()));
+        }
+
+        return SyntaxFactory.PropertyDeclaration(
+                SyntaxFactory.ParseTypeName(property.Type.ToDisplayString()).WithTrailingTrivia(SyntaxFactory.Space),
+                property.Name)
+            .WithModifiers(CreateOverrideModifiers(property.DeclaredAccessibility))
+            .WithAccessorList(SyntaxFactory.AccessorList(SyntaxFactory.List(accessors)))
+            .NormalizeWhitespace();
+    }
+
+    internal static BlockSyntax CreateThrowNotImplementedBody()
+    {
+        return SyntaxFactory.Block(
+            SyntaxFactory.ThrowStatement(
+                SyntaxFactory.ObjectCreationExpression(
+                    SyntaxFactory.ParseTypeName("global::System.NotImplementedException"))
+                .WithArgumentList(SyntaxFactory.ArgumentList())));
+    }
+
+    private static ParameterSyntax CreateParameter(IParameterSymbol parameter)
+    {
+        var syntax = SyntaxFactory.Parameter(SyntaxFactory.Identifier(parameter.Name))
+            .WithType(SyntaxFactory.ParseTypeName(parameter.Type.ToDisplayString()).WithTrailingTrivia(SyntaxFactory.Space));
+
+        var refKeyword = parameter.RefKind switch
+        {
+            RefKind.Ref => SyntaxKind.RefKeyword,
+            RefKind.Out => SyntaxKind.OutKeyword,
+            RefKind.In => SyntaxKind.InKeyword,
+            _ => SyntaxKind.None
+        };
+
+        if (refKeyword == SyntaxKind.None)
+            return syntax;
+
+        return syntax.WithModifiers(SyntaxFactory.TokenList(
+            SyntaxFactory.Token(refKeyword).WithTrailingTrivia(SyntaxFactory.Space)));
+    }
+
+    private static SyntaxTokenList CreateOverrideModifiers(Accessibility accessibility)
+    {
+        var tokens = new List<SyntaxToken>();
+        tokens.AddRange(ParseAccessibility(accessibility));
+        tokens.Add(SyntaxFactory.Token(SyntaxKind.OverrideKeyword).WithTrailingTrivia(SyntaxFactory.Space));
+        return SyntaxFactory.TokenList(tokens);
+    }
+
+    private static IEnumerable<SyntaxToken> ParseAccessibility(Accessibility accessibility)
+    {
+        return accessibility switch
+        {
+            Accessibility.Protected => new[]
+            {
+                SyntaxFactory.Token(SyntaxKind.ProtectedKeyword).WithTrailingTrivia(SyntaxFactory.Space)
+            },
+            Accessibility.Internal => new[]
+            {
+                SyntaxFactory.Token(SyntaxKind.InternalKeyword).WithTrailingTrivia(SyntaxFactory.Space)
+            },
+            Accessibility.ProtectedOrInternal => new[]
+            {
+                SyntaxFactory.Token(SyntaxKind.ProtectedKeyword).WithTrailingTrivia(SyntaxFactory.Space),
+                SyntaxFactory.Token(SyntaxKind.InternalKeyword).WithTrailingTrivia(SyntaxFactory.Space)
+            },
+            Accessibility.ProtectedAndInternal => new[]
+            {
+                SyntaxFactory.Token(SyntaxKind.PrivateKeyword).WithTrailingTrivia(SyntaxFactory.Space),
+                SyntaxFactory.Token(SyntaxKind.ProtectedKeyword).WithTrailingTrivia(SyntaxFactory.Space)
+            },
+            _ => new[]
+            {
+                SyntaxFactory.Token(SyntaxKind.PublicKeyword).WithTrailingTrivia(SyntaxFactory.Space)
+            }
+        };
+    }
+
+    private static TypeDeclarationSyntax AddMembers(
+        TypeDeclarationSyntax typeDeclaration,
+        List<MemberDeclarationSyntax> newMembers)
+    {
+        var members = typeDeclaration.Members.ToList();
+
+        foreach (var member in newMembers)
+        {
+            members.Add(member
+                .WithLeadingTrivia(SyntaxFactory.CarriageReturnLineFeed, SyntaxFactory.CarriageReturnLineFeed)
+                .WithTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed));
+        }
+
+        return typeDeclaration.WithMembers(SyntaxFactory.List(members));
+    }
+
+    private static RefactoringResult CreatePreviewResult(
+        Guid operationId,
+        ImplementAbstractParams @params,
+        List<ISymbol> members,
+        List<MemberDeclarationSyntax> implementations)
+    {
+        var memberNames = string.Join(", ", members.Select(m => m.Name));
+        var implCode = string.Join("\n\n",
+            implementations.Select(i => i.NormalizeWhitespace().ToFullString()));
+
+        var pendingChanges = new List<PendingChange>
+        {
+            new()
+            {
+                File = @params.SourceFile,
+                ChangeType = ChangeKind.Modify,
+                Description = $"Implement abstract members on '{@params.TypeName}': {memberNames}",
+                BeforeSnippet = $"// End of type '{@params.TypeName}'",
+                AfterSnippet = implCode
+            }
+        };
+
+        return RefactoringResult.PreviewResult(operationId, pendingChanges);
+    }
+}

--- a/src/RoslynMcp.Core/Resolution/MemberAnalyzer.cs
+++ b/src/RoslynMcp.Core/Resolution/MemberAnalyzer.cs
@@ -45,16 +45,16 @@ public static class MemberAnalyzer
     }
 
     /// <summary>
-    /// Gets abstract methods and properties inherited from base types that the
-    /// selected type has not yet implemented.
+    /// Gets abstract methods, properties, and indexers inherited from base types
+    /// that the selected type has not yet implemented.
     /// </summary>
     /// <param name="type">The type to analyze.</param>
-    /// <returns>Unimplemented inherited abstract members (methods and properties).</returns>
+    /// <returns>Unimplemented inherited abstract members (methods, properties, and indexers).</returns>
     public static IEnumerable<ISymbol> GetUnimplementedAbstractMembers(INamedTypeSymbol type)
     {
         var declared = new HashSet<string>(
             type.GetMembers()
-                .Where(m => m is IMethodSymbol { MethodKind: MethodKind.Ordinary } or IPropertySymbol { IsIndexer: false })
+                .Where(m => m is IMethodSymbol { MethodKind: MethodKind.Ordinary } or IPropertySymbol)
                 .Select(GetMemberSignature));
 
         var current = type.BaseType;
@@ -76,7 +76,7 @@ public static class MemberAnalyzer
                         isAbstract = method.IsAbstract;
                         isConcreteOverride = method.IsOverride && !method.IsAbstract;
                         break;
-                    case IPropertySymbol property when !property.IsIndexer:
+                    case IPropertySymbol property:
                         signature = GetMemberSignature(property);
                         isAbstract = property.IsAbstract;
                         isConcreteOverride = property.IsOverride && !property.IsAbstract;
@@ -242,9 +242,24 @@ public static class MemberAnalyzer
     {
         return member switch
         {
-            IMethodSymbol method => $"{method.Name}({string.Join(",", method.Parameters.Select(p => p.Type.ToDisplayString()))})",
+            IMethodSymbol method => $"{method.Name}({string.Join(",", method.Parameters.Select(FormatParameterSignature))})",
+            IPropertySymbol { IsIndexer: true } indexer =>
+                $"this[{string.Join(",", indexer.Parameters.Select(FormatParameterSignature))}]",
             IPropertySymbol prop => prop.Name,
             _ => member.Name
+        };
+    }
+
+    private static string FormatParameterSignature(IParameterSymbol parameter)
+    {
+        var type = parameter.Type.ToDisplayString();
+        return parameter.RefKind switch
+        {
+            RefKind.Ref => $"ref {type}",
+            RefKind.Out => $"out {type}",
+            RefKind.In => $"in {type}",
+            RefKind.RefReadOnlyParameter => $"ref readonly {type}",
+            _ => type
         };
     }
 

--- a/src/RoslynMcp.Core/Resolution/MemberAnalyzer.cs
+++ b/src/RoslynMcp.Core/Resolution/MemberAnalyzer.cs
@@ -45,6 +45,65 @@ public static class MemberAnalyzer
     }
 
     /// <summary>
+    /// Gets abstract methods and properties inherited from base types that the
+    /// selected type has not yet implemented.
+    /// </summary>
+    /// <param name="type">The type to analyze.</param>
+    /// <returns>Unimplemented inherited abstract members (methods and properties).</returns>
+    public static IEnumerable<ISymbol> GetUnimplementedAbstractMembers(INamedTypeSymbol type)
+    {
+        var declared = new HashSet<string>(
+            type.GetMembers()
+                .Where(m => m is IMethodSymbol { MethodKind: MethodKind.Ordinary } or IPropertySymbol { IsIndexer: false })
+                .Select(GetMemberSignature));
+
+        var current = type.BaseType;
+        while (current != null && current.SpecialType != SpecialType.System_Object)
+        {
+            foreach (var member in current.GetMembers())
+            {
+                if (member.IsImplicitlyDeclared || member.IsStatic)
+                    continue;
+
+                string? signature = null;
+                var isAbstract = false;
+                var isConcreteOverride = false;
+
+                switch (member)
+                {
+                    case IMethodSymbol method when method.MethodKind == MethodKind.Ordinary:
+                        signature = GetMemberSignature(method);
+                        isAbstract = method.IsAbstract;
+                        isConcreteOverride = method.IsOverride && !method.IsAbstract;
+                        break;
+                    case IPropertySymbol property when !property.IsIndexer:
+                        signature = GetMemberSignature(property);
+                        isAbstract = property.IsAbstract;
+                        isConcreteOverride = property.IsOverride && !property.IsAbstract;
+                        break;
+                }
+
+                if (signature == null || declared.Contains(signature))
+                    continue;
+
+                if (isConcreteOverride)
+                {
+                    declared.Add(signature);
+                    continue;
+                }
+
+                if (!isAbstract)
+                    continue;
+
+                declared.Add(signature);
+                yield return member;
+            }
+
+            current = current.BaseType;
+        }
+    }
+
+    /// <summary>
     /// Gets virtual/abstract members from base classes that can be overridden.
     /// </summary>
     /// <param name="type">The type to analyze.</param>

--- a/src/RoslynMcp.Server/McpServerHost.cs
+++ b/src/RoslynMcp.Server/McpServerHost.cs
@@ -40,6 +40,7 @@ public sealed class McpServerHost : IAsyncDisposable
         // Phase 2 - Expanded Operations
         _toolRegistry.Register(new ExtractInterfaceTool(workspaceProvider));
         _toolRegistry.Register(new ImplementInterfaceTool(workspaceProvider));
+        _toolRegistry.Register(new ImplementAbstractTool(workspaceProvider));
         _toolRegistry.Register(new GenerateOverridesTool(workspaceProvider));
         _toolRegistry.Register(new ExtractVariableTool(workspaceProvider));
         _toolRegistry.Register(new InlineVariableTool(workspaceProvider));

--- a/src/RoslynMcp.Server/Tools/ImplementAbstractTool.cs
+++ b/src/RoslynMcp.Server/Tools/ImplementAbstractTool.cs
@@ -1,0 +1,135 @@
+using System.Text.Json;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.Refactoring;
+using RoslynMcp.Core.Refactoring.Generate;
+using RoslynMcp.Core.Workspace;
+using RoslynMcp.Server.Transport;
+
+namespace RoslynMcp.Server.Tools;
+
+/// <summary>
+/// MCP tool handler for implement_abstract operation.
+/// </summary>
+public sealed class ImplementAbstractTool : IToolHandler
+{
+    private readonly IWorkspaceProvider _workspaceProvider;
+    private readonly JsonSerializerOptions _jsonOptions;
+
+    /// <summary>
+    /// Creates a new implement abstract tool.
+    /// </summary>
+    public ImplementAbstractTool(IWorkspaceProvider workspaceProvider)
+    {
+        _workspaceProvider = workspaceProvider;
+        _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = false
+        };
+    }
+
+    /// <inheritdoc />
+    public string Name => "implement_abstract";
+
+    /// <inheritdoc />
+    public string Description =>
+        "Generate implementation stubs for unimplemented abstract members inherited by a selected class. Placeholder body is throw new NotImplementedException();";
+
+    /// <inheritdoc />
+    public object InputSchema => new
+    {
+        type = "object",
+        required = new[] { "solutionPath", "sourceFile", "typeName" },
+        properties = new
+        {
+            solutionPath = new
+            {
+                type = "string",
+                description = "Absolute path to the .sln or .csproj file"
+            },
+            sourceFile = new
+            {
+                type = "string",
+                description = "Absolute path to the source file containing the type"
+            },
+            typeName = new
+            {
+                type = "string",
+                description = "Name of the class to implement inherited abstract members on"
+            },
+            members = new
+            {
+                type = "array",
+                items = new { type = "string" },
+                description = "Names of specific abstract members to implement. If not specified, implements all missing members."
+            },
+            preview = new
+            {
+                type = "boolean",
+                description = "Return computed changes without applying",
+                @default = false
+            }
+        },
+        additionalProperties = false
+    };
+
+    /// <inheritdoc />
+    public async Task<ToolResult> ExecuteAsync(JsonElement? arguments, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (arguments == null)
+            {
+                return ToolResult.Error("Arguments required");
+            }
+
+            var args = JsonSerializer.Deserialize<ImplementAbstractArgs>(arguments.Value.GetRawText(), _jsonOptions);
+            if (args == null)
+            {
+                return ToolResult.Error("Failed to parse arguments");
+            }
+
+            using var context = await _workspaceProvider.CreateContextAsync(
+                args.SolutionPath,
+                cancellationToken);
+
+            var operation = new ImplementAbstractOperation(context);
+            var @params = new ImplementAbstractParams
+            {
+                SourceFile = args.SourceFile,
+                TypeName = args.TypeName,
+                Members = args.Members,
+                Preview = args.Preview ?? false
+            };
+
+            var result = await operation.ExecuteAsync(@params, cancellationToken);
+
+            var json = JsonSerializer.Serialize(result, _jsonOptions);
+            return result.Success ? ToolResult.Success(json) : ToolResult.Error(json);
+        }
+        catch (RefactoringException ex)
+        {
+            var error = ex.ToError();
+            var json = JsonSerializer.Serialize(new { success = false, error }, _jsonOptions);
+            return ToolResult.Error(json);
+        }
+        catch (Exception ex)
+        {
+            var json = JsonSerializer.Serialize(new
+            {
+                success = false,
+                error = new { code = "INTERNAL_ERROR", message = ex.Message }
+            }, _jsonOptions);
+            return ToolResult.Error(json);
+        }
+    }
+
+    private sealed class ImplementAbstractArgs
+    {
+        public string SolutionPath { get; init; } = "";
+        public string SourceFile { get; init; } = "";
+        public string TypeName { get; init; } = "";
+        public List<string>? Members { get; init; }
+        public bool? Preview { get; init; }
+    }
+}

--- a/tests/RoslynMcp.Cli.Tests/HelpGeneratorTests.cs
+++ b/tests/RoslynMcp.Cli.Tests/HelpGeneratorTests.cs
@@ -15,11 +15,11 @@ public class HelpGeneratorTests
     }
 
     [Fact]
-    public void GenerateGlobalHelp_Lists52Tools()
+    public void GenerateGlobalHelp_Lists53Tools()
     {
         var registry = ToolRegistry.BuildDefault();
         var help = HelpGenerator.GenerateGlobalHelp(registry);
-        Assert.Contains("Total: 52 tools", help);
+        Assert.Contains("Total: 53 tools", help);
         Assert.Contains("pull-members-up", help);
         Assert.Contains("push-members-down", help);
         Assert.Contains("use-base-type", help);
@@ -30,6 +30,7 @@ public class HelpGeneratorTests
         Assert.Contains("convert-to-block-body", help);
         Assert.Contains("generate-property", help);
         Assert.Contains("generate-method-stub", help);
+        Assert.Contains("implement-abstract", help);
     }
 
     [Fact]

--- a/tests/RoslynMcp.Cli.Tests/ToolRegistryTests.cs
+++ b/tests/RoslynMcp.Cli.Tests/ToolRegistryTests.cs
@@ -6,11 +6,11 @@ namespace RoslynMcp.Cli.Tests;
 public class ToolRegistryTests
 {
     [Fact]
-    public void BuildDefault_Registers52Tools()
+    public void BuildDefault_Registers53Tools()
     {
         var registry = ToolRegistry.BuildDefault();
         var tools = registry.GetAllTools();
-        Assert.Equal(52, tools.Count);
+        Assert.Equal(53, tools.Count);
     }
 
     [Fact]
@@ -100,6 +100,7 @@ public class ToolRegistryTests
     [InlineData("generate-constructor", "Refactoring")]
     [InlineData("generate-property", "Refactoring")]
     [InlineData("generate-method-stub", "Refactoring")]
+    [InlineData("implement-abstract", "Refactoring")]
     [InlineData("add-missing-usings", "Refactoring")]
     [InlineData("format-document", "Refactoring")]
     [InlineData("get-symbol-info", "Query")]
@@ -112,11 +113,11 @@ public class ToolRegistryTests
     }
 
     [Fact]
-    public void RefactoringToolCount_Is39()
+    public void RefactoringToolCount_Is40()
     {
         var registry = ToolRegistry.BuildDefault();
         var count = registry.GetAllTools().Count(t => t.Category == "Refactoring");
-        Assert.Equal(39, count);
+        Assert.Equal(40, count);
     }
 
     [Fact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Generate/ImplementAbstractOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Generate/ImplementAbstractOperationTests.cs
@@ -1,0 +1,577 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using RoslynMcp.Contracts.Errors;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.Refactoring;
+using RoslynMcp.Core.Refactoring.Generate;
+using RoslynMcp.Core.Workspace;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Refactoring.Generate;
+
+/// <summary>
+/// Operation-level tests for <see cref="ImplementAbstractOperation"/>.
+/// </summary>
+public class ImplementAbstractOperationTests
+{
+    #region Input Validation
+
+    [Fact]
+    public void Validate_MissingSourceFile_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            ImplementAbstractOperation.Validate(new ImplementAbstractParams
+            {
+                SourceFile = "",
+                TypeName = "Widget"
+            }));
+
+        Assert.Equal(ErrorCodes.MissingRequiredParam, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_MissingTypeName_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            ImplementAbstractOperation.Validate(new ImplementAbstractParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                TypeName = ""
+            }));
+
+        Assert.Equal(ErrorCodes.MissingRequiredParam, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_RelativePath_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            ImplementAbstractOperation.Validate(new ImplementAbstractParams
+            {
+                SourceFile = "Types.cs",
+                TypeName = "Widget"
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidSourcePath, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_MissingFile_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            ImplementAbstractOperation.Validate(new ImplementAbstractParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                TypeName = "Widget"
+            }));
+
+        Assert.Equal(ErrorCodes.SourceFileNotFound, ex.ErrorCode);
+    }
+
+    #endregion
+
+    #region P0 Happy Path
+
+    [SkippableFact]
+    public async Task ImplementAbstract_Method_AddsOverrideStub()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public abstract class Shape
+            {
+                public abstract void Draw();
+            }
+
+            public class Circle : Shape
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ImplementAbstractOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new ImplementAbstractParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Circle"
+        });
+
+        Assert.True(result.Success);
+        Assert.False(result.Preview);
+        Assert.NotNull(result.Symbol);
+        Assert.Equal("Circle", result.Symbol.Name);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("public override void Draw()", updated);
+        Assert.Contains("throw new global::System.NotImplementedException();", updated);
+    }
+
+    [SkippableFact]
+    public async Task ImplementAbstract_Property_AddsOverrideAccessors()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public abstract class Shape
+            {
+                public abstract int Area { get; }
+            }
+
+            public class Circle : Shape
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ImplementAbstractOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new ImplementAbstractParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Circle"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("public override int Area", updated);
+        Assert.Contains("get", updated);
+        Assert.Contains("throw new global::System.NotImplementedException();", updated);
+        Assert.DoesNotContain("set", updated);
+    }
+
+    [SkippableFact]
+    public async Task ImplementAbstract_MethodAndProperty_AddsBoth()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public abstract class Shape
+            {
+                public abstract string Name { get; set; }
+
+                public abstract void Draw();
+            }
+
+            public class Circle : Shape
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ImplementAbstractOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new ImplementAbstractParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Circle"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("public override string Name", updated);
+        Assert.Contains("public override void Draw()", updated);
+        Assert.Contains("throw new global::System.NotImplementedException();", updated);
+    }
+
+    [SkippableFact]
+    public async Task ImplementAbstract_ProtectedMember_PreservesAccessibility()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public abstract class Shape
+            {
+                protected abstract void Paint();
+            }
+
+            public class Circle : Shape
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ImplementAbstractOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new ImplementAbstractParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Circle"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("protected override void Paint()", updated);
+    }
+
+    [SkippableFact]
+    public async Task ImplementAbstract_AlreadyImplementedMember_GeneratesRemaining()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public abstract class Shape
+            {
+                public abstract void Draw();
+                public abstract void Resize();
+            }
+
+            public class Circle : Shape
+            {
+                public override void Draw()
+                {
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ImplementAbstractOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new ImplementAbstractParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Circle"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("public override void Resize()", updated);
+        Assert.Contains("throw new global::System.NotImplementedException();", updated);
+        Assert.Equal(1, CountOccurrences(updated, "public override void Draw()"));
+    }
+
+    [SkippableFact]
+    public async Task ImplementAbstract_Preview_DoesNotWriteFiles()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public abstract class Shape
+            {
+                public abstract void Draw();
+            }
+
+            public class Circle : Shape
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ImplementAbstractOperation(workspace.Context);
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var result = await operation.ExecuteAsync(new ImplementAbstractParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Circle",
+            Preview = true
+        });
+
+        Assert.True(result.Success);
+        Assert.True(result.Preview);
+        Assert.NotNull(result.PendingChanges);
+        Assert.NotEmpty(result.PendingChanges);
+        Assert.Contains("Draw", result.PendingChanges[0].AfterSnippet);
+        Assert.Contains("NotImplementedException", result.PendingChanges[0].AfterSnippet);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [SkippableFact]
+    public async Task ImplementAbstract_MembersFilter_ImplementsRequestedOnly()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public abstract class Shape
+            {
+                public abstract void Draw();
+                public abstract void Resize();
+            }
+
+            public class Circle : Shape
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ImplementAbstractOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new ImplementAbstractParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Circle",
+            Members = new[] { "Resize" }
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("public override void Resize()", updated);
+        Assert.DoesNotContain("public override void Draw()", updated);
+    }
+
+    #endregion
+
+    #region Reject Cases
+
+    [SkippableFact]
+    public async Task ImplementAbstract_NoSymbol_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public abstract class Shape
+            {
+                public abstract void Draw();
+            }
+
+            public class Circle : Shape
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ImplementAbstractOperation(workspace.Context);
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new ImplementAbstractParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "Missing"
+            }));
+
+        Assert.Equal(ErrorCodes.SymbolNotFound, ex.ErrorCode);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [SkippableFact]
+    public async Task ImplementAbstract_NoUnimplementedAbstractMembers_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Widget
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ImplementAbstractOperation(workspace.Context);
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new ImplementAbstractParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "Widget"
+            }));
+
+        Assert.Equal(ErrorCodes.NoUnimplementedAbstractMembers, ex.ErrorCode);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [SkippableFact]
+    public async Task ImplementAbstract_AlreadyFullyImplemented_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public abstract class Shape
+            {
+                public abstract void Draw();
+            }
+
+            public class Circle : Shape
+            {
+                public override void Draw()
+                {
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ImplementAbstractOperation(workspace.Context);
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new ImplementAbstractParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "Circle"
+            }));
+
+        Assert.Equal(ErrorCodes.NoUnimplementedAbstractMembers, ex.ErrorCode);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [SkippableFact]
+    public async Task ImplementAbstract_UnsupportedTarget_Enum_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public enum Status
+            {
+                Ready
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ImplementAbstractOperation(workspace.Context);
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new ImplementAbstractParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "Status"
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidSymbolKind, ex.ErrorCode);
+        Assert.Contains("not a supported target", ex.Message);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [SkippableFact]
+    public async Task ImplementAbstract_UnsupportedTarget_Interface_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public interface IDrawable
+            {
+                void Draw();
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ImplementAbstractOperation(workspace.Context);
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new ImplementAbstractParams
+            {
+                SourceFile = workspace.SourcePath,
+                TypeName = "IDrawable"
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidSymbolKind, ex.ErrorCode);
+        Assert.Contains("not a supported target", ex.Message);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [Fact]
+    public void ImplementAbstract_UneditableDocument_Throws()
+    {
+        var workspace = new AdhocWorkspace();
+        var project = workspace.AddProject("P", LanguageNames.CSharp);
+        var document = workspace.AddDocument(project.Id, "Generated.cs", SourceText.From("class C {}"));
+
+        var ex = Assert.Throws<RefactoringException>(() =>
+            ImplementAbstractOperation.ValidateDocumentIsEditable(document, workspace));
+
+        Assert.Equal(ErrorCodes.DocumentNotEditable, ex.ErrorCode);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static string AbsoluteTestPath() =>
+        Path.Combine(Path.GetTempPath(), "RoslynMcpImplementAbstractMissing.cs");
+
+    private static string NormalizeNewlines(string text) =>
+        text.Replace("\r\n", "\n", StringComparison.Ordinal);
+
+    private static int CountOccurrences(string text, string value)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = text.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += value.Length;
+        }
+
+        return count;
+    }
+
+    private sealed class TempWorkspace : IAsyncDisposable
+    {
+        public required string DirectoryPath { get; init; }
+        public required string ProjectPath { get; init; }
+        public required string SourcePath { get; init; }
+        public required WorkspaceContext Context { get; init; }
+
+        public static async Task<TempWorkspace> CreateAsync(string source, string fileName = "Types.cs")
+        {
+            Skip.IfNot(ModuleInitializer.MsBuildAvailable, ModuleInitializer.MsBuildError ?? "MSBuild not available");
+
+            var directory = Path.Combine(Path.GetTempPath(), "RoslynMcpImplementAbstract_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(directory);
+
+            var projectPath = Path.Combine(directory, "TestApp.csproj");
+            var sourcePath = Path.Combine(directory, fileName);
+
+            await File.WriteAllTextAsync(projectPath, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net9.0</TargetFramework>
+                    <Nullable>enable</Nullable>
+                  </PropertyGroup>
+                </Project>
+                """);
+            await File.WriteAllTextAsync(sourcePath, source);
+
+            try
+            {
+                var provider = new MSBuildWorkspaceProvider();
+                var context = await provider.CreateContextAsync(projectPath);
+                if (context.GetDocumentByPath(sourcePath) == null)
+                {
+                    context.Dispose();
+                    throw new InvalidOperationException($"Workspace loaded but did not include {sourcePath}.");
+                }
+
+                return new TempWorkspace
+                {
+                    DirectoryPath = directory,
+                    ProjectPath = projectPath,
+                    SourcePath = sourcePath,
+                    Context = context
+                };
+            }
+            catch (Exception ex) when (ex is not SkipException)
+            {
+                try
+                {
+                    Directory.Delete(directory, recursive: true);
+                }
+                catch
+                {
+                    // ignore cleanup failures
+                }
+
+                Skip.If(true, $"Workspace load failed: {ex.Message}");
+                throw;
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            Context.Dispose();
+            await Task.Run(() =>
+            {
+                try
+                {
+                    Directory.Delete(DirectoryPath, recursive: true);
+                }
+                catch
+                {
+                    // ignore locked temp files
+                }
+            });
+        }
+    }
+
+    #endregion
+}

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Generate/ImplementAbstractOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Generate/ImplementAbstractOperationTests.cs
@@ -310,6 +310,236 @@ public class ImplementAbstractOperationTests
 
     #endregion
 
+    #region Review Fold
+
+    [SkippableFact]
+    public async Task ImplementAbstract_InitSetter_EmitsInitNotSet()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public abstract class Shape
+            {
+                public abstract int Area { get; init; }
+            }
+
+            public class Circle : Shape
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ImplementAbstractOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new ImplementAbstractParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Circle"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("public override int Area", updated);
+        Assert.Contains("init", updated);
+        Assert.DoesNotContain("set", updated);
+        Assert.Contains("throw new global::System.NotImplementedException();", updated);
+    }
+
+    [SkippableFact]
+    public async Task ImplementAbstract_ProtectedSetter_PreservesAccessorAccessibility()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public abstract class Shape
+            {
+                public abstract string Name { get; protected set; }
+            }
+
+            public class Circle : Shape
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ImplementAbstractOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new ImplementAbstractParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Circle"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("public override string Name", updated);
+        Assert.Contains("protected set", updated);
+        Assert.Contains("throw new global::System.NotImplementedException();", updated);
+    }
+
+    [SkippableFact]
+    public async Task ImplementAbstract_RefKindOverloads_GeneratesBoth()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public abstract class Shape
+            {
+                public abstract void Resize(int size);
+                public abstract void Resize(ref int size);
+            }
+
+            public class Circle : Shape
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ImplementAbstractOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new ImplementAbstractParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Circle"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("public override void Resize(int size)", updated);
+        Assert.Contains("public override void Resize(ref int size)", updated);
+        Assert.Equal(2, CountOccurrences(updated, "public override void Resize("));
+    }
+
+    [SkippableFact]
+    public async Task ImplementAbstract_ByRefReturns_PreservesRefAndRefReadonly()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public abstract class Shape
+            {
+                public abstract ref int GetCell();
+                public abstract ref readonly int GetOrigin();
+            }
+
+            public class Circle : Shape
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ImplementAbstractOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new ImplementAbstractParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Circle"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("public override ref int GetCell()", updated);
+        Assert.Contains("public override ref readonly int GetOrigin()", updated);
+        Assert.Contains("throw new global::System.NotImplementedException();", updated);
+    }
+
+    [SkippableFact]
+    public async Task ImplementAbstract_Indexer_AddsOverrideStub()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public abstract class Shape
+            {
+                public abstract int this[int index] { get; set; }
+            }
+
+            public class Circle : Shape
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ImplementAbstractOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new ImplementAbstractParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Circle"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("public override int this[int index]", updated);
+        Assert.Contains("throw new global::System.NotImplementedException();", updated);
+    }
+
+    [SkippableFact]
+    public async Task ImplementAbstract_IndexerOverloads_GeneratesBoth()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public abstract class Shape
+            {
+                public abstract int this[int index] { get; }
+                public abstract int this[string name] { get; }
+            }
+
+            public class Circle : Shape
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ImplementAbstractOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new ImplementAbstractParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Circle"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("public override int this[int index]", updated);
+        Assert.Contains("public override int this[string name]", updated);
+    }
+
+    [SkippableFact]
+    public async Task ImplementAbstract_RequiredProperty_KeepsRequired()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public abstract class Shape
+            {
+                public abstract required string Name { get; set; }
+            }
+
+            public class Circle : Shape
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ImplementAbstractOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new ImplementAbstractParams
+        {
+            SourceFile = workspace.SourcePath,
+            TypeName = "Circle"
+        });
+
+        Assert.True(result.Success);
+        var updated = NormalizeNewlines(await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("required", updated);
+        Assert.Contains("public override required string Name", updated);
+        Assert.Contains("throw new global::System.NotImplementedException();", updated);
+    }
+
+    #endregion
+
     #region Reject Cases
 
     [SkippableFact]

--- a/tests/RoslynMcp.Server.Tests/Tools/ImplementAbstractToolTests.cs
+++ b/tests/RoslynMcp.Server.Tests/Tools/ImplementAbstractToolTests.cs
@@ -1,0 +1,117 @@
+using System.Text.Json;
+using RoslynMcp.Server.Tests.TestHelpers;
+using RoslynMcp.Server.Tools;
+using RoslynMcp.Server.Transport;
+using Xunit;
+
+namespace RoslynMcp.Server.Tests.Tools;
+
+/// <summary>
+/// Unit tests for ImplementAbstractTool.
+/// Tests tool definition and argument validation.
+/// </summary>
+public class ImplementAbstractToolTests
+{
+    private readonly ImplementAbstractTool _tool;
+
+    public ImplementAbstractToolTests()
+    {
+        _tool = new ImplementAbstractTool(new ThrowingWorkspaceProvider());
+    }
+
+    #region GetDefinition Tests
+
+    [Fact]
+    public void GetDefinition_ReturnsCorrectName()
+    {
+        Assert.Equal("implement_abstract", _tool.Name);
+    }
+
+    [Fact]
+    public void GetDefinition_ReturnsNonEmptyDescription()
+    {
+        Assert.NotNull(_tool.Description);
+        Assert.NotEmpty(_tool.Description);
+    }
+
+    [Fact]
+    public void GetDefinition_ReturnsCorrectSchema()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.Equal("object", root.GetProperty("type").GetString());
+        Assert.True(root.TryGetProperty("properties", out _));
+        Assert.True(root.TryGetProperty("required", out _));
+    }
+
+    [Fact]
+    public void GetDefinition_HasRequiredFields()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var required = doc.RootElement.GetProperty("required");
+
+        var requiredFields = new List<string>();
+        foreach (var item in required.EnumerateArray())
+        {
+            requiredFields.Add(item.GetString()!);
+        }
+
+        Assert.Contains("solutionPath", requiredFields);
+        Assert.Contains("sourceFile", requiredFields);
+        Assert.Contains("typeName", requiredFields);
+    }
+
+    [Fact]
+    public void GetDefinition_HasProperties_ForAllParameters()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var properties = doc.RootElement.GetProperty("properties");
+
+        Assert.True(properties.TryGetProperty("solutionPath", out _));
+        Assert.True(properties.TryGetProperty("sourceFile", out _));
+        Assert.True(properties.TryGetProperty("typeName", out _));
+        Assert.True(properties.TryGetProperty("members", out _));
+        Assert.True(properties.TryGetProperty("preview", out _));
+    }
+
+    #endregion
+
+    #region ExecuteAsync Argument Validation Tests
+
+    [Fact]
+    public async Task ExecuteAsync_NullArguments_ReturnsError()
+    {
+        var result = await _tool.ExecuteAsync(null);
+
+        Assert.True(result.IsError);
+        Assert.Contains("Arguments required", GetResultText(result));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EmptyArguments_ReturnsError()
+    {
+        var args = JsonDocument.Parse("{}").RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static string GetResultText(ToolResult result)
+    {
+        return result.Content.FirstOrDefault()?.Text ?? string.Empty;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds `implement_abstract` / `ImplementAbstractOperation` as Generate Phase 3 from `Design/Expansion/Phase2/Arch-Generate-Operations.md` (table 1.1 `implement_abstract`, §9 Phase 3). Placement is next to `ImplementInterfaceOperation`.

Started from current `master` (`e962060`, generate_method_stub #51) so this increment does not conflict with that work.

A selected class receives stubs for unimplemented abstract members inherited from its base type:

- Abstract methods, properties, and indexers
- Placeholder body: `throw new global::System.NotImplementedException();`
- Override modifier with the inherited member's accessibility
- Init setters, reduced-accessibility accessors, by-ref returns, ref-kind overloads, and `required` properties

Preview computes the stubs and does not write files.

Rejects:

- No symbol (type not found / unresolvable)
- No unimplemented abstract members
- Uneditable document
- Unsupported target (enum, interface, struct, static class)

## Related Issues

Closes #56

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Test additions or updates

## Testing

- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Manual testing performed (operation + MCP tool + CLI registry tests locally)

P0 coverage:

- Happy path: abstract method stub, abstract property stub, method + property, protected accessibility, remaining member after a partial implementation, members filter, preview does not write files
- Rejects: no symbol, no unimplemented abstracts (plain class and fully implemented derived class), unsupported enum/interface, uneditable document
- MCP + CLI registration; tool count **52 → 53**; refactoring category **39 → 40**

Review fold (Codex TAKEs):

- Init setter emits `init`, not `set`; `protected set` keeps accessor accessibility
- `M(int)` and `M(ref int)` are distinct and both generated
- `ref` / `ref readonly` returns preserved
- Abstract indexers discovered and emitted, including overloads
- `required` stays on the override

Local results after the review-fold commit (`601b599`) on Linux / .NET 9.0.317:

- ImplementAbstract operation tests: 24 passed
- ImplementAbstract MCP tool tests: 7 passed
- Full suite: 1076 passed (Core 553, Server 421, CLI 102), 0 failed, 0 skipped
- Build: 0 warnings, 0 errors

**Test Configuration**:
- OS: Linux
- .NET Version: 9.0.317

## Additional Notes

Follows existing `ImplementInterfaceOperation` and Generate* leftover patterns (`GeneratePropertyOperation`, `GenerateMethodStubOperation`). Out of scope: `inline_constant`, encapsulate, undo, Bank of America STAR, a second leftover.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e463a722-b903-49c2-b970-3f11f2ef481c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e463a722-b903-49c2-b970-3f11f2ef481c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

