### PR TITLE
Add add_parameter refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - `generate_method_stub` — generate a method from an undefined call site, inferring target type, parameters, and return type from usage, with a `throw new NotImplementedException();` body, preview mode, and rejects for missing call sites, existing methods, uneditable or external targets, and uninferable return types
 - `implement_abstract` — generate implementation stubs for unimplemented abstract methods and properties inherited by a selected class, with a `throw new NotImplementedException();` body, preview mode, and rejects for missing symbols, no unimplemented abstract members, uneditable documents, and unsupported targets
 - `inline_constant` — replace references to a `const` field with a formatted literal (typed null casts), optionally remove the declaration, with preview mode and rejects for non-constants (including static readonly), public API constants, attribute usages, missing symbols, and uneditable documents
+- `add_parameter` — add a named parameter to a method and update call sites, overrides, and interface implementations, with preview mode and rejects for duplicate names, invalid types, out-of-range positions, required-after-optional, params-not-last, missing methods, and uneditable documents
 
 ## [0.4.0] - 2026-02-23
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Let AI assistants like Claude safely refactor your C# codebase using the same Roslyn compiler platform that powers Visual Studio.
 
-Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that exposes **54 Roslyn-powered tools** to AI assistants and other MCP clients. It combines 30 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 5 code generation tools, and 8 code conversion tools -- giving your AI deep code intelligence, comprehensive refactoring, and modern C# syntax transformations with full solution-wide reference tracking and preview support.
+Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that exposes **55 Roslyn-powered tools** to AI assistants and other MCP clients. It combines 31 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 5 code generation tools, and 8 code conversion tools -- giving your AI deep code intelligence, comprehensive refactoring, and modern C# syntax transformations with full solution-wide reference tracking and preview support.
 
 ---
 
@@ -30,7 +30,7 @@ Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotoc
 
 ## Why RoslynMcpServer?
 
-- **54 tools** -- refactoring, navigation, analysis, generation, and conversion tools, the most comprehensive Roslyn MCP server available
+- **55 tools** -- refactoring, navigation, analysis, generation, and conversion tools, the most comprehensive Roslyn MCP server available
 - **Preview mode on every operation** -- see exactly what will change before applying
 - **Atomic file writes with rollback** -- if any file write fails, all changes are reverted
 - **Solution-wide reference updates** -- renames and moves propagate across your entire solution
@@ -102,7 +102,7 @@ Claude will use the `rename_symbol` tool to rename the class and update every re
 
 ## Standalone CLI
 
-All 54 tools are also available as a standalone CLI for use in scripts, CI/CD pipelines, and terminals without an AI assistant.
+All 55 tools are also available as a standalone CLI for use in scripts, CI/CD pipelines, and terminals without an AI assistant.
 
 ### Install
 
@@ -222,6 +222,7 @@ All tools accept a `solutionPath` parameter (absolute path to a `.sln`, `.slnx`,
 | Tool | Description | Key Parameters |
 |------|-------------|----------------|
 | `change_signature` | Add, remove, or reorder method parameters and update all call sites. | `sourceFile`, `methodName`, `parameters` (array of changes), `line` |
+| `add_parameter` | Add a named parameter to a method and update call sites, overrides, and interface implementations. | `sourceFile`, `methodName`, `parameterName`, `parameterType`, `defaultValue`, `position`, `line`, `column`, `updateOverrides`, `updateImplementations` |
 | `encapsulate_field` | Convert a field to a property with backing field. | `sourceFile`, `fieldName`, `propertyName`, `readOnly` |
 
 ### Generate

--- a/src/RoslynMcp.Cli/ToolRegistry.cs
+++ b/src/RoslynMcp.Cli/ToolRegistry.cs
@@ -47,7 +47,7 @@ public sealed class ToolEntry
 }
 
 /// <summary>
-/// Maps tool names to execution delegates for all 54 Roslyn tools.
+/// Maps tool names to execution delegates for all 55 Roslyn tools.
 /// </summary>
 public sealed class ToolRegistry
 {
@@ -139,7 +139,7 @@ public sealed class ToolRegistry
         _tools.Values.OrderBy(t => t.Category).ThenBy(t => t.Name).ToList();
 
     /// <summary>
-    /// Build the default registry with all 54 tools registered.
+    /// Build the default registry with all 55 tools registered.
     /// </summary>
     public static ToolRegistry BuildDefault()
     {
@@ -185,9 +185,11 @@ public sealed class ToolRegistry
         r.RegisterRefactoring<InlineConstantOperation, InlineConstantParams>(
             "inline-constant", "Inline a const field by replacing references with its literal value");
 
-        // ── Refactoring: Signature (1) ────────────────────────────────
+        // ── Refactoring: Signature (2) ────────────────────────────────
         r.RegisterRefactoring<ChangeSignatureOperation, ChangeSignatureParams>(
             "change-signature", "Add, remove, or reorder method parameters");
+        r.RegisterRefactoring<AddParameterOperation, AddParameterParams>(
+            "add-parameter", "Add a named parameter to a method and update call sites");
 
         // ── Refactoring: Encapsulate (1) ──────────────────────────────
         r.RegisterRefactoring<EncapsulateFieldOperation, EncapsulateFieldParams>(

--- a/src/RoslynMcp.Contracts/Enums/RefactoringKind.cs
+++ b/src/RoslynMcp.Contracts/Enums/RefactoringKind.cs
@@ -66,6 +66,10 @@ public enum RefactoringKind
     /// <summary>Inline a constant by replacing references with its literal value.</summary>
     InlineConstant,
 
+    // Signature Operations
+    /// <summary>Add a parameter to a method and update call sites.</summary>
+    AddParameter,
+
     // Generate Operations
     /// <summary>Generate constructor from fields/properties.</summary>
     GenerateConstructor,

--- a/src/RoslynMcp.Contracts/Errors/ErrorCodes.cs
+++ b/src/RoslynMcp.Contracts/Errors/ErrorCodes.cs
@@ -410,6 +410,20 @@ public static class ErrorCodes
     /// <summary>No unimplemented abstract members remain on the selected type.</summary>
     public const string NoUnimplementedAbstractMembers = "3126";
 
+    // --------------------------------------------
+    // Signature Errors (3127-3129)
+    // 3060-3066 and 3080-3089 are already shipped for generate/async.
+    // --------------------------------------------
+
+    /// <summary>Parameter with this name already exists on the method.</summary>
+    public const string ParameterAlreadyExists = "3127";
+
+    /// <summary>Required parameters cannot follow optional parameters.</summary>
+    public const string RequiredAfterOptional = "3128";
+
+    /// <summary>A params parameter must remain last in the parameter list.</summary>
+    public const string ParamsNotLast = "3129";
+
     // ============================================
     // System Errors (4xxx)
     // ============================================

--- a/src/RoslynMcp.Contracts/Errors/ErrorCodes.cs
+++ b/src/RoslynMcp.Contracts/Errors/ErrorCodes.cs
@@ -424,6 +424,9 @@ public static class ErrorCodes
     /// <summary>A params parameter must remain last in the parameter list.</summary>
     public const string ParamsNotLast = "3129";
 
+    /// <summary>A method reference is not a supported invocation and cannot be updated (method group, delegate).</summary>
+    public const string UnsupportedCallSite = "3130";
+
     // ============================================
     // System Errors (4xxx)
     // ============================================

--- a/src/RoslynMcp.Contracts/Models/AddParameterParams.cs
+++ b/src/RoslynMcp.Contracts/Models/AddParameterParams.cs
@@ -1,0 +1,63 @@
+namespace RoslynMcp.Contracts.Models;
+
+/// <summary>
+/// Parameters for the add_parameter tool.
+/// </summary>
+public sealed class AddParameterParams
+{
+    /// <summary>
+    /// Absolute path to the source file containing the method.
+    /// </summary>
+    public required string SourceFile { get; init; }
+
+    /// <summary>
+    /// Name of the method to modify.
+    /// </summary>
+    public required string MethodName { get; init; }
+
+    /// <summary>
+    /// Name for the new parameter.
+    /// </summary>
+    public required string ParameterName { get; init; }
+
+    /// <summary>
+    /// C# type of the new parameter.
+    /// </summary>
+    public required string ParameterType { get; init; }
+
+    /// <summary>
+    /// Default value used at existing call sites (and on the declaration when provided).
+    /// </summary>
+    public string? DefaultValue { get; init; }
+
+    /// <summary>
+    /// 0-based insertion position. -1 (default) inserts at the end of required
+    /// parameters (before optionals and <c>params</c>).
+    /// </summary>
+    public int Position { get; init; } = -1;
+
+    /// <summary>
+    /// Line number for disambiguation if multiple methods have the same name (1-based).
+    /// </summary>
+    public int? Line { get; init; }
+
+    /// <summary>
+    /// Column number for disambiguation (1-based).
+    /// </summary>
+    public int? Column { get; init; }
+
+    /// <summary>
+    /// Update the virtual/override chain together. Default: true.
+    /// </summary>
+    public bool UpdateOverrides { get; init; } = true;
+
+    /// <summary>
+    /// Update interface declarations and implementations together. Default: true.
+    /// </summary>
+    public bool UpdateImplementations { get; init; } = true;
+
+    /// <summary>
+    /// Return computed changes without applying. Default: false.
+    /// </summary>
+    public bool Preview { get; init; }
+}

--- a/src/RoslynMcp.Core/Refactoring/Signature/AddParameterOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Signature/AddParameterOperation.cs
@@ -130,6 +130,14 @@ public sealed class AddParameterOperation : RefactoringOperationBase<AddParamete
         var attachDefaultToDeclaration = CanAttachDefaultToDeclaration(methodDecl.ParameterList, insertIndex);
         ValidateResultingSignature(methodDecl.ParameterList, insertIndex, @params, attachDefaultToDeclaration);
 
+        if (!string.IsNullOrEmpty(@params.DefaultValue))
+        {
+            ValidateDefaultValue(
+                semanticModel,
+                @params.ParameterType,
+                @params.DefaultValue);
+        }
+
         var relatedMethods = await GetRelatedMethodsAsync(
             methodSymbol,
             @params.UpdateOverrides,
@@ -363,22 +371,28 @@ public sealed class AddParameterOperation : RefactoringOperationBase<AddParamete
 
         if (updateImplementations)
         {
-            if (method.ContainingType.TypeKind == TypeKind.Interface)
+            foreach (var candidate in results.ToList())
             {
-                var implementations = await SymbolFinder.FindImplementationsAsync(
-                    method, Context.Solution, cancellationToken: cancellationToken);
-                foreach (var impl in implementations.OfType<IMethodSymbol>())
-                    results.Add(impl);
-            }
-
-            foreach (var iface in method.ContainingType.AllInterfaces)
-            {
-                foreach (var ifaceMethod in iface.GetMembers(method.Name).OfType<IMethodSymbol>())
+                if (candidate.ContainingType.TypeKind == TypeKind.Interface)
                 {
-                    var impl = method.ContainingType.FindImplementationForInterfaceMember(ifaceMethod);
-                    if (impl is IMethodSymbol implMethod &&
-                        SymbolEqualityComparer.Default.Equals(implMethod, method))
+                    var implementations = await SymbolFinder.FindImplementationsAsync(
+                        candidate, Context.Solution, cancellationToken: cancellationToken);
+                    foreach (var impl in implementations.OfType<IMethodSymbol>())
+                        results.Add(impl);
+                    continue;
+                }
+
+                foreach (var iface in candidate.ContainingType.AllInterfaces)
+                {
+                    foreach (var ifaceMethod in iface.GetMembers(candidate.Name).OfType<IMethodSymbol>())
                     {
+                        var impl = candidate.ContainingType.FindImplementationForInterfaceMember(ifaceMethod);
+                        if (impl is not IMethodSymbol implMethod ||
+                            !ShareOverrideRoot(implMethod, candidate))
+                        {
+                            continue;
+                        }
+
                         results.Add(ifaceMethod);
                         var otherImpls = await SymbolFinder.FindImplementationsAsync(
                             ifaceMethod,
@@ -416,7 +430,7 @@ public sealed class AddParameterOperation : RefactoringOperationBase<AddParamete
                         ErrorCodes.DocumentNotEditable,
                         $"Could not locate the document for method '{method.Name}'.");
 
-                targets.Add(new DeclarationTarget(document, declaration.Span, method.Name));
+                targets.Add(new DeclarationTarget(document, declaration.Span));
             }
         }
 
@@ -452,22 +466,26 @@ public sealed class AddParameterOperation : RefactoringOperationBase<AddParamete
                     if (root == null)
                         continue;
 
-                    var node = root.FindNode(location.Location.SourceSpan);
-                    var invocation = node.AncestorsAndSelf().OfType<InvocationExpressionSyntax>().FirstOrDefault();
-                    if (invocation == null)
+                    var node = root.FindNode(location.Location.SourceSpan, getInnermostNodeForTie: true);
+                    if (IsDeclarationName(node, location.Location.SourceSpan))
                         continue;
 
-                    if (invocation.ArgumentList.Span.Contains(location.Location.SourceSpan) ||
-                        node.AncestorsAndSelf().OfType<MethodDeclarationSyntax>().Any(m =>
-                            m.Identifier.Span.IntersectsWith(location.Location.SourceSpan)))
+                    var invocation = node.AncestorsAndSelf().OfType<InvocationExpressionSyntax>().FirstOrDefault();
+                    if (invocation != null && IsInvokedMethodName(invocation, location.Location.SourceSpan))
                     {
+                        if (!seen.Add((document.Id, invocation.Span)))
+                            continue;
+
+                        callSites.Add(new CallSite(document, invocation.Span));
                         continue;
                     }
 
-                    if (!seen.Add((document.Id, invocation.Span)))
+                    if (IsNameOfArgument(node))
                         continue;
 
-                    callSites.Add(new CallSite(document, invocation.Span));
+                    throw new RefactoringException(
+                        ErrorCodes.UnsupportedCallSite,
+                        $"Method '{method.Name}' is used as a method group or other unsupported reference and cannot be updated automatically.");
                 }
             }
         }
@@ -507,23 +525,14 @@ public sealed class AddParameterOperation : RefactoringOperationBase<AddParamete
                 .Where(c => c.Document.Id == documentId)
                 .Select(c => c.Span)
                 .ToHashSet();
-            var targetNames = declarations
-                .Where(d => d.Document.Id == documentId)
-                .Select(d => d.MethodName)
-                .ToHashSet();
 
             var methods = root.DescendantNodes()
                 .OfType<MethodDeclarationSyntax>()
-                .Where(m =>
-                    declarationSpans.Contains(m.Span) ||
-                    (targetNames.Contains(m.Identifier.Text) &&
-                     m.ParameterList.Parameters.Count == originalParams.Count))
+                .Where(m => declarationSpans.Contains(m.Span))
                 .ToList();
             var invocations = root.DescendantNodes()
                 .OfType<InvocationExpressionSyntax>()
-                .Where(i =>
-                    invocationSpans.Contains(i.Span) ||
-                    (targetNames.Count > 0 && IsInvocationOf(i, targetNames)))
+                .Where(i => invocationSpans.Contains(i.Span))
                 .ToList();
 
             var rewriter = new AddParameterRewriter(
@@ -728,6 +737,109 @@ public sealed class AddParameterOperation : RefactoringOperationBase<AddParamete
         return !expression.ContainsDiagnostics && !expression.IsMissing;
     }
 
+    internal static void ValidateDefaultValue(
+        SemanticModel semanticModel,
+        string parameterType,
+        string defaultValue)
+    {
+        var expression = SyntaxFactory.ParseExpression(defaultValue);
+        if (expression.IsMissing || expression.ContainsDiagnostics)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidDefaultValue,
+                $"'{defaultValue}' is not a valid default value expression.");
+        }
+
+        var parseOptions = (CSharpParseOptions)semanticModel.SyntaxTree.Options;
+        var probeTree = CSharpSyntaxTree.ParseText($$"""
+            namespace __RoslynMcpProbe
+            {
+                static class Probe
+                {
+                    static void M()
+                    {
+                        {{parameterType}} __v = {{defaultValue}};
+                    }
+                }
+            }
+            """, parseOptions);
+
+        var probeCompilation = semanticModel.Compilation.AddSyntaxTrees(probeTree);
+        var probeModel = probeCompilation.GetSemanticModel(probeTree);
+        var local = probeTree.GetRoot().DescendantNodes().OfType<LocalDeclarationStatementSyntax>().FirstOrDefault();
+        var initializer = local?.Declaration.Variables.FirstOrDefault()?.Initializer?.Value;
+        if (local == null || initializer == null)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidDefaultValue,
+                $"'{defaultValue}' is not a valid default value expression.");
+        }
+
+        var targetType = probeModel.GetTypeInfo(local.Declaration.Type).Type;
+        if (targetType == null || targetType.TypeKind == TypeKind.Error)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidParameterType,
+                $"'{parameterType}' is not a valid C# parameter type.");
+        }
+
+        var conversion = probeModel.ClassifyConversion(initializer, targetType);
+        if (!conversion.Exists || (!conversion.IsIdentity && !conversion.IsImplicit))
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidDefaultValue,
+                $"'{defaultValue}' is not implicitly convertible to '{parameterType}'.");
+        }
+
+        if (IsDefaultValueExpression(initializer))
+            return;
+
+        if (!probeModel.GetConstantValue(initializer).HasValue)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidDefaultValue,
+                $"'{defaultValue}' is not a compile-time constant or default(T).");
+        }
+    }
+
+    private static bool IsDefaultValueExpression(ExpressionSyntax expression) =>
+        expression.IsKind(SyntaxKind.DefaultLiteralExpression) ||
+        expression is DefaultExpressionSyntax;
+
+    private static bool IsDeclarationName(SyntaxNode node, TextSpan referenceSpan)
+    {
+        return node.AncestorsAndSelf().OfType<MethodDeclarationSyntax>()
+            .Any(m => m.Identifier.Span.IntersectsWith(referenceSpan));
+    }
+
+    private static bool IsInvokedMethodName(InvocationExpressionSyntax invocation, TextSpan referenceSpan)
+    {
+        if (invocation.ArgumentList.Span.Contains(referenceSpan))
+            return false;
+
+        return invocation.Expression switch
+        {
+            IdentifierNameSyntax identifier => identifier.Span.IntersectsWith(referenceSpan),
+            MemberAccessExpressionSyntax member => member.Name.Span.IntersectsWith(referenceSpan),
+            MemberBindingExpressionSyntax binding => binding.Name.Span.IntersectsWith(referenceSpan),
+            _ => invocation.Expression.Span.IntersectsWith(referenceSpan)
+        };
+    }
+
+    private static bool IsNameOfArgument(SyntaxNode node)
+    {
+        foreach (var invocation in node.AncestorsAndSelf().OfType<InvocationExpressionSyntax>())
+        {
+            if (invocation.Expression is IdentifierNameSyntax identifier &&
+                identifier.Identifier.Text == "nameof")
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private static bool IsParams(ParameterSyntax parameter) =>
         parameter.Modifiers.Any(m => m.IsKind(SyntaxKind.ParamsKeyword));
 
@@ -737,6 +849,17 @@ public sealed class AddParameterOperation : RefactoringOperationBase<AddParamete
     private static bool HasSourceDeclaration(IMethodSymbol method) =>
         method.DeclaringSyntaxReferences.Length > 0 &&
         method.Locations.Any(l => l.IsInSource);
+
+    private static bool ShareOverrideRoot(IMethodSymbol left, IMethodSymbol right) =>
+        SymbolEqualityComparer.Default.Equals(GetOverrideRoot(left), GetOverrideRoot(right));
+
+    private static IMethodSymbol GetOverrideRoot(IMethodSymbol method)
+    {
+        var current = method;
+        while (current.OverriddenMethod != null)
+            current = current.OverriddenMethod;
+        return current;
+    }
 
     private static string NormalizeIdentifier(string name) =>
         name.StartsWith('@') && name.Length > 1 ? name[1..] : name;
@@ -756,20 +879,7 @@ public sealed class AddParameterOperation : RefactoringOperationBase<AddParamete
         return SyntaxFactory.SeparatedList(nodes, separators);
     }
 
-    private static bool IsInvocationOf(InvocationExpressionSyntax invocation, HashSet<string> methodNames)
-    {
-        var name = invocation.Expression switch
-        {
-            IdentifierNameSyntax identifier => identifier.Identifier.Text,
-            MemberAccessExpressionSyntax member => member.Name.Identifier.Text,
-            MemberBindingExpressionSyntax binding => binding.Name.Identifier.Text,
-            _ => null
-        };
-
-        return name != null && methodNames.Contains(name);
-    }
-
-    private sealed record DeclarationTarget(Document Document, TextSpan Span, string MethodName);
+    private sealed record DeclarationTarget(Document Document, TextSpan Span);
 
     private sealed record CallSite(Document Document, TextSpan Span);
 

--- a/src/RoslynMcp.Core/Refactoring/Signature/AddParameterOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Signature/AddParameterOperation.cs
@@ -325,7 +325,11 @@ public sealed class AddParameterOperation : RefactoringOperationBase<AddParamete
         if (!string.IsNullOrEmpty(defaultValue))
         {
             paramSyntax = paramSyntax.WithDefault(
-                SyntaxFactory.EqualsValueClause(SyntaxFactory.ParseExpression(defaultValue)));
+                SyntaxFactory.EqualsValueClause(
+                    SyntaxFactory.Token(SyntaxKind.EqualsToken)
+                        .WithLeadingTrivia(SyntaxFactory.Space)
+                        .WithTrailingTrivia(SyntaxFactory.Space),
+                    SyntaxFactory.ParseExpression(defaultValue)));
         }
 
         return paramSyntax;
@@ -412,7 +416,7 @@ public sealed class AddParameterOperation : RefactoringOperationBase<AddParamete
                         ErrorCodes.DocumentNotEditable,
                         $"Could not locate the document for method '{method.Name}'.");
 
-                targets.Add(new DeclarationTarget(document, declaration.Span));
+                targets.Add(new DeclarationTarget(document, declaration.Span, method.Name));
             }
         }
 
@@ -503,14 +507,23 @@ public sealed class AddParameterOperation : RefactoringOperationBase<AddParamete
                 .Where(c => c.Document.Id == documentId)
                 .Select(c => c.Span)
                 .ToHashSet();
+            var targetNames = declarations
+                .Where(d => d.Document.Id == documentId)
+                .Select(d => d.MethodName)
+                .ToHashSet();
 
             var methods = root.DescendantNodes()
                 .OfType<MethodDeclarationSyntax>()
-                .Where(m => declarationSpans.Contains(m.Span))
+                .Where(m =>
+                    declarationSpans.Contains(m.Span) ||
+                    (targetNames.Contains(m.Identifier.Text) &&
+                     m.ParameterList.Parameters.Count == originalParams.Count))
                 .ToList();
             var invocations = root.DescendantNodes()
                 .OfType<InvocationExpressionSyntax>()
-                .Where(i => invocationSpans.Contains(i.Span))
+                .Where(i =>
+                    invocationSpans.Contains(i.Span) ||
+                    (targetNames.Count > 0 && IsInvocationOf(i, targetNames)))
                 .ToList();
 
             var rewriter = new AddParameterRewriter(
@@ -606,7 +619,8 @@ public sealed class AddParameterOperation : RefactoringOperationBase<AddParamete
         }
 
         return invocation.WithArgumentList(
-            SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(newArgs)));
+            SyntaxFactory.ArgumentList(SeparatedWithSpaces(newArgs))
+                .WithTriviaFrom(invocation.ArgumentList));
     }
 
     internal static ArgumentSyntax CreateArgument(string paramName, string? defaultValue)
@@ -727,7 +741,35 @@ public sealed class AddParameterOperation : RefactoringOperationBase<AddParamete
     private static string NormalizeIdentifier(string name) =>
         name.StartsWith('@') && name.Length > 1 ? name[1..] : name;
 
-    private sealed record DeclarationTarget(Document Document, TextSpan Span);
+    private static SeparatedSyntaxList<T> SeparatedWithSpaces<T>(IReadOnlyList<T> nodes)
+        where T : SyntaxNode
+    {
+        if (nodes.Count == 0)
+            return SyntaxFactory.SeparatedList<T>();
+
+        var separators = nodes.Count == 1
+            ? Array.Empty<SyntaxToken>()
+            : Enumerable.Repeat(
+                SyntaxFactory.Token(SyntaxKind.CommaToken).WithTrailingTrivia(SyntaxFactory.Space),
+                nodes.Count - 1).ToArray();
+
+        return SyntaxFactory.SeparatedList(nodes, separators);
+    }
+
+    private static bool IsInvocationOf(InvocationExpressionSyntax invocation, HashSet<string> methodNames)
+    {
+        var name = invocation.Expression switch
+        {
+            IdentifierNameSyntax identifier => identifier.Identifier.Text,
+            MemberAccessExpressionSyntax member => member.Name.Identifier.Text,
+            MemberBindingExpressionSyntax binding => binding.Name.Identifier.Text,
+            _ => null
+        };
+
+        return name != null && methodNames.Contains(name);
+    }
+
+    private sealed record DeclarationTarget(Document Document, TextSpan Span, string MethodName);
 
     private sealed record CallSite(Document Document, TextSpan Span);
 
@@ -773,7 +815,7 @@ public sealed class AddParameterOperation : RefactoringOperationBase<AddParamete
             var insertAt = Math.Min(_insertIndex, parameters.Count);
             parameters.Insert(insertAt, _newParameter);
             return visited.WithParameterList(
-                SyntaxFactory.ParameterList(SyntaxFactory.SeparatedList(parameters))
+                SyntaxFactory.ParameterList(SeparatedWithSpaces(parameters))
                     .WithTriviaFrom(visited.ParameterList));
         }
 

--- a/src/RoslynMcp.Core/Refactoring/Signature/AddParameterOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Signature/AddParameterOperation.cs
@@ -1,0 +1,795 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Text;
+using RoslynMcp.Contracts.Enums;
+using RoslynMcp.Contracts.Errors;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.FileSystem;
+using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Workspace;
+
+namespace RoslynMcp.Core.Refactoring.Signature;
+
+/// <summary>
+/// Adds a named parameter to a method and updates call sites, overrides,
+/// and interface implementations.
+/// </summary>
+public sealed class AddParameterOperation : RefactoringOperationBase<AddParameterParams>
+{
+    /// <summary>
+    /// Creates a new add parameter operation.
+    /// </summary>
+    public AddParameterOperation(WorkspaceContext context) : base(context)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override void ValidateParams(AddParameterParams @params) => Validate(@params);
+
+    /// <summary>
+    /// Validates add-parameter inputs. Internal so tests can exercise rules
+    /// without loading a workspace.
+    /// </summary>
+    internal static void Validate(AddParameterParams @params)
+    {
+        if (string.IsNullOrWhiteSpace(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "sourceFile is required.");
+
+        if (string.IsNullOrWhiteSpace(@params.MethodName))
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "methodName is required.");
+
+        if (string.IsNullOrWhiteSpace(@params.ParameterName))
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "parameterName is required.");
+
+        if (string.IsNullOrWhiteSpace(@params.ParameterType))
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "parameterType is required.");
+
+        if (!PathResolver.IsAbsolutePath(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.InvalidSourcePath, "sourceFile must be an absolute path.");
+
+        if (!PathResolver.IsValidCSharpFilePath(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.InvalidSourcePath, "sourceFile must be a .cs file.");
+
+        if (!File.Exists(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.SourceFileNotFound, $"Source file not found: {@params.SourceFile}");
+
+        if (!IsValidIdentifier(@params.ParameterName))
+            throw new RefactoringException(ErrorCodes.InvalidSymbolName, $"'{@params.ParameterName}' is not a valid parameter name.");
+
+        if (!IsValidParameterType(@params.ParameterType))
+            throw new RefactoringException(ErrorCodes.InvalidParameterType, $"'{@params.ParameterType}' is not a valid C# parameter type.");
+
+        if (@params.Position < -1)
+            throw new RefactoringException(ErrorCodes.InvalidParameterPosition, "position must be -1 (end) or a 0-based index.");
+
+        if (@params.Line.HasValue && @params.Line.Value < 1)
+            throw new RefactoringException(ErrorCodes.InvalidLineNumber, "Line number must be >= 1.");
+
+        if (@params.Column.HasValue && @params.Column.Value < 1)
+            throw new RefactoringException(ErrorCodes.InvalidColumnNumber, "Column number must be >= 1.");
+
+        if (@params.DefaultValue != null && !IsValidDefaultValueExpression(@params.DefaultValue))
+            throw new RefactoringException(ErrorCodes.InvalidDefaultValue, $"'{@params.DefaultValue}' is not a valid default value expression.");
+    }
+
+    /// <summary>
+    /// Rejects documents that cannot receive source edits.
+    /// </summary>
+    internal static void ValidateDocumentIsEditable(Document document, Microsoft.CodeAnalysis.Workspace workspace)
+    {
+        if (document is SourceGeneratedDocument)
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable (source-generated).");
+        }
+
+        if (string.IsNullOrWhiteSpace(document.FilePath) || !File.Exists(document.FilePath))
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable.");
+        }
+
+        if (!workspace.CanApplyChange(ApplyChangesKind.ChangeDocument))
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable (workspace cannot apply changes).");
+        }
+    }
+
+    /// <inheritdoc />
+    protected override async Task<RefactoringResult> ExecuteCoreAsync(
+        Guid operationId,
+        AddParameterParams @params,
+        CancellationToken cancellationToken)
+    {
+        var document = GetDocumentOrThrow(@params.SourceFile);
+        ValidateDocumentIsEditable(document, Context.Workspace);
+
+        var root = await document.GetSyntaxRootAsync(cancellationToken);
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken);
+        if (root == null || semanticModel == null)
+            throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse file.");
+
+        var methodDecl = FindMethodDeclaration(root, @params);
+        var methodSymbol = semanticModel.GetDeclaredSymbol(methodDecl, cancellationToken)
+            ?? throw new RefactoringException(ErrorCodes.RoslynError, "Could not resolve method symbol.");
+
+        if (methodSymbol.Parameters.Any(p => p.Name == NormalizeIdentifier(@params.ParameterName)))
+        {
+            throw new RefactoringException(
+                ErrorCodes.ParameterAlreadyExists,
+                $"Parameter '{@params.ParameterName}' already exists in method '{@params.MethodName}'.");
+        }
+
+        var insertIndex = ComputeInsertionIndex(methodDecl.ParameterList, @params.Position);
+        var attachDefaultToDeclaration = CanAttachDefaultToDeclaration(methodDecl.ParameterList, insertIndex);
+        ValidateResultingSignature(methodDecl.ParameterList, insertIndex, @params, attachDefaultToDeclaration);
+
+        var relatedMethods = await GetRelatedMethodsAsync(
+            methodSymbol,
+            @params.UpdateOverrides,
+            @params.UpdateImplementations,
+            cancellationToken);
+
+        var declarationTargets = await CollectDeclarationTargetsAsync(relatedMethods, cancellationToken);
+        foreach (var target in declarationTargets)
+            ValidateDocumentIsEditable(target.Document, Context.Workspace);
+
+        var callSites = await CollectCallSitesAsync(relatedMethods, cancellationToken);
+        foreach (var callSite in callSites)
+            ValidateDocumentIsEditable(callSite.Document, Context.Workspace);
+
+        var declarationDefault = attachDefaultToDeclaration ? @params.DefaultValue : null;
+        var newParameter = CreateParameter(NormalizeIdentifier(@params.ParameterName), @params.ParameterType, declarationDefault);
+        var appending = insertIndex >= methodSymbol.Parameters.Length;
+
+        var newSolution = await ApplyChangesAsync(
+            document,
+            declarationTargets,
+            callSites,
+            methodSymbol.Parameters.ToList(),
+            insertIndex,
+            newParameter,
+            @params.ParameterName,
+            @params.DefaultValue,
+            appending,
+            cancellationToken);
+
+        if (@params.Preview)
+        {
+            return await CreatePreviewResultAsync(
+                operationId,
+                @params,
+                document,
+                newSolution,
+                insertIndex,
+                callSites.Count,
+                cancellationToken);
+        }
+
+        var commitResult = await CommitChangesAsync(newSolution, cancellationToken);
+
+        return RefactoringResult.Succeeded(
+            operationId,
+            new FileChanges
+            {
+                FilesModified = commitResult.FilesModified,
+                FilesCreated = commitResult.FilesCreated,
+                FilesDeleted = commitResult.FilesDeleted
+            },
+            new Contracts.Models.SymbolInfo
+            {
+                Name = @params.MethodName,
+                FullyQualifiedName = methodSymbol.ToDisplayString(),
+                Kind = Contracts.Enums.SymbolKind.Method
+            },
+            callSites.Count,
+            0);
+    }
+
+    internal static MethodDeclarationSyntax FindMethodDeclaration(SyntaxNode root, AddParameterParams @params)
+    {
+        var methods = root.DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .Where(m => m.Identifier.Text == @params.MethodName)
+            .ToList();
+
+        if (methods.Count == 0)
+        {
+            throw new RefactoringException(
+                ErrorCodes.MethodNotFound,
+                $"Method '{@params.MethodName}' not found.");
+        }
+
+        if (methods.Count == 1 && !@params.Line.HasValue && !@params.Column.HasValue)
+            return methods[0];
+
+        IEnumerable<MethodDeclarationSyntax> filtered = methods;
+        if (@params.Line.HasValue)
+        {
+            filtered = filtered.Where(m =>
+                m.GetLocation().GetLineSpan().StartLinePosition.Line + 1 == @params.Line.Value);
+        }
+
+        if (@params.Column.HasValue)
+        {
+            filtered = filtered.Where(m =>
+                m.GetLocation().GetLineSpan().StartLinePosition.Character + 1 == @params.Column.Value);
+        }
+
+        var matches = filtered.ToList();
+        if (matches.Count == 1)
+            return matches[0];
+
+        if (matches.Count == 0)
+        {
+            throw new RefactoringException(
+                ErrorCodes.MethodNotFound,
+                @params.Line.HasValue
+                    ? $"Method '{@params.MethodName}' not found at line {@params.Line}."
+                    : $"Method '{@params.MethodName}' not found.");
+        }
+
+        var lines = matches
+            .Select(m => m.GetLocation().GetLineSpan().StartLinePosition.Line + 1)
+            .ToList();
+        throw new RefactoringException(
+            ErrorCodes.SymbolAmbiguous,
+            $"Multiple methods named '{@params.MethodName}' found. Provide line number. Options: {string.Join(", ", lines)}");
+    }
+
+    internal static int ComputeInsertionIndex(ParameterListSyntax list, int position)
+    {
+        var count = list.Parameters.Count;
+        if (position == -1)
+        {
+            for (var i = 0; i < count; i++)
+            {
+                if (IsParams(list.Parameters[i]) || IsOptional(list.Parameters[i]))
+                    return i;
+            }
+
+            return count;
+        }
+
+        if (position < 0 || position > count)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidParameterPosition,
+                $"Position {position} is out of range. Valid range is 0 to {count}.");
+        }
+
+        return position;
+    }
+
+    internal static bool CanAttachDefaultToDeclaration(ParameterListSyntax original, int insertIndex)
+    {
+        for (var i = insertIndex; i < original.Parameters.Count; i++)
+        {
+            if (!IsOptional(original.Parameters[i]) && !IsParams(original.Parameters[i]))
+                return false;
+        }
+
+        return true;
+    }
+
+    internal static void ValidateResultingSignature(
+        ParameterListSyntax original,
+        int insertIndex,
+        AddParameterParams @params,
+        bool attachDefaultToDeclaration)
+    {
+        var hypothetical = original.Parameters.ToList();
+        hypothetical.Insert(insertIndex, CreateParameter(
+            NormalizeIdentifier(@params.ParameterName),
+            @params.ParameterType,
+            attachDefaultToDeclaration ? @params.DefaultValue : null));
+
+        var seenOptional = false;
+        for (var i = 0; i < hypothetical.Count; i++)
+        {
+            var parameter = hypothetical[i];
+            var isParams = IsParams(parameter);
+            var isOptional = IsOptional(parameter);
+
+            if (isParams && i != hypothetical.Count - 1)
+            {
+                throw new RefactoringException(
+                    ErrorCodes.ParamsNotLast,
+                    "A params parameter must remain last in the parameter list.");
+            }
+
+            if (isOptional)
+            {
+                seenOptional = true;
+            }
+            else if (seenOptional && !isParams)
+            {
+                throw new RefactoringException(
+                    ErrorCodes.RequiredAfterOptional,
+                    "Required parameters cannot follow optional parameters.");
+            }
+        }
+    }
+
+    internal static ParameterSyntax CreateParameter(string name, string type, string? defaultValue)
+    {
+        var paramSyntax = SyntaxFactory.Parameter(SyntaxFactory.Identifier(name))
+            .WithType(SyntaxFactory.ParseTypeName(type).WithTrailingTrivia(SyntaxFactory.Space));
+
+        if (!string.IsNullOrEmpty(defaultValue))
+        {
+            paramSyntax = paramSyntax.WithDefault(
+                SyntaxFactory.EqualsValueClause(SyntaxFactory.ParseExpression(defaultValue)));
+        }
+
+        return paramSyntax;
+    }
+
+    private async Task<List<IMethodSymbol>> GetRelatedMethodsAsync(
+        IMethodSymbol method,
+        bool updateOverrides,
+        bool updateImplementations,
+        CancellationToken cancellationToken)
+    {
+        var results = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default) { method };
+
+        if (updateOverrides)
+        {
+            var current = method;
+            while (current.OverriddenMethod != null)
+            {
+                results.Add(current.OverriddenMethod);
+                current = current.OverriddenMethod;
+            }
+
+            foreach (var symbol in results.ToList())
+            {
+                var overrides = await SymbolFinder.FindOverridesAsync(
+                    symbol, Context.Solution, cancellationToken: cancellationToken);
+                foreach (var ov in overrides.OfType<IMethodSymbol>())
+                    results.Add(ov);
+            }
+        }
+
+        if (updateImplementations)
+        {
+            if (method.ContainingType.TypeKind == TypeKind.Interface)
+            {
+                var implementations = await SymbolFinder.FindImplementationsAsync(
+                    method, Context.Solution, cancellationToken: cancellationToken);
+                foreach (var impl in implementations.OfType<IMethodSymbol>())
+                    results.Add(impl);
+            }
+
+            foreach (var iface in method.ContainingType.AllInterfaces)
+            {
+                foreach (var ifaceMethod in iface.GetMembers(method.Name).OfType<IMethodSymbol>())
+                {
+                    var impl = method.ContainingType.FindImplementationForInterfaceMember(ifaceMethod);
+                    if (impl is IMethodSymbol implMethod &&
+                        SymbolEqualityComparer.Default.Equals(implMethod, method))
+                    {
+                        results.Add(ifaceMethod);
+                        var otherImpls = await SymbolFinder.FindImplementationsAsync(
+                            ifaceMethod,
+                            Context.Solution,
+                            cancellationToken: cancellationToken);
+                        foreach (var other in otherImpls.OfType<IMethodSymbol>())
+                            results.Add(other);
+                    }
+                }
+            }
+        }
+
+        return results.Where(HasSourceDeclaration).ToList();
+    }
+
+    private async Task<List<DeclarationTarget>> CollectDeclarationTargetsAsync(
+        IReadOnlyList<IMethodSymbol> methods,
+        CancellationToken cancellationToken)
+    {
+        var targets = new List<DeclarationTarget>();
+
+        foreach (var method in methods)
+        {
+            foreach (var syntaxRef in method.DeclaringSyntaxReferences)
+            {
+                if (await syntaxRef.GetSyntaxAsync(cancellationToken) is not MethodDeclarationSyntax declaration)
+                {
+                    throw new RefactoringException(
+                        ErrorCodes.InvalidSelection,
+                        $"Method '{method.Name}' is an unsupported target for add_parameter.");
+                }
+
+                var document = Context.Solution.GetDocument(syntaxRef.SyntaxTree)
+                    ?? throw new RefactoringException(
+                        ErrorCodes.DocumentNotEditable,
+                        $"Could not locate the document for method '{method.Name}'.");
+
+                targets.Add(new DeclarationTarget(document, declaration.Span));
+            }
+        }
+
+        if (targets.Count == 0)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidSelection,
+                "The selected method is an unsupported target for add_parameter.");
+        }
+
+        return targets;
+    }
+
+    private async Task<List<CallSite>> CollectCallSitesAsync(
+        IReadOnlyList<IMethodSymbol> methods,
+        CancellationToken cancellationToken)
+    {
+        var callSites = new List<CallSite>();
+        var seen = new HashSet<(DocumentId Id, TextSpan Span)>();
+
+        foreach (var method in methods)
+        {
+            var references = await SymbolFinder.FindReferencesAsync(method, Context.Solution, cancellationToken);
+            foreach (var referenced in references)
+            {
+                foreach (var location in referenced.Locations)
+                {
+                    if (location.Location.Kind != LocationKind.SourceFile)
+                        continue;
+
+                    var document = location.Document;
+                    var root = await document.GetSyntaxRootAsync(cancellationToken);
+                    if (root == null)
+                        continue;
+
+                    var node = root.FindNode(location.Location.SourceSpan);
+                    var invocation = node.AncestorsAndSelf().OfType<InvocationExpressionSyntax>().FirstOrDefault();
+                    if (invocation == null)
+                        continue;
+
+                    if (invocation.ArgumentList.Span.Contains(location.Location.SourceSpan) ||
+                        node.AncestorsAndSelf().OfType<MethodDeclarationSyntax>().Any(m =>
+                            m.Identifier.Span.IntersectsWith(location.Location.SourceSpan)))
+                    {
+                        continue;
+                    }
+
+                    if (!seen.Add((document.Id, invocation.Span)))
+                        continue;
+
+                    callSites.Add(new CallSite(document, invocation.Span));
+                }
+            }
+        }
+
+        return callSites;
+    }
+
+    private static async Task<Solution> ApplyChangesAsync(
+        Document originatingDocument,
+        IReadOnlyList<DeclarationTarget> declarations,
+        IReadOnlyList<CallSite> callSites,
+        IReadOnlyList<IParameterSymbol> originalParams,
+        int insertIndex,
+        ParameterSyntax newParameter,
+        string parameterName,
+        string? defaultValue,
+        bool appending,
+        CancellationToken cancellationToken)
+    {
+        var solution = originatingDocument.Project.Solution;
+        var documentIds = declarations.Select(d => d.Document.Id)
+            .Concat(callSites.Select(c => c.Document.Id))
+            .ToHashSet();
+
+        foreach (var documentId in documentIds)
+        {
+            var document = solution.GetDocument(documentId)
+                ?? throw new RefactoringException(ErrorCodes.RoslynError, "Document disappeared from solution.");
+            var root = await document.GetSyntaxRootAsync(cancellationToken)
+                ?? throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse file.");
+
+            var declarationSpans = declarations
+                .Where(d => d.Document.Id == documentId)
+                .Select(d => d.Span)
+                .ToHashSet();
+            var invocationSpans = callSites
+                .Where(c => c.Document.Id == documentId)
+                .Select(c => c.Span)
+                .ToHashSet();
+
+            var methods = root.DescendantNodes()
+                .OfType<MethodDeclarationSyntax>()
+                .Where(m => declarationSpans.Contains(m.Span))
+                .ToList();
+            var invocations = root.DescendantNodes()
+                .OfType<InvocationExpressionSyntax>()
+                .Where(i => invocationSpans.Contains(i.Span))
+                .ToList();
+
+            var rewriter = new AddParameterRewriter(
+                methods,
+                invocations,
+                insertIndex,
+                newParameter,
+                originalParams,
+                parameterName,
+                defaultValue,
+                appending);
+            root = rewriter.Visit(root)
+                ?? throw new RefactoringException(ErrorCodes.RoslynError, "Failed to rewrite add_parameter targets.");
+
+            solution = document.WithSyntaxRoot(root).Project.Solution;
+        }
+
+        return solution;
+    }
+
+    internal static InvocationExpressionSyntax UpdateInvocation(
+        InvocationExpressionSyntax invocation,
+        IReadOnlyList<IParameterSymbol> originalParams,
+        int insertIndex,
+        string parameterName,
+        string? defaultValue,
+        bool appending)
+    {
+        var originalArgs = invocation.ArgumentList.Arguments.ToList();
+        var newArg = CreateArgument(parameterName, defaultValue);
+        var useNamedInsertion = !appending || originalArgs.Any(a => a.NameColon != null);
+
+        if (useNamedInsertion && newArg.NameColon == null)
+        {
+            newArg = newArg.WithNameColon(
+                SyntaxFactory.NameColon(SyntaxFactory.IdentifierName(NormalizeIdentifier(parameterName))));
+        }
+
+        var namedOriginal = new Dictionary<string, ArgumentSyntax>();
+        var positionalOriginal = new List<ArgumentSyntax>();
+        foreach (var arg in originalArgs)
+        {
+            if (arg.NameColon != null)
+                namedOriginal[arg.NameColon.Name.Identifier.Text] = arg;
+            else
+                positionalOriginal.Add(arg);
+        }
+
+        var newArgs = new List<ArgumentSyntax>();
+        var positionalIndex = 0;
+        var namedNewArgInserted = false;
+
+        for (var i = 0; i < originalParams.Count + 1; i++)
+        {
+            if (i == insertIndex)
+            {
+                newArgs.Add(newArg);
+                namedNewArgInserted = newArg.NameColon != null;
+                continue;
+            }
+
+            var originalIndex = i < insertIndex ? i : i - 1;
+            if (originalIndex < 0 || originalIndex >= originalParams.Count)
+                continue;
+
+            var originalParam = originalParams[originalIndex];
+            if (namedOriginal.TryGetValue(originalParam.Name, out var namedArg))
+            {
+                newArgs.Add(namedArg);
+                continue;
+            }
+
+            if (positionalIndex >= positionalOriginal.Count)
+                continue;
+
+            var positional = positionalOriginal[positionalIndex++];
+            if (namedNewArgInserted && positional.NameColon == null)
+            {
+                positional = positional.WithNameColon(
+                    SyntaxFactory.NameColon(SyntaxFactory.IdentifierName(originalParam.Name)));
+            }
+
+            newArgs.Add(positional);
+        }
+
+        while (positionalIndex < positionalOriginal.Count)
+            newArgs.Add(positionalOriginal[positionalIndex++]);
+
+        foreach (var leftover in namedOriginal.Values)
+        {
+            if (!newArgs.Contains(leftover))
+                newArgs.Add(leftover);
+        }
+
+        return invocation.WithArgumentList(
+            SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(newArgs)));
+    }
+
+    internal static ArgumentSyntax CreateArgument(string paramName, string? defaultValue)
+    {
+        var expression = SyntaxFactory.ParseExpression(
+            string.IsNullOrEmpty(defaultValue) ? "default" : defaultValue);
+        return SyntaxFactory.Argument(expression);
+    }
+
+    private static async Task<RefactoringResult> CreatePreviewResultAsync(
+        Guid operationId,
+        AddParameterParams @params,
+        Document originalDocument,
+        Solution newSolution,
+        int insertIndex,
+        int callSiteCount,
+        CancellationToken cancellationToken)
+    {
+        var pendingChanges = new List<PendingChange>();
+        var originalSolution = originalDocument.Project.Solution;
+
+        foreach (var projectChanges in newSolution.GetChanges(originalSolution).GetProjectChanges())
+        {
+            foreach (var docId in projectChanges.GetChangedDocuments())
+            {
+                var oldDoc = originalSolution.GetDocument(docId);
+                var newDoc = newSolution.GetDocument(docId);
+                if (oldDoc?.FilePath == null || newDoc == null)
+                    continue;
+
+                var before = await oldDoc.GetTextAsync(cancellationToken);
+                var after = await newDoc.GetTextAsync(cancellationToken);
+                pendingChanges.Add(new PendingChange
+                {
+                    File = oldDoc.FilePath,
+                    ChangeType = ChangeKind.Modify,
+                    Description = $"Add parameter '{@params.ParameterName}' to '{@params.MethodName}' at position {insertIndex} ({callSiteCount} call site(s) to update)",
+                    BeforeSnippet = before.ToString(),
+                    AfterSnippet = after.ToString()
+                });
+            }
+        }
+
+        if (pendingChanges.Count == 0)
+        {
+            pendingChanges.Add(new PendingChange
+            {
+                File = @params.SourceFile,
+                ChangeType = ChangeKind.Modify,
+                Description = $"Add parameter '{@params.ParameterName}' to '{@params.MethodName}'",
+                BeforeSnippet = null,
+                AfterSnippet = null
+            });
+        }
+
+        return RefactoringResult.PreviewResult(operationId, pendingChanges);
+    }
+
+    internal static bool IsValidIdentifier(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return false;
+
+        if (name.StartsWith('@') && name.Length > 1)
+        {
+            var bare = name[1..];
+            return SyntaxFacts.IsValidIdentifier(bare) ||
+                   SyntaxFacts.GetKeywordKind(bare) != SyntaxKind.None;
+        }
+
+        if (!SyntaxFacts.IsValidIdentifier(name))
+            return false;
+
+        var keywordKind = SyntaxFacts.GetKeywordKind(name);
+        return keywordKind == SyntaxKind.None || !SyntaxFacts.IsReservedKeyword(keywordKind);
+    }
+
+    internal static bool IsValidParameterType(string type)
+    {
+        if (string.IsNullOrWhiteSpace(type))
+            return false;
+
+        var parsed = SyntaxFactory.ParseTypeName(type);
+        if (parsed.ContainsDiagnostics || parsed.IsMissing)
+            return false;
+
+        var remainder = type.Trim();
+        var written = parsed.ToString();
+        if (!string.Equals(written.Trim(), remainder, StringComparison.Ordinal))
+        {
+            // ParseTypeName is permissive; reject leftovers such as "int int".
+            if (remainder.Length > written.Trim().Length)
+                return false;
+        }
+
+        return parsed is not IdentifierNameSyntax identifier || !identifier.IsMissing;
+    }
+
+    internal static bool IsValidDefaultValueExpression(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return false;
+
+        var expression = SyntaxFactory.ParseExpression(value);
+        return !expression.ContainsDiagnostics && !expression.IsMissing;
+    }
+
+    private static bool IsParams(ParameterSyntax parameter) =>
+        parameter.Modifiers.Any(m => m.IsKind(SyntaxKind.ParamsKeyword));
+
+    private static bool IsOptional(ParameterSyntax parameter) =>
+        parameter.Default != null;
+
+    private static bool HasSourceDeclaration(IMethodSymbol method) =>
+        method.DeclaringSyntaxReferences.Length > 0 &&
+        method.Locations.Any(l => l.IsInSource);
+
+    private static string NormalizeIdentifier(string name) =>
+        name.StartsWith('@') && name.Length > 1 ? name[1..] : name;
+
+    private sealed record DeclarationTarget(Document Document, TextSpan Span);
+
+    private sealed record CallSite(Document Document, TextSpan Span);
+
+    private sealed class AddParameterRewriter : CSharpSyntaxRewriter
+    {
+        private readonly HashSet<MethodDeclarationSyntax> _methods;
+        private readonly HashSet<InvocationExpressionSyntax> _invocations;
+        private readonly int _insertIndex;
+        private readonly ParameterSyntax _newParameter;
+        private readonly IReadOnlyList<IParameterSymbol> _originalParams;
+        private readonly string _parameterName;
+        private readonly string? _defaultValue;
+        private readonly bool _appending;
+
+        public AddParameterRewriter(
+            IReadOnlyList<MethodDeclarationSyntax> methods,
+            IReadOnlyList<InvocationExpressionSyntax> invocations,
+            int insertIndex,
+            ParameterSyntax newParameter,
+            IReadOnlyList<IParameterSymbol> originalParams,
+            string parameterName,
+            string? defaultValue,
+            bool appending)
+        {
+            _methods = new HashSet<MethodDeclarationSyntax>(methods);
+            _invocations = new HashSet<InvocationExpressionSyntax>(invocations);
+            _insertIndex = insertIndex;
+            _newParameter = newParameter;
+            _originalParams = originalParams;
+            _parameterName = parameterName;
+            _defaultValue = defaultValue;
+            _appending = appending;
+        }
+
+        public override SyntaxNode? VisitMethodDeclaration(MethodDeclarationSyntax node)
+        {
+            var visited = (MethodDeclarationSyntax)base.VisitMethodDeclaration(node)!;
+            var original = _methods.FirstOrDefault(m => m.Span == node.Span && m.Identifier.Text == node.Identifier.Text);
+            if (original == null)
+                return visited;
+
+            var parameters = visited.ParameterList.Parameters.ToList();
+            var insertAt = Math.Min(_insertIndex, parameters.Count);
+            parameters.Insert(insertAt, _newParameter);
+            return visited.WithParameterList(
+                SyntaxFactory.ParameterList(SyntaxFactory.SeparatedList(parameters))
+                    .WithTriviaFrom(visited.ParameterList));
+        }
+
+        public override SyntaxNode? VisitInvocationExpression(InvocationExpressionSyntax node)
+        {
+            var visited = (InvocationExpressionSyntax)base.VisitInvocationExpression(node)!;
+            if (!_invocations.Contains(node) && !_invocations.Any(i => i.Span == node.Span))
+                return visited;
+
+            return UpdateInvocation(
+                visited,
+                _originalParams,
+                _insertIndex,
+                _parameterName,
+                _defaultValue,
+                _appending);
+        }
+    }
+}

--- a/src/RoslynMcp.Server/McpServerHost.cs
+++ b/src/RoslynMcp.Server/McpServerHost.cs
@@ -48,6 +48,7 @@ public sealed class McpServerHost : IAsyncDisposable
         _toolRegistry.Register(new InlineConstantTool(workspaceProvider));
         _toolRegistry.Register(new ExtractConstantTool(workspaceProvider));
         _toolRegistry.Register(new ChangeSignatureTool(workspaceProvider));
+        _toolRegistry.Register(new AddParameterTool(workspaceProvider));
         _toolRegistry.Register(new EncapsulateFieldTool(workspaceProvider));
         _toolRegistry.Register(new ConvertToAsyncTool(workspaceProvider));
         _toolRegistry.Register(new ExtractBaseClassTool(workspaceProvider));

--- a/src/RoslynMcp.Server/Tools/AddParameterTool.cs
+++ b/src/RoslynMcp.Server/Tools/AddParameterTool.cs
@@ -1,0 +1,185 @@
+using System.Text.Json;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.Refactoring;
+using RoslynMcp.Core.Refactoring.Signature;
+using RoslynMcp.Core.Workspace;
+using RoslynMcp.Server.Transport;
+
+namespace RoslynMcp.Server.Tools;
+
+/// <summary>
+/// MCP tool handler for add_parameter operation.
+/// </summary>
+public sealed class AddParameterTool : IToolHandler
+{
+    private readonly IWorkspaceProvider _workspaceProvider;
+    private readonly JsonSerializerOptions _jsonOptions;
+
+    /// <summary>
+    /// Creates a new add parameter tool.
+    /// </summary>
+    public AddParameterTool(IWorkspaceProvider workspaceProvider)
+    {
+        _workspaceProvider = workspaceProvider;
+        _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = false
+        };
+    }
+
+    /// <inheritdoc />
+    public string Name => "add_parameter";
+
+    /// <inheritdoc />
+    public string Description => "Add a named parameter to a method and update call sites, overrides, and interface implementations.";
+
+    /// <inheritdoc />
+    public object InputSchema => new
+    {
+        type = "object",
+        required = new[] { "solutionPath", "sourceFile", "methodName", "parameterName", "parameterType" },
+        properties = new
+        {
+            solutionPath = new
+            {
+                type = "string",
+                description = "Absolute path to the .sln or .csproj file"
+            },
+            sourceFile = new
+            {
+                type = "string",
+                description = "Absolute path to the source file containing the method"
+            },
+            methodName = new
+            {
+                type = "string",
+                description = "Name of the method to modify"
+            },
+            parameterName = new
+            {
+                type = "string",
+                description = "Name for the new parameter"
+            },
+            parameterType = new
+            {
+                type = "string",
+                description = "C# type of the new parameter"
+            },
+            defaultValue = new
+            {
+                type = "string",
+                description = "Default value for existing call sites"
+            },
+            position = new
+            {
+                type = "integer",
+                description = "0-based insertion position; -1 inserts at the end of required parameters",
+                @default = -1
+            },
+            line = new
+            {
+                type = "integer",
+                description = "Line number for disambiguation if multiple methods have the same name (1-based)"
+            },
+            column = new
+            {
+                type = "integer",
+                description = "Column number for disambiguation (1-based)"
+            },
+            updateOverrides = new
+            {
+                type = "boolean",
+                description = "Update the virtual/override chain together",
+                @default = true
+            },
+            updateImplementations = new
+            {
+                type = "boolean",
+                description = "Update interface declarations and implementations together",
+                @default = true
+            },
+            preview = new
+            {
+                type = "boolean",
+                description = "Return computed changes without applying",
+                @default = false
+            }
+        },
+        additionalProperties = false
+    };
+
+    /// <inheritdoc />
+    public async Task<ToolResult> ExecuteAsync(JsonElement? arguments, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (arguments == null)
+            {
+                return ToolResult.Error("Arguments required");
+            }
+
+            var args = JsonSerializer.Deserialize<AddParameterArgs>(arguments.Value.GetRawText(), _jsonOptions);
+            if (args == null)
+            {
+                return ToolResult.Error("Failed to parse arguments");
+            }
+
+            using var context = await _workspaceProvider.CreateContextAsync(
+                args.SolutionPath,
+                cancellationToken);
+
+            var operation = new AddParameterOperation(context);
+            var @params = new AddParameterParams
+            {
+                SourceFile = args.SourceFile,
+                MethodName = args.MethodName,
+                ParameterName = args.ParameterName,
+                ParameterType = args.ParameterType,
+                DefaultValue = args.DefaultValue,
+                Position = args.Position ?? -1,
+                Line = args.Line,
+                Column = args.Column,
+                UpdateOverrides = args.UpdateOverrides ?? true,
+                UpdateImplementations = args.UpdateImplementations ?? true,
+                Preview = args.Preview ?? false
+            };
+
+            var result = await operation.ExecuteAsync(@params, cancellationToken);
+
+            var json = JsonSerializer.Serialize(result, _jsonOptions);
+            return result.Success ? ToolResult.Success(json) : ToolResult.Error(json);
+        }
+        catch (RefactoringException ex)
+        {
+            var error = ex.ToError();
+            var json = JsonSerializer.Serialize(new { success = false, error }, _jsonOptions);
+            return ToolResult.Error(json);
+        }
+        catch (Exception ex)
+        {
+            var json = JsonSerializer.Serialize(new
+            {
+                success = false,
+                error = new { code = "INTERNAL_ERROR", message = ex.Message }
+            }, _jsonOptions);
+            return ToolResult.Error(json);
+        }
+    }
+
+    private sealed class AddParameterArgs
+    {
+        public string SolutionPath { get; init; } = "";
+        public string SourceFile { get; init; } = "";
+        public string MethodName { get; init; } = "";
+        public string ParameterName { get; init; } = "";
+        public string ParameterType { get; init; } = "";
+        public string? DefaultValue { get; init; }
+        public int? Position { get; init; }
+        public int? Line { get; init; }
+        public int? Column { get; init; }
+        public bool? UpdateOverrides { get; init; }
+        public bool? UpdateImplementations { get; init; }
+        public bool? Preview { get; init; }
+    }
+}

--- a/tests/RoslynMcp.Cli.Tests/HelpGeneratorTests.cs
+++ b/tests/RoslynMcp.Cli.Tests/HelpGeneratorTests.cs
@@ -15,11 +15,11 @@ public class HelpGeneratorTests
     }
 
     [Fact]
-    public void GenerateGlobalHelp_Lists54Tools()
+    public void GenerateGlobalHelp_Lists55Tools()
     {
         var registry = ToolRegistry.BuildDefault();
         var help = HelpGenerator.GenerateGlobalHelp(registry);
-        Assert.Contains("Total: 54 tools", help);
+        Assert.Contains("Total: 55 tools", help);
         Assert.Contains("pull-members-up", help);
         Assert.Contains("push-members-down", help);
         Assert.Contains("use-base-type", help);
@@ -32,6 +32,7 @@ public class HelpGeneratorTests
         Assert.Contains("generate-method-stub", help);
         Assert.Contains("implement-abstract", help);
         Assert.Contains("inline-constant", help);
+        Assert.Contains("add-parameter", help);
     }
 
     [Fact]

--- a/tests/RoslynMcp.Cli.Tests/ToolRegistryTests.cs
+++ b/tests/RoslynMcp.Cli.Tests/ToolRegistryTests.cs
@@ -6,11 +6,11 @@ namespace RoslynMcp.Cli.Tests;
 public class ToolRegistryTests
 {
     [Fact]
-    public void BuildDefault_Registers54Tools()
+    public void BuildDefault_Registers55Tools()
     {
         var registry = ToolRegistry.BuildDefault();
         var tools = registry.GetAllTools();
-        Assert.Equal(54, tools.Count);
+        Assert.Equal(55, tools.Count);
     }
 
     [Fact]
@@ -85,6 +85,7 @@ public class ToolRegistryTests
     [InlineData("extract-method", "Refactoring")]
     [InlineData("inline-method", "Refactoring")]
     [InlineData("inline-constant", "Refactoring")]
+    [InlineData("add-parameter", "Refactoring")]
     [InlineData("pull-members-up", "Refactoring")]
     [InlineData("push-members-down", "Refactoring")]
     [InlineData("use-base-type", "Refactoring")]
@@ -114,11 +115,11 @@ public class ToolRegistryTests
     }
 
     [Fact]
-    public void RefactoringToolCount_Is41()
+    public void RefactoringToolCount_Is42()
     {
         var registry = ToolRegistry.BuildDefault();
         var count = registry.GetAllTools().Count(t => t.Category == "Refactoring");
-        Assert.Equal(41, count);
+        Assert.Equal(42, count);
     }
 
     [Fact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Signature/AddParameterOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Signature/AddParameterOperationTests.cs
@@ -1,0 +1,642 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using RoslynMcp.Contracts.Errors;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.Refactoring;
+using RoslynMcp.Core.Refactoring.Signature;
+using RoslynMcp.Core.Workspace;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Refactoring.Signature;
+
+/// <summary>
+/// Operation-level tests for <see cref="AddParameterOperation"/>.
+/// </summary>
+public class AddParameterOperationTests
+{
+    #region Input Validation
+
+    [Fact]
+    public void Validate_MissingSourceFile_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            AddParameterOperation.Validate(ValidParams(sourceFile: "")));
+
+        Assert.Equal(ErrorCodes.MissingRequiredParam, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_MissingMethodName_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            AddParameterOperation.Validate(ValidParams(methodName: "")));
+
+        Assert.Equal(ErrorCodes.MissingRequiredParam, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_MissingParameterName_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            AddParameterOperation.Validate(ValidParams(parameterName: "")));
+
+        Assert.Equal(ErrorCodes.MissingRequiredParam, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_MissingParameterType_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            AddParameterOperation.Validate(ValidParams(parameterType: "")));
+
+        Assert.Equal(ErrorCodes.MissingRequiredParam, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_RelativePath_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            AddParameterOperation.Validate(ValidParams(sourceFile: "Worker.cs")));
+
+        Assert.Equal(ErrorCodes.InvalidSourcePath, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_MissingFile_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            AddParameterOperation.Validate(ValidParams()));
+
+        Assert.Equal(ErrorCodes.SourceFileNotFound, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_InvalidParameterType_Throws()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "RoslynMcpAddParameterInvalidType.cs");
+        File.WriteAllText(path, "class C {}");
+        try
+        {
+            var ex = Assert.Throws<RefactoringException>(() =>
+                AddParameterOperation.Validate(ValidParams(sourceFile: path, parameterType: "int int")));
+
+            Assert.Equal(ErrorCodes.InvalidParameterType, ex.ErrorCode);
+            Assert.Equal("1010", ex.ErrorCode);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Validate_InvalidPosition_Throws()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "RoslynMcpAddParameterInvalidPos.cs");
+        File.WriteAllText(path, "class C {}");
+        try
+        {
+            var ex = Assert.Throws<RefactoringException>(() =>
+                AddParameterOperation.Validate(ValidParams(sourceFile: path, position: -2)));
+
+            Assert.Equal(ErrorCodes.InvalidParameterPosition, ex.ErrorCode);
+            Assert.Equal("1011", ex.ErrorCode);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void IsValidParameterType_RejectsUnparseableTypes()
+    {
+        Assert.True(AddParameterOperation.IsValidParameterType("int"));
+        Assert.True(AddParameterOperation.IsValidParameterType("string?"));
+        Assert.True(AddParameterOperation.IsValidParameterType("List<int>"));
+        Assert.False(AddParameterOperation.IsValidParameterType(""));
+        Assert.False(AddParameterOperation.IsValidParameterType("int int"));
+        Assert.False(AddParameterOperation.IsValidParameterType("???"));
+    }
+
+    #endregion
+
+    #region Happy Path
+
+    [SkippableFact]
+    public async Task AddParameter_SimpleAdd_AppendsAtEnd()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public void Process(int count)
+                {
+                }
+
+                public void Run()
+                {
+                    Process(3);
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new AddParameterOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new AddParameterParams
+        {
+            SourceFile = workspace.SourcePath,
+            MethodName = "Process",
+            ParameterName = "label",
+            ParameterType = "string",
+            DefaultValue = "\"ok\""
+        });
+
+        Assert.True(result.Success);
+        Assert.False(result.Preview);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Contains("public void Process(int count, string label = \"ok\")", text);
+        Assert.Contains("Process(3, \"ok\")", text);
+    }
+
+    [SkippableFact]
+    public async Task AddParameter_DefaultValue_UpdatesCallSites()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public int Process(int count)
+                {
+                    return count;
+                }
+
+                public int Run() => Process(3) + Process(4);
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new AddParameterOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new AddParameterParams
+        {
+            SourceFile = workspace.SourcePath,
+            MethodName = "Process",
+            ParameterName = "timeout",
+            ParameterType = "int",
+            DefaultValue = "30"
+        });
+
+        Assert.True(result.Success);
+        Assert.Equal(2, result.ReferencesUpdated);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Contains("public int Process(int count, int timeout = 30)", text);
+        Assert.Contains("Process(3, 30)", text);
+        Assert.Contains("Process(4, 30)", text);
+    }
+
+    [SkippableFact]
+    public async Task AddParameter_NamedArgs_InsertsNamedArgument()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public void Process(int count, string name)
+                {
+                }
+
+                public void Run()
+                {
+                    Process(count: 3, name: "a");
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new AddParameterOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new AddParameterParams
+        {
+            SourceFile = workspace.SourcePath,
+            MethodName = "Process",
+            ParameterName = "flag",
+            ParameterType = "bool",
+            DefaultValue = "true",
+            Position = 1
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Contains("public void Process(int count, bool flag, string name)", text);
+        Assert.Contains("flag:", text);
+        Assert.Contains("true", text);
+        Assert.Contains("name:", text);
+    }
+
+    [SkippableFact]
+    public async Task AddParameter_OverrideAndInterface_UpdatesChain()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public interface IWorker
+            {
+                void Process(int count);
+            }
+
+            public class WorkerBase : IWorker
+            {
+                public virtual void Process(int count)
+                {
+                }
+            }
+
+            public class Worker : WorkerBase
+            {
+                public override void Process(int count)
+                {
+                }
+
+                public void Run(IWorker worker)
+                {
+                    worker.Process(1);
+                    Process(2);
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new AddParameterOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new AddParameterParams
+        {
+            SourceFile = workspace.SourcePath,
+            MethodName = "Process",
+            ParameterName = "timeout",
+            ParameterType = "int",
+            DefaultValue = "30",
+            Line = 17
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Contains("void Process(int count, int timeout = 30);", text);
+        Assert.Contains("public virtual void Process(int count, int timeout = 30)", text);
+        Assert.Contains("public override void Process(int count, int timeout = 30)", text);
+        Assert.Contains("worker.Process(1, 30)", text);
+        Assert.Contains("Process(2, 30)", text);
+    }
+
+    [SkippableFact]
+    public async Task AddParameter_Preview_ReturnsChangesAndWritesNothing()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public void Process(int count)
+                {
+                }
+
+                public void Run() => Process(3);
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var original = await File.ReadAllTextAsync(workspace.SourcePath);
+        var operation = new AddParameterOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new AddParameterParams
+        {
+            SourceFile = workspace.SourcePath,
+            MethodName = "Process",
+            ParameterName = "label",
+            ParameterType = "string",
+            DefaultValue = "\"ok\"",
+            Preview = true
+        });
+
+        Assert.True(result.Success);
+        Assert.True(result.Preview);
+        Assert.NotNull(result.PendingChanges);
+        Assert.NotEmpty(result.PendingChanges);
+        Assert.Contains(result.PendingChanges, c =>
+            c.AfterSnippet != null &&
+            c.AfterSnippet.Contains("string label") &&
+            c.AfterSnippet.Contains("Process(3, \"ok\")"));
+
+        var after = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Equal(original, after);
+    }
+
+    [SkippableFact]
+    public async Task AddParameter_BeforeParams_KeepsParamsLast()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public void Process(int count, params string[] rest)
+                {
+                }
+
+                public void Run() => Process(1, "a", "b");
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new AddParameterOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new AddParameterParams
+        {
+            SourceFile = workspace.SourcePath,
+            MethodName = "Process",
+            ParameterName = "label",
+            ParameterType = "string",
+            DefaultValue = "\"x\""
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Contains("public void Process(int count, string label = \"x\", params string[] rest)", text);
+    }
+
+    #endregion
+
+    #region Rejects
+
+    [SkippableFact]
+    public async Task AddParameter_DuplicateName_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public void Process(int count)
+                {
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new AddParameterOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new AddParameterParams
+            {
+                SourceFile = workspace.SourcePath,
+                MethodName = "Process",
+                ParameterName = "count",
+                ParameterType = "string"
+            }));
+
+        Assert.Equal(ErrorCodes.ParameterAlreadyExists, ex.ErrorCode);
+        Assert.Equal("3127", ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task AddParameter_PositionOutOfRange_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public void Process(int count)
+                {
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new AddParameterOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new AddParameterParams
+            {
+                SourceFile = workspace.SourcePath,
+                MethodName = "Process",
+                ParameterName = "label",
+                ParameterType = "string",
+                Position = 4
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidParameterPosition, ex.ErrorCode);
+        Assert.Equal("1011", ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task AddParameter_RequiredAfterOptional_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public void Process(int count = 1)
+                {
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new AddParameterOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new AddParameterParams
+            {
+                SourceFile = workspace.SourcePath,
+                MethodName = "Process",
+                ParameterName = "label",
+                ParameterType = "string",
+                Position = 1
+            }));
+
+        Assert.Equal(ErrorCodes.RequiredAfterOptional, ex.ErrorCode);
+        Assert.Equal("3128", ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task AddParameter_ParamsNotLast_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public void Process(params int[] values)
+                {
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new AddParameterOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new AddParameterParams
+            {
+                SourceFile = workspace.SourcePath,
+                MethodName = "Process",
+                ParameterName = "label",
+                ParameterType = "string",
+                Position = 1
+            }));
+
+        Assert.Equal(ErrorCodes.ParamsNotLast, ex.ErrorCode);
+        Assert.Equal("3129", ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task AddParameter_MissingMethod_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public void Process(int count)
+                {
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new AddParameterOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new AddParameterParams
+            {
+                SourceFile = workspace.SourcePath,
+                MethodName = "DoesNotExist",
+                ParameterName = "label",
+                ParameterType = "string"
+            }));
+
+        Assert.Equal(ErrorCodes.MethodNotFound, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void AddParameter_UneditableDocument_Throws()
+    {
+        var workspace = new AdhocWorkspace();
+        var project = workspace.AddProject("P", LanguageNames.CSharp);
+        var document = workspace.AddDocument(project.Id, "Generated.cs", SourceText.From("class C {}"));
+
+        var ex = Assert.Throws<RefactoringException>(() =>
+            AddParameterOperation.ValidateDocumentIsEditable(document, workspace));
+
+        Assert.Equal(ErrorCodes.DocumentNotEditable, ex.ErrorCode);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static AddParameterParams ValidParams(
+        string? sourceFile = null,
+        string methodName = "Process",
+        string parameterName = "timeout",
+        string parameterType = "int",
+        int position = -1) => new()
+        {
+            SourceFile = sourceFile ?? Path.Combine(Path.GetTempPath(), "RoslynMcpAddParameterMissing.cs"),
+            MethodName = methodName,
+            ParameterName = parameterName,
+            ParameterType = parameterType,
+            Position = position
+        };
+
+    private sealed class TempWorkspace : IAsyncDisposable
+    {
+        public required string DirectoryPath { get; init; }
+        public required string ProjectPath { get; init; }
+        public required string SourcePath { get; init; }
+        public required WorkspaceContext Context { get; init; }
+
+        public static async Task<TempWorkspace> CreateAsync(string source, string fileName = "Worker.cs")
+        {
+            Skip.IfNot(ModuleInitializer.MsBuildAvailable, ModuleInitializer.MsBuildError ?? "MSBuild not available");
+
+            var directory = Path.Combine(Path.GetTempPath(), "RoslynMcpAddParameter_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(directory);
+
+            var projectPath = Path.Combine(directory, "TestApp.csproj");
+            await File.WriteAllTextAsync(projectPath, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net9.0</TargetFramework>
+                    <Nullable>enable</Nullable>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var sourcePath = Path.Combine(directory, fileName);
+            await File.WriteAllTextAsync(sourcePath, source);
+
+            try
+            {
+                var provider = new MSBuildWorkspaceProvider();
+                var context = await provider.CreateContextAsync(projectPath);
+                if (context.GetDocumentByPath(sourcePath) == null)
+                {
+                    context.Dispose();
+                    throw new InvalidOperationException($"Workspace loaded but did not include {sourcePath}.");
+                }
+
+                return new TempWorkspace
+                {
+                    DirectoryPath = directory,
+                    ProjectPath = projectPath,
+                    SourcePath = sourcePath,
+                    Context = context
+                };
+            }
+            catch (Exception ex) when (ex is not SkipException)
+            {
+                try
+                {
+                    Directory.Delete(directory, recursive: true);
+                }
+                catch
+                {
+                    // ignore cleanup failures
+                }
+
+                Skip.If(true, $"Workspace load failed: {ex.Message}");
+                throw;
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            Context.Dispose();
+            await Task.Run(() =>
+            {
+                try
+                {
+                    Directory.Delete(DirectoryPath, recursive: true);
+                }
+                catch
+                {
+                    // ignore locked temp files
+                }
+            });
+        }
+    }
+
+    #endregion
+}

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Signature/AddParameterOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Signature/AddParameterOperationTests.cs
@@ -373,6 +373,55 @@ public class AddParameterOperationTests
         Assert.Contains("public void Process(int count, string label = \"x\", params string[] rest)", text);
     }
 
+    [SkippableFact]
+    public async Task AddParameter_SameNameOnOtherType_LeavesUnselectedMethodUntouched()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Alpha
+            {
+                public void Process(int count)
+                {
+                }
+
+                public void Run() => Process(1);
+            }
+
+            public class Beta
+            {
+                public void Process(string name)
+                {
+                }
+
+                public void Run() => Process("x");
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new AddParameterOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new AddParameterParams
+        {
+            SourceFile = workspace.SourcePath,
+            MethodName = "Process",
+            ParameterName = "label",
+            ParameterType = "string",
+            DefaultValue = "\"ok\"",
+            Line = 5
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Contains("public void Process(int count, string label = \"ok\")", text);
+        Assert.Contains("public void Run() => Process(1, \"ok\");", text);
+        Assert.Contains("public void Process(string name)", text);
+        Assert.Contains("public void Run() => Process(\"x\");", text);
+        Assert.DoesNotContain("Process(string name, string label", text);
+        Assert.DoesNotContain("Process(\"x\", \"ok\")", text);
+    }
+
     #endregion
 
     #region Rejects
@@ -540,6 +589,139 @@ public class AddParameterOperationTests
             AddParameterOperation.ValidateDocumentIsEditable(document, workspace));
 
         Assert.Equal(ErrorCodes.DocumentNotEditable, ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task AddParameter_MethodGroup_ThrowsAndWritesNothing()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public int Process(int count) => count;
+
+                public void Run()
+                {
+                    System.Func<int, int> handler = Process;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var original = await File.ReadAllTextAsync(workspace.SourcePath);
+        var operation = new AddParameterOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new AddParameterParams
+            {
+                SourceFile = workspace.SourcePath,
+                MethodName = "Process",
+                ParameterName = "timeout",
+                ParameterType = "int",
+                DefaultValue = "30"
+            }));
+
+        Assert.Equal(ErrorCodes.UnsupportedCallSite, ex.ErrorCode);
+        Assert.Equal("3130", ex.ErrorCode);
+        Assert.Equal(original, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [SkippableFact]
+    public async Task AddParameter_NonConstantDefault_DateTimeNow_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public void Process(int count)
+                {
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var original = await File.ReadAllTextAsync(workspace.SourcePath);
+        var operation = new AddParameterOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new AddParameterParams
+            {
+                SourceFile = workspace.SourcePath,
+                MethodName = "Process",
+                ParameterName = "when",
+                ParameterType = "System.DateTime",
+                DefaultValue = "System.DateTime.Now"
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidDefaultValue, ex.ErrorCode);
+        Assert.Equal("1013", ex.ErrorCode);
+        Assert.Equal(original, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [SkippableFact]
+    public async Task AddParameter_NonConstantDefault_NewObject_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public void Process(int count)
+                {
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var original = await File.ReadAllTextAsync(workspace.SourcePath);
+        var operation = new AddParameterOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new AddParameterParams
+            {
+                SourceFile = workspace.SourcePath,
+                MethodName = "Process",
+                ParameterName = "state",
+                ParameterType = "object",
+                DefaultValue = "new object()"
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidDefaultValue, ex.ErrorCode);
+        Assert.Equal(original, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [SkippableFact]
+    public async Task AddParameter_IncompatibleDefault_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public void Process(int count)
+                {
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var original = await File.ReadAllTextAsync(workspace.SourcePath);
+        var operation = new AddParameterOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new AddParameterParams
+            {
+                SourceFile = workspace.SourcePath,
+                MethodName = "Process",
+                ParameterName = "timeout",
+                ParameterType = "int",
+                DefaultValue = "\"hello\""
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidDefaultValue, ex.ErrorCode);
+        Assert.Equal(original, await File.ReadAllTextAsync(workspace.SourcePath));
     }
 
     #endregion

--- a/tests/RoslynMcp.Server.Tests/Tools/AddParameterToolTests.cs
+++ b/tests/RoslynMcp.Server.Tests/Tools/AddParameterToolTests.cs
@@ -1,0 +1,141 @@
+using System.Text.Json;
+using RoslynMcp.Server.Tests.TestHelpers;
+using RoslynMcp.Server.Tools;
+using RoslynMcp.Server.Transport;
+using Xunit;
+
+namespace RoslynMcp.Server.Tests.Tools;
+
+/// <summary>
+/// Unit tests for AddParameterTool.
+/// Tests tool definition and argument validation.
+/// </summary>
+public class AddParameterToolTests
+{
+    private readonly AddParameterTool _tool;
+
+    public AddParameterToolTests()
+    {
+        // Fails loudly if workspace creation is attempted; argument validation is exercised via ExecuteAsync error paths.
+        _tool = new AddParameterTool(new ThrowingWorkspaceProvider());
+    }
+
+    #region GetDefinition Tests
+
+    [Fact]
+    public void GetDefinition_ReturnsCorrectName()
+    {
+        Assert.Equal("add_parameter", _tool.Name);
+    }
+
+    [Fact]
+    public void GetDefinition_ReturnsNonEmptyDescription()
+    {
+        Assert.NotNull(_tool.Description);
+        Assert.NotEmpty(_tool.Description);
+    }
+
+    [Fact]
+    public void GetDefinition_ReturnsCorrectSchema()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.Equal("object", root.GetProperty("type").GetString());
+        Assert.True(root.TryGetProperty("properties", out _));
+        Assert.True(root.TryGetProperty("required", out _));
+    }
+
+    [Fact]
+    public void GetDefinition_HasRequiredFields()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var required = doc.RootElement.GetProperty("required");
+
+        var requiredFields = new List<string>();
+        foreach (var item in required.EnumerateArray())
+        {
+            requiredFields.Add(item.GetString()!);
+        }
+
+        Assert.Contains("solutionPath", requiredFields);
+        Assert.Contains("sourceFile", requiredFields);
+        Assert.Contains("methodName", requiredFields);
+        Assert.Contains("parameterName", requiredFields);
+        Assert.Contains("parameterType", requiredFields);
+    }
+
+    [Fact]
+    public void GetDefinition_HasProperties_ForAllParameters()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var properties = doc.RootElement.GetProperty("properties");
+
+        Assert.True(properties.TryGetProperty("solutionPath", out _));
+        Assert.True(properties.TryGetProperty("sourceFile", out _));
+        Assert.True(properties.TryGetProperty("methodName", out _));
+        Assert.True(properties.TryGetProperty("parameterName", out _));
+        Assert.True(properties.TryGetProperty("parameterType", out _));
+        Assert.True(properties.TryGetProperty("defaultValue", out _));
+        Assert.True(properties.TryGetProperty("position", out _));
+        Assert.True(properties.TryGetProperty("line", out _));
+        Assert.True(properties.TryGetProperty("column", out _));
+        Assert.True(properties.TryGetProperty("updateOverrides", out _));
+        Assert.True(properties.TryGetProperty("updateImplementations", out _));
+        Assert.True(properties.TryGetProperty("preview", out _));
+    }
+
+    #endregion
+
+    #region ExecuteAsync Argument Validation Tests
+
+    [Fact]
+    public async Task ExecuteAsync_NullArguments_ReturnsError()
+    {
+        var result = await _tool.ExecuteAsync(null);
+
+        Assert.True(result.IsError);
+        Assert.Contains("Arguments required", GetResultText(result));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EmptyArguments_ReturnsError()
+    {
+        var args = JsonDocument.Parse("{}").RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MissingRequiredField_ReturnsError()
+    {
+        var args = JsonDocument.Parse(@"{
+            ""solutionPath"": ""C:/test/test.sln"",
+            ""sourceFile"": ""C:/test/Test.cs"",
+            ""methodName"": ""DoWork""
+        }").RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static string GetResultText(ToolResult result)
+    {
+        return result.Content.FirstOrDefault()?.Text ?? string.Empty;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Description

Adds leftover #60: `add_parameter` / `AddParameterOperation`, a sibling of shipped `change_signature`.

The operation inserts a named parameter on the selected method, updates existing call sites so they still compile (default value, or named-arg insertion when not appending), and updates the override chain and interface implementations when those flags are true. `-1` position means the end of required parameters (before optionals and `params`). Preview computes diffs and does not write files.

Rejects duplicate names, unparseable types (`1010`), out-of-range positions (`1011`), required-after-optional, `params` not last, missing methods, uneditable documents, unsupported declaration targets, non-invocation method references (`3130`), and defaults that are not a compile-time constant or `default(T)` implicitly convertible to the parameter type (`1013`). New semantic codes use unused `3127-3130` because `3060-3066` and `3080-3089` are already shipped for generate/async.

Follow-up on this same PR addresses three correctness findings:
- Rewrite only `SymbolFinder` / declaration-target spans (no same-name/arity fallback).
- Reject method-group / delegate references before writing files.
- Validate optional defaults with a semantic probe compilation, not parse-only.

MCP + CLI registration increments tool counts from 54 to 55 (CLI refactoring tools 41 to 42).

## 🔗 Related Issues

Closes #60

## 🎯 Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Test additions or updates

## 🧪 Testing

`dotnet test --filter FullyQualifiedName~AddParameter` is green (26 Core tests). Coverage includes simple add, defaults at call sites, named-arg insertion, override/interface chain, same-file two-type isolation, preview (no writes), method-group reject (no writes), non-constant/incompatible defaults, and the original reject cases.

**Test Configuration**:
- OS: Linux
- .NET Version: 9.0

## 📋 Additional Notes

Placement is `src/RoslynMcp.Core/Refactoring/Signature/` next to `ChangeSignatureOperation`. Call-site updates follow that sibling's invocation rewrite; override/interface discovery uses Roslyn `SymbolFinder` rather than a new parallel engine. ChangeSignature had no extracted helpers for these three cases.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8fcf1dbe-1097-49c6-82e5-91de2ee245c3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8fcf1dbe-1097-49c6-82e5-91de2ee245c3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

