### PR TITLE
Add remove_parameter refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - `implement_abstract` — generate implementation stubs for unimplemented abstract methods and properties inherited by a selected class, with a `throw new NotImplementedException();` body, preview mode, and rejects for missing symbols, no unimplemented abstract members, uneditable documents, and unsupported targets
 - `inline_constant` — replace references to a `const` field with a formatted literal (typed null casts), optionally remove the declaration, with preview mode and rejects for non-constants (including static readonly), public API constants, attribute usages, missing symbols, and uneditable documents
 - `add_parameter` — add a named parameter to a method and update call sites, overrides, and interface implementations, with preview mode and rejects for duplicate names, invalid types, out-of-range positions, required-after-optional, params-not-last, missing methods, and uneditable documents
+- `remove_parameter` — remove a named parameter from a method and drop matching call-site arguments, with override/interface updates, preview mode, force-gated body handling that must stay compiling, and rejects for a missing parameter, used-in-body without force, method-group references, missing methods, and uneditable documents
 
 ## [0.4.0] - 2026-02-23
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Let AI assistants like Claude safely refactor your C# codebase using the same Roslyn compiler platform that powers Visual Studio.
 
-Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that exposes **55 Roslyn-powered tools** to AI assistants and other MCP clients. It combines 31 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 5 code generation tools, and 8 code conversion tools -- giving your AI deep code intelligence, comprehensive refactoring, and modern C# syntax transformations with full solution-wide reference tracking and preview support.
+Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that exposes **56 Roslyn-powered tools** to AI assistants and other MCP clients. It combines 32 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 5 code generation tools, and 8 code conversion tools -- giving your AI deep code intelligence, comprehensive refactoring, and modern C# syntax transformations with full solution-wide reference tracking and preview support.
 
 ---
 
@@ -30,7 +30,7 @@ Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotoc
 
 ## Why RoslynMcpServer?
 
-- **55 tools** -- refactoring, navigation, analysis, generation, and conversion tools, the most comprehensive Roslyn MCP server available
+- **56 tools** -- refactoring, navigation, analysis, generation, and conversion tools, the most comprehensive Roslyn MCP server available
 - **Preview mode on every operation** -- see exactly what will change before applying
 - **Atomic file writes with rollback** -- if any file write fails, all changes are reverted
 - **Solution-wide reference updates** -- renames and moves propagate across your entire solution
@@ -102,7 +102,7 @@ Claude will use the `rename_symbol` tool to rename the class and update every re
 
 ## Standalone CLI
 
-All 55 tools are also available as a standalone CLI for use in scripts, CI/CD pipelines, and terminals without an AI assistant.
+All 56 tools are also available as a standalone CLI for use in scripts, CI/CD pipelines, and terminals without an AI assistant.
 
 ### Install
 
@@ -223,6 +223,7 @@ All tools accept a `solutionPath` parameter (absolute path to a `.sln`, `.slnx`,
 |------|-------------|----------------|
 | `change_signature` | Add, remove, or reorder method parameters and update all call sites. | `sourceFile`, `methodName`, `parameters` (array of changes), `line` |
 | `add_parameter` | Add a named parameter to a method and update call sites, overrides, and interface implementations. | `sourceFile`, `methodName`, `parameterName`, `parameterType`, `defaultValue`, `position`, `line`, `column`, `updateOverrides`, `updateImplementations` |
+| `remove_parameter` | Remove a named parameter from a method and drop matching call-site arguments, updating overrides and interface implementations. | `sourceFile`, `methodName`, `parameterName`, `line`, `column`, `force`, `updateOverrides`, `updateImplementations` |
 | `encapsulate_field` | Convert a field to a property with backing field. | `sourceFile`, `fieldName`, `propertyName`, `readOnly` |
 
 ### Generate

--- a/src/RoslynMcp.Cli/ToolRegistry.cs
+++ b/src/RoslynMcp.Cli/ToolRegistry.cs
@@ -47,7 +47,7 @@ public sealed class ToolEntry
 }
 
 /// <summary>
-/// Maps tool names to execution delegates for all 55 Roslyn tools.
+/// Maps tool names to execution delegates for all 56 Roslyn tools.
 /// </summary>
 public sealed class ToolRegistry
 {
@@ -139,7 +139,7 @@ public sealed class ToolRegistry
         _tools.Values.OrderBy(t => t.Category).ThenBy(t => t.Name).ToList();
 
     /// <summary>
-    /// Build the default registry with all 55 tools registered.
+    /// Build the default registry with all 56 tools registered.
     /// </summary>
     public static ToolRegistry BuildDefault()
     {
@@ -185,11 +185,13 @@ public sealed class ToolRegistry
         r.RegisterRefactoring<InlineConstantOperation, InlineConstantParams>(
             "inline-constant", "Inline a const field by replacing references with its literal value");
 
-        // ── Refactoring: Signature (2) ────────────────────────────────
+        // ── Refactoring: Signature (3) ────────────────────────────────
         r.RegisterRefactoring<ChangeSignatureOperation, ChangeSignatureParams>(
             "change-signature", "Add, remove, or reorder method parameters");
         r.RegisterRefactoring<AddParameterOperation, AddParameterParams>(
             "add-parameter", "Add a named parameter to a method and update call sites");
+        r.RegisterRefactoring<RemoveParameterOperation, RemoveParameterParams>(
+            "remove-parameter", "Remove a named parameter from a method and update call sites");
 
         // ── Refactoring: Encapsulate (1) ──────────────────────────────
         r.RegisterRefactoring<EncapsulateFieldOperation, EncapsulateFieldParams>(

--- a/src/RoslynMcp.Contracts/Enums/RefactoringKind.cs
+++ b/src/RoslynMcp.Contracts/Enums/RefactoringKind.cs
@@ -70,6 +70,9 @@ public enum RefactoringKind
     /// <summary>Add a parameter to a method and update call sites.</summary>
     AddParameter,
 
+    /// <summary>Remove a parameter from a method and update call sites.</summary>
+    RemoveParameter,
+
     // Generate Operations
     /// <summary>Generate constructor from fields/properties.</summary>
     GenerateConstructor,

--- a/src/RoslynMcp.Contracts/Errors/ErrorCodes.cs
+++ b/src/RoslynMcp.Contracts/Errors/ErrorCodes.cs
@@ -411,7 +411,7 @@ public static class ErrorCodes
     public const string NoUnimplementedAbstractMembers = "3126";
 
     // --------------------------------------------
-    // Signature Errors (3127-3129)
+    // Signature Errors (3127-3131)
     // 3060-3066 and 3080-3089 are already shipped for generate/async.
     // --------------------------------------------
 
@@ -426,6 +426,10 @@ public static class ErrorCodes
 
     /// <summary>A method reference is not a supported invocation and cannot be updated (method group, delegate).</summary>
     public const string UnsupportedCallSite = "3130";
+
+    /// <summary>Parameter is referenced in the method body and force is false.</summary>
+    public const string ParameterUsedInBody = "3131";
+
 
     // ============================================
     // System Errors (4xxx)

--- a/src/RoslynMcp.Contracts/Models/RemoveParameterParams.cs
+++ b/src/RoslynMcp.Contracts/Models/RemoveParameterParams.cs
@@ -1,0 +1,54 @@
+namespace RoslynMcp.Contracts.Models;
+
+/// <summary>
+/// Parameters for the remove_parameter tool.
+/// </summary>
+public sealed class RemoveParameterParams
+{
+    /// <summary>
+    /// Absolute path to the source file containing the method.
+    /// </summary>
+    public required string SourceFile { get; init; }
+
+    /// <summary>
+    /// Name of the method to modify.
+    /// </summary>
+    public required string MethodName { get; init; }
+
+    /// <summary>
+    /// Name of the parameter to remove.
+    /// </summary>
+    public required string ParameterName { get; init; }
+
+    /// <summary>
+    /// Line number for disambiguation if multiple methods have the same name (1-based).
+    /// </summary>
+    public int? Line { get; init; }
+
+    /// <summary>
+    /// Column number for disambiguation (1-based).
+    /// </summary>
+    public int? Column { get; init; }
+
+    /// <summary>
+    /// Remove the parameter even if it is referenced in the method body.
+    /// Body usages are replaced only when the solution stays compiling.
+    /// Default: false.
+    /// </summary>
+    public bool Force { get; init; }
+
+    /// <summary>
+    /// Update the virtual/override chain together. Default: true.
+    /// </summary>
+    public bool UpdateOverrides { get; init; } = true;
+
+    /// <summary>
+    /// Update interface declarations and implementations together. Default: true.
+    /// </summary>
+    public bool UpdateImplementations { get; init; } = true;
+
+    /// <summary>
+    /// Return computed changes without applying. Default: false.
+    /// </summary>
+    public bool Preview { get; init; }
+}

--- a/src/RoslynMcp.Core/Refactoring/Signature/RemoveParameterOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Signature/RemoveParameterOperation.cs
@@ -1,0 +1,816 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Text;
+using RoslynMcp.Contracts.Enums;
+using RoslynMcp.Contracts.Errors;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.FileSystem;
+using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Workspace;
+
+namespace RoslynMcp.Core.Refactoring.Signature;
+
+/// <summary>
+/// Removes a named parameter from a method and updates call sites, overrides,
+/// and interface implementations.
+/// </summary>
+public sealed class RemoveParameterOperation : RefactoringOperationBase<RemoveParameterParams>
+{
+    /// <summary>
+    /// Creates a new remove parameter operation.
+    /// </summary>
+    public RemoveParameterOperation(WorkspaceContext context) : base(context)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override void ValidateParams(RemoveParameterParams @params) => Validate(@params);
+
+    /// <summary>
+    /// Validates remove-parameter inputs. Internal so tests can exercise rules
+    /// without loading a workspace.
+    /// </summary>
+    internal static void Validate(RemoveParameterParams @params)
+    {
+        if (string.IsNullOrWhiteSpace(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "sourceFile is required.");
+
+        if (string.IsNullOrWhiteSpace(@params.MethodName))
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "methodName is required.");
+
+        if (string.IsNullOrWhiteSpace(@params.ParameterName))
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "parameterName is required.");
+
+        if (!PathResolver.IsAbsolutePath(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.InvalidSourcePath, "sourceFile must be an absolute path.");
+
+        if (!PathResolver.IsValidCSharpFilePath(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.InvalidSourcePath, "sourceFile must be a .cs file.");
+
+        if (!File.Exists(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.SourceFileNotFound, $"Source file not found: {@params.SourceFile}");
+
+        if (@params.Line.HasValue && @params.Line.Value < 1)
+            throw new RefactoringException(ErrorCodes.InvalidLineNumber, "Line number must be >= 1.");
+
+        if (@params.Column.HasValue && @params.Column.Value < 1)
+            throw new RefactoringException(ErrorCodes.InvalidColumnNumber, "Column number must be >= 1.");
+    }
+
+    /// <summary>
+    /// Rejects documents that cannot receive source edits.
+    /// </summary>
+    internal static void ValidateDocumentIsEditable(Document document, Microsoft.CodeAnalysis.Workspace workspace)
+    {
+        if (document is SourceGeneratedDocument)
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable (source-generated).");
+        }
+
+        if (string.IsNullOrWhiteSpace(document.FilePath) || !File.Exists(document.FilePath))
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable.");
+        }
+
+        if (!workspace.CanApplyChange(ApplyChangesKind.ChangeDocument))
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable (workspace cannot apply changes).");
+        }
+    }
+
+    /// <inheritdoc />
+    protected override async Task<RefactoringResult> ExecuteCoreAsync(
+        Guid operationId,
+        RemoveParameterParams @params,
+        CancellationToken cancellationToken)
+    {
+        var document = GetDocumentOrThrow(@params.SourceFile);
+        ValidateDocumentIsEditable(document, Context.Workspace);
+
+        var root = await document.GetSyntaxRootAsync(cancellationToken);
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken);
+        if (root == null || semanticModel == null)
+            throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse file.");
+
+        var methodDecl = FindMethodDeclaration(root, @params);
+        var methodSymbol = semanticModel.GetDeclaredSymbol(methodDecl, cancellationToken)
+            ?? throw new RefactoringException(ErrorCodes.RoslynError, "Could not resolve method symbol.");
+
+        var parameter = FindParameter(methodSymbol, @params.ParameterName);
+        var removeIndex = parameter.Ordinal;
+
+        var relatedMethods = await GetRelatedMethodsAsync(
+            methodSymbol,
+            @params.UpdateOverrides,
+            @params.UpdateImplementations,
+            cancellationToken);
+
+        var namesAtIndex = relatedMethods
+            .Where(m => m.Parameters.Length > removeIndex)
+            .Select(m => m.Parameters[removeIndex].Name)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var declarationTargets = await CollectDeclarationTargetsAsync(relatedMethods, cancellationToken);
+        foreach (var target in declarationTargets)
+            ValidateDocumentIsEditable(target.Document, Context.Workspace);
+
+        var callSites = await CollectCallSitesAsync(relatedMethods, cancellationToken);
+        foreach (var callSite in callSites)
+            ValidateDocumentIsEditable(callSite.Document, Context.Workspace);
+
+        var bodyUsages = await CollectBodyUsagesAsync(relatedMethods, removeIndex, cancellationToken);
+        if (bodyUsages.Count > 0 && !@params.Force)
+        {
+            throw new RefactoringException(
+                ErrorCodes.ParameterUsedInBody,
+                $"Parameter '{@params.ParameterName}' is referenced in the method body. Set force=true to remove it.",
+                new Dictionary<string, object>
+                {
+                    ["usageCount"] = bodyUsages.Count,
+                    ["parameterName"] = @params.ParameterName
+                },
+                ["Set force=true to remove the parameter if leftover body usages can be replaced without breaking compilation."]);
+        }
+
+        if (bodyUsages.Any(u => !u.CanReplaceWithDefault))
+        {
+            throw new RefactoringException(
+                ErrorCodes.CompilationError,
+                $"Parameter '{@params.ParameterName}' is used in the method body in a way that cannot be replaced without leaving the solution uncompilable.");
+        }
+
+        foreach (var usage in bodyUsages)
+            ValidateDocumentIsEditable(usage.Document, Context.Workspace);
+
+        var newSolution = await ApplyChangesAsync(
+            document,
+            declarationTargets,
+            callSites,
+            bodyUsages,
+            methodSymbol.Parameters.ToList(),
+            removeIndex,
+            namesAtIndex,
+            cancellationToken);
+
+        if (@params.Preview)
+        {
+            return await CreatePreviewResultAsync(
+                operationId,
+                @params,
+                document,
+                newSolution,
+                callSites.Count,
+                cancellationToken);
+        }
+
+        var commitResult = await CommitChangesAsync(newSolution, cancellationToken);
+
+        return RefactoringResult.Succeeded(
+            operationId,
+            new FileChanges
+            {
+                FilesModified = commitResult.FilesModified,
+                FilesCreated = commitResult.FilesCreated,
+                FilesDeleted = commitResult.FilesDeleted
+            },
+            new Contracts.Models.SymbolInfo
+            {
+                Name = @params.MethodName,
+                FullyQualifiedName = methodSymbol.ToDisplayString(),
+                Kind = Contracts.Enums.SymbolKind.Method
+            },
+            callSites.Count,
+            0);
+    }
+
+    internal static MethodDeclarationSyntax FindMethodDeclaration(SyntaxNode root, RemoveParameterParams @params)
+    {
+        var methods = root.DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .Where(m => m.Identifier.Text == @params.MethodName)
+            .ToList();
+
+        if (methods.Count == 0)
+        {
+            throw new RefactoringException(
+                ErrorCodes.MethodNotFound,
+                $"Method '{@params.MethodName}' not found.");
+        }
+
+        if (methods.Count == 1 && !@params.Line.HasValue && !@params.Column.HasValue)
+            return methods[0];
+
+        IEnumerable<MethodDeclarationSyntax> filtered = methods;
+        if (@params.Line.HasValue)
+        {
+            filtered = filtered.Where(m =>
+                m.GetLocation().GetLineSpan().StartLinePosition.Line + 1 == @params.Line.Value);
+        }
+
+        if (@params.Column.HasValue)
+        {
+            filtered = filtered.Where(m =>
+                m.GetLocation().GetLineSpan().StartLinePosition.Character + 1 == @params.Column.Value);
+        }
+
+        var matches = filtered.ToList();
+        if (matches.Count == 1)
+            return matches[0];
+
+        if (matches.Count == 0)
+        {
+            throw new RefactoringException(
+                ErrorCodes.MethodNotFound,
+                @params.Line.HasValue
+                    ? $"Method '{@params.MethodName}' not found at line {@params.Line}."
+                    : $"Method '{@params.MethodName}' not found.");
+        }
+
+        var lines = matches
+            .Select(m => m.GetLocation().GetLineSpan().StartLinePosition.Line + 1)
+            .ToList();
+        throw new RefactoringException(
+            ErrorCodes.SymbolAmbiguous,
+            $"Multiple methods named '{@params.MethodName}' found. Provide line number. Options: {string.Join(", ", lines)}");
+    }
+
+    internal static IParameterSymbol FindParameter(IMethodSymbol method, string name)
+    {
+        var normalized = NormalizeIdentifier(name);
+        var parameter = method.Parameters.FirstOrDefault(p => p.Name == normalized);
+        if (parameter != null)
+            return parameter;
+
+        var available = string.Join(", ", method.Parameters.Select(p => p.Name));
+        throw new RefactoringException(
+            ErrorCodes.ParameterNotFound,
+            string.IsNullOrEmpty(available)
+                ? $"Parameter '{name}' not found on method '{method.Name}'."
+                : $"Parameter '{name}' not found on method '{method.Name}'. Available: {available}");
+    }
+
+    private async Task<List<IMethodSymbol>> GetRelatedMethodsAsync(
+        IMethodSymbol method,
+        bool updateOverrides,
+        bool updateImplementations,
+        CancellationToken cancellationToken)
+    {
+        var results = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default) { method };
+
+        if (updateOverrides)
+        {
+            var current = method;
+            while (current.OverriddenMethod != null)
+            {
+                results.Add(current.OverriddenMethod);
+                current = current.OverriddenMethod;
+            }
+
+            foreach (var symbol in results.ToList())
+            {
+                var overrides = await SymbolFinder.FindOverridesAsync(
+                    symbol, Context.Solution, cancellationToken: cancellationToken);
+                foreach (var ov in overrides.OfType<IMethodSymbol>())
+                    results.Add(ov);
+            }
+        }
+
+        if (updateImplementations)
+        {
+            foreach (var candidate in results.ToList())
+            {
+                if (candidate.ContainingType.TypeKind == TypeKind.Interface)
+                {
+                    var implementations = await SymbolFinder.FindImplementationsAsync(
+                        candidate, Context.Solution, cancellationToken: cancellationToken);
+                    foreach (var impl in implementations.OfType<IMethodSymbol>())
+                        results.Add(impl);
+                    continue;
+                }
+
+                foreach (var iface in candidate.ContainingType.AllInterfaces)
+                {
+                    foreach (var ifaceMethod in iface.GetMembers(candidate.Name).OfType<IMethodSymbol>())
+                    {
+                        var impl = candidate.ContainingType.FindImplementationForInterfaceMember(ifaceMethod);
+                        if (impl is not IMethodSymbol implMethod ||
+                            !ShareOverrideRoot(implMethod, candidate))
+                        {
+                            continue;
+                        }
+
+                        results.Add(ifaceMethod);
+                        var otherImpls = await SymbolFinder.FindImplementationsAsync(
+                            ifaceMethod,
+                            Context.Solution,
+                            cancellationToken: cancellationToken);
+                        foreach (var other in otherImpls.OfType<IMethodSymbol>())
+                            results.Add(other);
+                    }
+                }
+            }
+        }
+
+        return results.Where(HasSourceDeclaration).ToList();
+    }
+
+    private async Task<List<DeclarationTarget>> CollectDeclarationTargetsAsync(
+        IReadOnlyList<IMethodSymbol> methods,
+        CancellationToken cancellationToken)
+    {
+        var targets = new List<DeclarationTarget>();
+
+        foreach (var method in methods)
+        {
+            foreach (var syntaxRef in method.DeclaringSyntaxReferences)
+            {
+                if (await syntaxRef.GetSyntaxAsync(cancellationToken) is not MethodDeclarationSyntax declaration)
+                {
+                    throw new RefactoringException(
+                        ErrorCodes.InvalidSelection,
+                        $"Method '{method.Name}' is an unsupported target for remove_parameter.");
+                }
+
+                var document = Context.Solution.GetDocument(syntaxRef.SyntaxTree)
+                    ?? throw new RefactoringException(
+                        ErrorCodes.DocumentNotEditable,
+                        $"Could not locate the document for method '{method.Name}'.");
+
+                targets.Add(new DeclarationTarget(document, declaration.Span));
+            }
+        }
+
+        if (targets.Count == 0)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidSelection,
+                "The selected method is an unsupported target for remove_parameter.");
+        }
+
+        return targets;
+    }
+
+    private async Task<List<CallSite>> CollectCallSitesAsync(
+        IReadOnlyList<IMethodSymbol> methods,
+        CancellationToken cancellationToken)
+    {
+        var callSites = new List<CallSite>();
+        var seen = new HashSet<(DocumentId Id, TextSpan Span)>();
+
+        foreach (var method in methods)
+        {
+            var references = await SymbolFinder.FindReferencesAsync(method, Context.Solution, cancellationToken);
+            foreach (var referenced in references)
+            {
+                foreach (var location in referenced.Locations)
+                {
+                    if (location.Location.Kind != LocationKind.SourceFile)
+                        continue;
+
+                    var document = location.Document;
+                    var root = await document.GetSyntaxRootAsync(cancellationToken);
+                    if (root == null)
+                        continue;
+
+                    var node = root.FindNode(location.Location.SourceSpan, getInnermostNodeForTie: true);
+                    if (IsDeclarationName(node, location.Location.SourceSpan))
+                        continue;
+
+                    var invocation = node.AncestorsAndSelf().OfType<InvocationExpressionSyntax>().FirstOrDefault();
+                    if (invocation != null && IsInvokedMethodName(invocation, location.Location.SourceSpan))
+                    {
+                        if (!seen.Add((document.Id, invocation.Span)))
+                            continue;
+
+                        callSites.Add(new CallSite(document, invocation.Span));
+                        continue;
+                    }
+
+                    if (IsNameOfArgument(node))
+                        continue;
+
+                    throw new RefactoringException(
+                        ErrorCodes.UnsupportedCallSite,
+                        $"Method '{method.Name}' is used as a method group or other unsupported reference and cannot be updated automatically.");
+                }
+            }
+        }
+
+        return callSites;
+    }
+
+    private async Task<List<BodyUsage>> CollectBodyUsagesAsync(
+        IReadOnlyList<IMethodSymbol> methods,
+        int parameterIndex,
+        CancellationToken cancellationToken)
+    {
+        var usages = new List<BodyUsage>();
+        var seen = new HashSet<(DocumentId Id, TextSpan Span)>();
+
+        foreach (var method in methods)
+        {
+            if (parameterIndex < 0 || parameterIndex >= method.Parameters.Length)
+                continue;
+
+            var parameter = method.Parameters[parameterIndex];
+            foreach (var syntaxRef in method.DeclaringSyntaxReferences)
+            {
+                if (await syntaxRef.GetSyntaxAsync(cancellationToken) is not MethodDeclarationSyntax declaration)
+                    continue;
+
+                var document = Context.Solution.GetDocument(syntaxRef.SyntaxTree);
+                if (document == null)
+                    continue;
+
+                var model = await document.GetSemanticModelAsync(cancellationToken);
+                if (model == null)
+                    continue;
+
+                var body = (SyntaxNode?)declaration.Body ?? declaration.ExpressionBody;
+                if (body == null)
+                    continue;
+
+                foreach (var identifier in body.DescendantNodes().OfType<IdentifierNameSyntax>())
+                {
+                    var symbol = model.GetSymbolInfo(identifier, cancellationToken).Symbol;
+                    if (!SymbolEqualityComparer.Default.Equals(symbol, parameter))
+                        continue;
+
+                    if (!seen.Add((document.Id, identifier.Span)))
+                        continue;
+
+                    usages.Add(new BodyUsage(document, identifier.Span, CanReplaceWithDefault(identifier)));
+                }
+            }
+        }
+
+        return usages;
+    }
+
+    private static async Task<Solution> ApplyChangesAsync(
+        Document originatingDocument,
+        IReadOnlyList<DeclarationTarget> declarations,
+        IReadOnlyList<CallSite> callSites,
+        IReadOnlyList<BodyUsage> bodyUsages,
+        IReadOnlyList<IParameterSymbol> originalParams,
+        int removeIndex,
+        IReadOnlySet<string> namesAtIndex,
+        CancellationToken cancellationToken)
+    {
+        var solution = originatingDocument.Project.Solution;
+        var documentIds = declarations.Select(d => d.Document.Id)
+            .Concat(callSites.Select(c => c.Document.Id))
+            .Concat(bodyUsages.Select(u => u.Document.Id))
+            .ToHashSet();
+
+        foreach (var documentId in documentIds)
+        {
+            var document = solution.GetDocument(documentId)
+                ?? throw new RefactoringException(ErrorCodes.RoslynError, "Document disappeared from solution.");
+            var root = await document.GetSyntaxRootAsync(cancellationToken)
+                ?? throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse file.");
+
+            var declarationSpans = declarations
+                .Where(d => d.Document.Id == documentId)
+                .Select(d => d.Span)
+                .ToHashSet();
+            var invocationSpans = callSites
+                .Where(c => c.Document.Id == documentId)
+                .Select(c => c.Span)
+                .ToHashSet();
+            var usageSpans = bodyUsages
+                .Where(u => u.Document.Id == documentId)
+                .Select(u => u.Span)
+                .ToHashSet();
+
+            var methods = root.DescendantNodes()
+                .OfType<MethodDeclarationSyntax>()
+                .Where(m => declarationSpans.Contains(m.Span))
+                .ToList();
+            var invocations = root.DescendantNodes()
+                .OfType<InvocationExpressionSyntax>()
+                .Where(i => invocationSpans.Contains(i.Span))
+                .ToList();
+            var identifiers = root.DescendantNodes()
+                .OfType<IdentifierNameSyntax>()
+                .Where(i => usageSpans.Contains(i.Span))
+                .ToList();
+
+            var rewriter = new RemoveParameterRewriter(
+                methods,
+                invocations,
+                identifiers,
+                removeIndex,
+                originalParams,
+                namesAtIndex);
+            root = rewriter.Visit(root)
+                ?? throw new RefactoringException(ErrorCodes.RoslynError, "Failed to rewrite remove_parameter targets.");
+
+            solution = document.WithSyntaxRoot(root).Project.Solution;
+        }
+
+        return solution;
+    }
+
+    internal static InvocationExpressionSyntax UpdateInvocation(
+        InvocationExpressionSyntax invocation,
+        IReadOnlyList<IParameterSymbol> originalParams,
+        int removeIndex,
+        IReadOnlySet<string> namesAtIndex)
+    {
+        var newArgs = RemoveArgument(invocation.ArgumentList, removeIndex, originalParams, namesAtIndex);
+        return invocation.WithArgumentList(newArgs);
+    }
+
+    internal static ArgumentListSyntax RemoveArgument(
+        ArgumentListSyntax args,
+        int removeIndex,
+        IReadOnlyList<IParameterSymbol> originalParams,
+        IReadOnlySet<string> namesAtIndex)
+    {
+        var originalArgs = args.Arguments.ToList();
+        var namedOriginal = new Dictionary<string, ArgumentSyntax>();
+        var positionalOriginal = new List<ArgumentSyntax>();
+        foreach (var arg in originalArgs)
+        {
+            if (arg.NameColon != null)
+                namedOriginal[arg.NameColon.Name.Identifier.Text] = arg;
+            else
+                positionalOriginal.Add(arg);
+        }
+
+        var newArgs = new List<ArgumentSyntax>();
+        var positionalIndex = 0;
+        var removingParams = removeIndex >= 0 &&
+                             removeIndex < originalParams.Count &&
+                             originalParams[removeIndex].IsParams;
+
+        for (var i = 0; i < originalParams.Count; i++)
+        {
+            var originalParam = originalParams[i];
+            if (namedOriginal.TryGetValue(originalParam.Name, out var namedArg))
+            {
+                if (i != removeIndex)
+                    newArgs.Add(namedArg);
+                continue;
+            }
+
+            if (positionalIndex >= positionalOriginal.Count)
+                continue;
+
+            var positional = positionalOriginal[positionalIndex++];
+            if (i == removeIndex)
+            {
+                if (removingParams)
+                    positionalIndex = positionalOriginal.Count;
+                continue;
+            }
+
+            newArgs.Add(positional);
+        }
+
+        while (positionalIndex < positionalOriginal.Count)
+            newArgs.Add(positionalOriginal[positionalIndex++]);
+
+        foreach (var leftover in namedOriginal)
+        {
+            if (namesAtIndex.Contains(leftover.Key))
+                continue;
+            if (!newArgs.Contains(leftover.Value))
+                newArgs.Add(leftover.Value);
+        }
+
+        return SyntaxFactory.ArgumentList(SeparatedWithSpaces(newArgs))
+            .WithTriviaFrom(args);
+    }
+
+    private static async Task<RefactoringResult> CreatePreviewResultAsync(
+        Guid operationId,
+        RemoveParameterParams @params,
+        Document originalDocument,
+        Solution newSolution,
+        int callSiteCount,
+        CancellationToken cancellationToken)
+    {
+        var pendingChanges = new List<PendingChange>();
+        var originalSolution = originalDocument.Project.Solution;
+
+        foreach (var projectChanges in newSolution.GetChanges(originalSolution).GetProjectChanges())
+        {
+            foreach (var docId in projectChanges.GetChangedDocuments())
+            {
+                var oldDoc = originalSolution.GetDocument(docId);
+                var newDoc = newSolution.GetDocument(docId);
+                if (oldDoc?.FilePath == null || newDoc == null)
+                    continue;
+
+                var before = await oldDoc.GetTextAsync(cancellationToken);
+                var after = await newDoc.GetTextAsync(cancellationToken);
+                pendingChanges.Add(new PendingChange
+                {
+                    File = oldDoc.FilePath,
+                    ChangeType = ChangeKind.Modify,
+                    Description = $"Remove parameter '{@params.ParameterName}' from '{@params.MethodName}' ({callSiteCount} call site(s) to update)",
+                    BeforeSnippet = before.ToString(),
+                    AfterSnippet = after.ToString()
+                });
+            }
+        }
+
+        if (pendingChanges.Count == 0)
+        {
+            pendingChanges.Add(new PendingChange
+            {
+                File = @params.SourceFile,
+                ChangeType = ChangeKind.Modify,
+                Description = $"Remove parameter '{@params.ParameterName}' from '{@params.MethodName}'",
+                BeforeSnippet = null,
+                AfterSnippet = null
+            });
+        }
+
+        return RefactoringResult.PreviewResult(operationId, pendingChanges);
+    }
+
+    private static bool CanReplaceWithDefault(IdentifierNameSyntax identifier)
+    {
+        if (IsNameOfArgument(identifier))
+            return false;
+
+        if (identifier.Parent is MemberAccessExpressionSyntax member && member.Expression == identifier)
+            return false;
+
+        if (identifier.Parent is MemberBindingExpressionSyntax)
+            return false;
+
+        if (identifier.Parent is ElementAccessExpressionSyntax element && element.Expression == identifier)
+            return false;
+
+        if (identifier.Parent is AssignmentExpressionSyntax assignment && assignment.Left == identifier)
+            return false;
+
+        if (identifier.Parent is PrefixUnaryExpressionSyntax prefix &&
+            (prefix.IsKind(SyntaxKind.PreIncrementExpression) || prefix.IsKind(SyntaxKind.PreDecrementExpression)))
+        {
+            return false;
+        }
+
+        if (identifier.Parent is PostfixUnaryExpressionSyntax postfix &&
+            (postfix.IsKind(SyntaxKind.PostIncrementExpression) || postfix.IsKind(SyntaxKind.PostDecrementExpression)))
+        {
+            return false;
+        }
+
+        if (identifier.Parent is ArgumentSyntax argument &&
+            (argument.RefKindKeyword.IsKind(SyntaxKind.RefKeyword) ||
+             argument.RefKindKeyword.IsKind(SyntaxKind.OutKeyword) ||
+             argument.RefKindKeyword.IsKind(SyntaxKind.InKeyword)))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool IsDeclarationName(SyntaxNode node, TextSpan referenceSpan)
+    {
+        return node.AncestorsAndSelf().OfType<MethodDeclarationSyntax>()
+            .Any(m => m.Identifier.Span.IntersectsWith(referenceSpan));
+    }
+
+    private static bool IsInvokedMethodName(InvocationExpressionSyntax invocation, TextSpan referenceSpan)
+    {
+        if (invocation.ArgumentList.Span.Contains(referenceSpan))
+            return false;
+
+        return invocation.Expression switch
+        {
+            IdentifierNameSyntax identifier => identifier.Span.IntersectsWith(referenceSpan),
+            MemberAccessExpressionSyntax member => member.Name.Span.IntersectsWith(referenceSpan),
+            MemberBindingExpressionSyntax binding => binding.Name.Span.IntersectsWith(referenceSpan),
+            _ => invocation.Expression.Span.IntersectsWith(referenceSpan)
+        };
+    }
+
+    private static bool IsNameOfArgument(SyntaxNode node)
+    {
+        foreach (var invocation in node.AncestorsAndSelf().OfType<InvocationExpressionSyntax>())
+        {
+            if (invocation.Expression is IdentifierNameSyntax identifier &&
+                identifier.Identifier.Text == "nameof")
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasSourceDeclaration(IMethodSymbol method) =>
+        method.DeclaringSyntaxReferences.Length > 0 &&
+        method.Locations.Any(l => l.IsInSource);
+
+    private static bool ShareOverrideRoot(IMethodSymbol left, IMethodSymbol right) =>
+        SymbolEqualityComparer.Default.Equals(GetOverrideRoot(left), GetOverrideRoot(right));
+
+    private static IMethodSymbol GetOverrideRoot(IMethodSymbol method)
+    {
+        var current = method;
+        while (current.OverriddenMethod != null)
+            current = current.OverriddenMethod;
+        return current;
+    }
+
+    private static string NormalizeIdentifier(string name) =>
+        name.StartsWith('@') && name.Length > 1 ? name[1..] : name;
+
+    private static SeparatedSyntaxList<T> SeparatedWithSpaces<T>(IReadOnlyList<T> nodes)
+        where T : SyntaxNode
+    {
+        if (nodes.Count == 0)
+            return SyntaxFactory.SeparatedList<T>();
+
+        var separators = nodes.Count == 1
+            ? Array.Empty<SyntaxToken>()
+            : Enumerable.Repeat(
+                SyntaxFactory.Token(SyntaxKind.CommaToken).WithTrailingTrivia(SyntaxFactory.Space),
+                nodes.Count - 1).ToArray();
+
+        return SyntaxFactory.SeparatedList(nodes, separators);
+    }
+
+    private sealed record DeclarationTarget(Document Document, TextSpan Span);
+
+    private sealed record CallSite(Document Document, TextSpan Span);
+
+    private sealed record BodyUsage(Document Document, TextSpan Span, bool CanReplaceWithDefault);
+
+    private sealed class RemoveParameterRewriter : CSharpSyntaxRewriter
+    {
+        private readonly HashSet<MethodDeclarationSyntax> _methods;
+        private readonly HashSet<InvocationExpressionSyntax> _invocations;
+        private readonly HashSet<IdentifierNameSyntax> _identifiers;
+        private readonly int _removeIndex;
+        private readonly IReadOnlyList<IParameterSymbol> _originalParams;
+        private readonly IReadOnlySet<string> _namesAtIndex;
+
+        public RemoveParameterRewriter(
+            IReadOnlyList<MethodDeclarationSyntax> methods,
+            IReadOnlyList<InvocationExpressionSyntax> invocations,
+            IReadOnlyList<IdentifierNameSyntax> identifiers,
+            int removeIndex,
+            IReadOnlyList<IParameterSymbol> originalParams,
+            IReadOnlySet<string> namesAtIndex)
+        {
+            _methods = new HashSet<MethodDeclarationSyntax>(methods);
+            _invocations = new HashSet<InvocationExpressionSyntax>(invocations);
+            _identifiers = new HashSet<IdentifierNameSyntax>(identifiers);
+            _removeIndex = removeIndex;
+            _originalParams = originalParams;
+            _namesAtIndex = namesAtIndex;
+        }
+
+        public override SyntaxNode? VisitMethodDeclaration(MethodDeclarationSyntax node)
+        {
+            var visited = (MethodDeclarationSyntax)base.VisitMethodDeclaration(node)!;
+            var original = _methods.FirstOrDefault(m => m.Span == node.Span && m.Identifier.Text == node.Identifier.Text);
+            if (original == null)
+                return visited;
+
+            var parameters = visited.ParameterList.Parameters.ToList();
+            if (_removeIndex < 0 || _removeIndex >= parameters.Count)
+                return visited;
+
+            parameters.RemoveAt(_removeIndex);
+            return visited.WithParameterList(
+                SyntaxFactory.ParameterList(SeparatedWithSpaces(parameters))
+                    .WithTriviaFrom(visited.ParameterList));
+        }
+
+        public override SyntaxNode? VisitInvocationExpression(InvocationExpressionSyntax node)
+        {
+            var visited = (InvocationExpressionSyntax)base.VisitInvocationExpression(node)!;
+            if (!_invocations.Contains(node) && !_invocations.Any(i => i.Span == node.Span))
+                return visited;
+
+            return UpdateInvocation(visited, _originalParams, _removeIndex, _namesAtIndex);
+        }
+
+        public override SyntaxNode? VisitIdentifierName(IdentifierNameSyntax node)
+        {
+            if (!_identifiers.Contains(node) && !_identifiers.Any(i => i.Span == node.Span && i.Identifier.Text == node.Identifier.Text))
+                return base.VisitIdentifierName(node);
+
+            return SyntaxFactory.LiteralExpression(SyntaxKind.DefaultLiteralExpression)
+                .WithTriviaFrom(node);
+        }
+    }
+}

--- a/src/RoslynMcp.Core/Refactoring/Signature/RemoveParameterOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Signature/RemoveParameterOperation.cs
@@ -160,6 +160,8 @@ public sealed class RemoveParameterOperation : RefactoringOperationBase<RemovePa
             namesAtIndex,
             cancellationToken);
 
+        await EnsureNoNewCompilationErrorsAsync(document.Project.Solution, newSolution, cancellationToken);
+
         if (@params.Preview)
         {
             return await CreatePreviewResultAsync(
@@ -390,7 +392,11 @@ public sealed class RemoveParameterOperation : RefactoringOperationBase<RemovePa
                         if (!seen.Add((document.Id, invocation.Span)))
                             continue;
 
-                        callSites.Add(new CallSite(document, invocation.Span));
+                        var model = await document.GetSemanticModelAsync(cancellationToken);
+                        var invoked = model?.GetSymbolInfo(invocation, cancellationToken).Symbol as IMethodSymbol;
+                        var isReduced = invoked?.MethodKind == MethodKind.ReducedExtension ||
+                                        invoked?.ReducedFrom != null;
+                        callSites.Add(new CallSite(document, invocation.Span, isReduced));
                         continue;
                     }
 
@@ -447,7 +453,11 @@ public sealed class RemoveParameterOperation : RefactoringOperationBase<RemovePa
                     if (!seen.Add((document.Id, identifier.Span)))
                         continue;
 
-                    usages.Add(new BodyUsage(document, identifier.Span, CanReplaceWithDefault(identifier)));
+                    usages.Add(new BodyUsage(
+                        document,
+                        identifier.Span,
+                        GetParameterTypeDisplay(parameter),
+                        CanReplaceWithDefault(identifier)));
                 }
             }
         }
@@ -482,14 +492,17 @@ public sealed class RemoveParameterOperation : RefactoringOperationBase<RemovePa
                 .Where(d => d.Document.Id == documentId)
                 .Select(d => d.Span)
                 .ToHashSet();
-            var invocationSpans = callSites
-                .Where(c => c.Document.Id == documentId)
+            var documentCallSites = callSites.Where(c => c.Document.Id == documentId).ToList();
+            var invocationSpans = documentCallSites.Select(c => c.Span).ToHashSet();
+            var reducedSpans = documentCallSites
+                .Where(c => c.IsReducedExtension)
                 .Select(c => c.Span)
                 .ToHashSet();
-            var usageSpans = bodyUsages
-                .Where(u => u.Document.Id == documentId)
-                .Select(u => u.Span)
-                .ToHashSet();
+            var documentUsages = bodyUsages.Where(u => u.Document.Id == documentId).ToList();
+            var usageSpans = documentUsages.Select(u => u.Span).ToHashSet();
+            var identifierTypes = documentUsages
+                .GroupBy(u => u.Span)
+                .ToDictionary(g => g.Key, g => g.First().TypeDisplay);
 
             var methods = root.DescendantNodes()
                 .OfType<MethodDeclarationSyntax>()
@@ -508,6 +521,8 @@ public sealed class RemoveParameterOperation : RefactoringOperationBase<RemovePa
                 methods,
                 invocations,
                 identifiers,
+                identifierTypes,
+                reducedSpans,
                 removeIndex,
                 originalParams,
                 namesAtIndex);
@@ -524,9 +539,15 @@ public sealed class RemoveParameterOperation : RefactoringOperationBase<RemovePa
         InvocationExpressionSyntax invocation,
         IReadOnlyList<IParameterSymbol> originalParams,
         int removeIndex,
-        IReadOnlySet<string> namesAtIndex)
+        IReadOnlySet<string> namesAtIndex,
+        bool isReducedExtension = false)
     {
-        var newArgs = RemoveArgument(invocation.ArgumentList, removeIndex, originalParams, namesAtIndex);
+        var newArgs = RemoveArgument(
+            invocation.ArgumentList,
+            removeIndex,
+            originalParams,
+            namesAtIndex,
+            isReducedExtension);
         return invocation.WithArgumentList(newArgs);
     }
 
@@ -534,21 +555,23 @@ public sealed class RemoveParameterOperation : RefactoringOperationBase<RemovePa
         ArgumentListSyntax args,
         int removeIndex,
         IReadOnlyList<IParameterSymbol> originalParams,
-        IReadOnlySet<string> namesAtIndex)
+        IReadOnlySet<string> namesAtIndex,
+        bool isReducedExtension = false)
     {
         var originalArgs = args.Arguments.ToList();
-        var namedOriginal = new Dictionary<string, ArgumentSyntax>();
+        var namedOriginal = new Dictionary<string, ArgumentSyntax>(StringComparer.Ordinal);
         var positionalOriginal = new List<ArgumentSyntax>();
         foreach (var arg in originalArgs)
         {
             if (arg.NameColon != null)
-                namedOriginal[arg.NameColon.Name.Identifier.Text] = arg;
+                namedOriginal[arg.NameColon.Name.Identifier.ValueText] = arg;
             else
                 positionalOriginal.Add(arg);
         }
 
         var newArgs = new List<ArgumentSyntax>();
         var positionalIndex = 0;
+        var firstExplicitOrdinal = isReducedExtension ? 1 : 0;
         var removingParams = removeIndex >= 0 &&
                              removeIndex < originalParams.Count &&
                              originalParams[removeIndex].IsParams;
@@ -562,6 +585,9 @@ public sealed class RemoveParameterOperation : RefactoringOperationBase<RemovePa
                     newArgs.Add(namedArg);
                 continue;
             }
+
+            if (i < firstExplicitOrdinal)
+                continue;
 
             if (positionalIndex >= positionalOriginal.Count)
                 continue;
@@ -588,7 +614,7 @@ public sealed class RemoveParameterOperation : RefactoringOperationBase<RemovePa
                 newArgs.Add(leftover.Value);
         }
 
-        return SyntaxFactory.ArgumentList(SeparatedWithSpaces(newArgs))
+        return SyntaxFactory.ArgumentList(KeepNodesPreservingSeparators(args.Arguments, newArgs))
             .WithTriviaFrom(args);
     }
 
@@ -732,32 +758,143 @@ public sealed class RemoveParameterOperation : RefactoringOperationBase<RemovePa
     private static string NormalizeIdentifier(string name) =>
         name.StartsWith('@') && name.Length > 1 ? name[1..] : name;
 
-    private static SeparatedSyntaxList<T> SeparatedWithSpaces<T>(IReadOnlyList<T> nodes)
+    private static string GetParameterTypeDisplay(IParameterSymbol parameter)
+    {
+        foreach (var syntaxRef in parameter.DeclaringSyntaxReferences)
+        {
+            if (syntaxRef.GetSyntax() is ParameterSyntax { Type: { } type })
+                return type.ToString().Trim();
+        }
+
+        return parameter.Type.ToDisplayString();
+    }
+
+    private static async Task EnsureNoNewCompilationErrorsAsync(
+        Solution original,
+        Solution updated,
+        CancellationToken cancellationToken)
+    {
+        var before = await CollectErrorKeysAsync(original, cancellationToken);
+        var after = await CollectErrorKeysAsync(updated, cancellationToken);
+        var introduced = after.Where(key => !before.Contains(key)).ToList();
+        if (introduced.Count == 0)
+            return;
+
+        throw new RefactoringException(
+            ErrorCodes.CompilationError,
+            "Removing the parameter would leave the solution uncompilable.");
+    }
+
+    private static async Task<HashSet<string>> CollectErrorKeysAsync(
+        Solution solution,
+        CancellationToken cancellationToken)
+    {
+        var keys = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var project in solution.Projects)
+        {
+            var compilation = await project.GetCompilationAsync(cancellationToken);
+            if (compilation == null)
+                continue;
+
+            foreach (var diagnostic in compilation.GetDiagnostics(cancellationToken))
+            {
+                if (diagnostic.Severity != DiagnosticSeverity.Error)
+                    continue;
+
+                keys.Add($"{diagnostic.Id}:{diagnostic.GetMessage()}");
+            }
+        }
+
+        return keys;
+    }
+
+    internal static SeparatedSyntaxList<T> RemoveAtPreservingSeparators<T>(
+        SeparatedSyntaxList<T> list,
+        int index)
         where T : SyntaxNode
     {
+        if (index < 0 || index >= list.Count)
+            return list;
+
+        var nodes = list.ToList();
+        var separators = list.GetSeparators().ToList();
+        nodes.RemoveAt(index);
+
+        if (separators.Count > 0)
+        {
+            if (index >= separators.Count)
+                separators.RemoveAt(separators.Count - 1);
+            else
+                separators.RemoveAt(index);
+        }
+
         if (nodes.Count == 0)
             return SyntaxFactory.SeparatedList<T>();
 
-        var separators = nodes.Count == 1
-            ? Array.Empty<SyntaxToken>()
-            : Enumerable.Repeat(
-                SyntaxFactory.Token(SyntaxKind.CommaToken).WithTrailingTrivia(SyntaxFactory.Space),
-                nodes.Count - 1).ToArray();
+        if (separators.Count >= nodes.Count)
+            separators = separators.Take(nodes.Count - 1).ToList();
 
         return SyntaxFactory.SeparatedList(nodes, separators);
     }
 
+    internal static SeparatedSyntaxList<T> KeepNodesPreservingSeparators<T>(
+        SeparatedSyntaxList<T> original,
+        IReadOnlyList<T> keep)
+        where T : SyntaxNode
+    {
+        if (keep.Count == 0)
+            return SyntaxFactory.SeparatedList<T>();
+
+        var originalNodes = original.ToList();
+        var separators = original.GetSeparators().ToList();
+        var keepIndices = new List<int>(keep.Count);
+        foreach (var node in keep)
+        {
+            var index = originalNodes.IndexOf(node);
+            if (index < 0)
+                return SyntaxFactory.SeparatedList(keep, DefaultCommaSeparators(keep.Count));
+
+            keepIndices.Add(index);
+        }
+
+        var newSeparators = new List<SyntaxToken>();
+        for (var i = 0; i < keepIndices.Count - 1; i++)
+        {
+            var from = keepIndices[i];
+            var to = keepIndices[i + 1];
+            if (to == from + 1 && from < separators.Count)
+                newSeparators.Add(separators[from]);
+            else
+                newSeparators.Add(CommaWithSpace());
+        }
+
+        return SyntaxFactory.SeparatedList(keep, newSeparators);
+    }
+
+    private static IReadOnlyList<SyntaxToken> DefaultCommaSeparators(int nodeCount)
+    {
+        if (nodeCount <= 1)
+            return Array.Empty<SyntaxToken>();
+
+        return Enumerable.Repeat(CommaWithSpace(), nodeCount - 1).ToArray();
+    }
+
+    private static SyntaxToken CommaWithSpace() =>
+        SyntaxFactory.Token(SyntaxKind.CommaToken).WithTrailingTrivia(SyntaxFactory.Space);
+
     private sealed record DeclarationTarget(Document Document, TextSpan Span);
 
-    private sealed record CallSite(Document Document, TextSpan Span);
+    private sealed record CallSite(Document Document, TextSpan Span, bool IsReducedExtension);
 
-    private sealed record BodyUsage(Document Document, TextSpan Span, bool CanReplaceWithDefault);
+    private sealed record BodyUsage(Document Document, TextSpan Span, string TypeDisplay, bool CanReplaceWithDefault);
 
     private sealed class RemoveParameterRewriter : CSharpSyntaxRewriter
     {
         private readonly HashSet<MethodDeclarationSyntax> _methods;
         private readonly HashSet<InvocationExpressionSyntax> _invocations;
         private readonly HashSet<IdentifierNameSyntax> _identifiers;
+        private readonly IReadOnlyDictionary<TextSpan, string> _identifierTypes;
+        private readonly HashSet<TextSpan> _reducedSpans;
         private readonly int _removeIndex;
         private readonly IReadOnlyList<IParameterSymbol> _originalParams;
         private readonly IReadOnlySet<string> _namesAtIndex;
@@ -766,6 +903,8 @@ public sealed class RemoveParameterOperation : RefactoringOperationBase<RemovePa
             IReadOnlyList<MethodDeclarationSyntax> methods,
             IReadOnlyList<InvocationExpressionSyntax> invocations,
             IReadOnlyList<IdentifierNameSyntax> identifiers,
+            IReadOnlyDictionary<TextSpan, string> identifierTypes,
+            HashSet<TextSpan> reducedSpans,
             int removeIndex,
             IReadOnlyList<IParameterSymbol> originalParams,
             IReadOnlySet<string> namesAtIndex)
@@ -773,6 +912,8 @@ public sealed class RemoveParameterOperation : RefactoringOperationBase<RemovePa
             _methods = new HashSet<MethodDeclarationSyntax>(methods);
             _invocations = new HashSet<InvocationExpressionSyntax>(invocations);
             _identifiers = new HashSet<IdentifierNameSyntax>(identifiers);
+            _identifierTypes = identifierTypes;
+            _reducedSpans = reducedSpans;
             _removeIndex = removeIndex;
             _originalParams = originalParams;
             _namesAtIndex = namesAtIndex;
@@ -785,13 +926,12 @@ public sealed class RemoveParameterOperation : RefactoringOperationBase<RemovePa
             if (original == null)
                 return visited;
 
-            var parameters = visited.ParameterList.Parameters.ToList();
-            if (_removeIndex < 0 || _removeIndex >= parameters.Count)
+            if (_removeIndex < 0 || _removeIndex >= visited.ParameterList.Parameters.Count)
                 return visited;
 
-            parameters.RemoveAt(_removeIndex);
             return visited.WithParameterList(
-                SyntaxFactory.ParameterList(SeparatedWithSpaces(parameters))
+                SyntaxFactory.ParameterList(
+                        RemoveAtPreservingSeparators(visited.ParameterList.Parameters, _removeIndex))
                     .WithTriviaFrom(visited.ParameterList));
         }
 
@@ -801,7 +941,8 @@ public sealed class RemoveParameterOperation : RefactoringOperationBase<RemovePa
             if (!_invocations.Contains(node) && !_invocations.Any(i => i.Span == node.Span))
                 return visited;
 
-            return UpdateInvocation(visited, _originalParams, _removeIndex, _namesAtIndex);
+            var isReduced = _reducedSpans.Contains(node.Span);
+            return UpdateInvocation(visited, _originalParams, _removeIndex, _namesAtIndex, isReduced);
         }
 
         public override SyntaxNode? VisitIdentifierName(IdentifierNameSyntax node)
@@ -809,7 +950,10 @@ public sealed class RemoveParameterOperation : RefactoringOperationBase<RemovePa
             if (!_identifiers.Contains(node) && !_identifiers.Any(i => i.Span == node.Span && i.Identifier.Text == node.Identifier.Text))
                 return base.VisitIdentifierName(node);
 
-            return SyntaxFactory.LiteralExpression(SyntaxKind.DefaultLiteralExpression)
+            var typeDisplay = _identifierTypes.TryGetValue(node.Span, out var stored)
+                ? stored
+                : "object";
+            return SyntaxFactory.DefaultExpression(SyntaxFactory.ParseTypeName(typeDisplay))
                 .WithTriviaFrom(node);
         }
     }

--- a/src/RoslynMcp.Server/McpServerHost.cs
+++ b/src/RoslynMcp.Server/McpServerHost.cs
@@ -49,6 +49,7 @@ public sealed class McpServerHost : IAsyncDisposable
         _toolRegistry.Register(new ExtractConstantTool(workspaceProvider));
         _toolRegistry.Register(new ChangeSignatureTool(workspaceProvider));
         _toolRegistry.Register(new AddParameterTool(workspaceProvider));
+        _toolRegistry.Register(new RemoveParameterTool(workspaceProvider));
         _toolRegistry.Register(new EncapsulateFieldTool(workspaceProvider));
         _toolRegistry.Register(new ConvertToAsyncTool(workspaceProvider));
         _toolRegistry.Register(new ExtractBaseClassTool(workspaceProvider));

--- a/src/RoslynMcp.Server/Tools/RemoveParameterTool.cs
+++ b/src/RoslynMcp.Server/Tools/RemoveParameterTool.cs
@@ -1,0 +1,171 @@
+using System.Text.Json;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.Refactoring;
+using RoslynMcp.Core.Refactoring.Signature;
+using RoslynMcp.Core.Workspace;
+using RoslynMcp.Server.Transport;
+
+namespace RoslynMcp.Server.Tools;
+
+/// <summary>
+/// MCP tool handler for remove_parameter operation.
+/// </summary>
+public sealed class RemoveParameterTool : IToolHandler
+{
+    private readonly IWorkspaceProvider _workspaceProvider;
+    private readonly JsonSerializerOptions _jsonOptions;
+
+    /// <summary>
+    /// Creates a new remove parameter tool.
+    /// </summary>
+    public RemoveParameterTool(IWorkspaceProvider workspaceProvider)
+    {
+        _workspaceProvider = workspaceProvider;
+        _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = false
+        };
+    }
+
+    /// <inheritdoc />
+    public string Name => "remove_parameter";
+
+    /// <inheritdoc />
+    public string Description => "Remove a named parameter from a method and update call sites, overrides, and interface implementations.";
+
+    /// <inheritdoc />
+    public object InputSchema => new
+    {
+        type = "object",
+        required = new[] { "solutionPath", "sourceFile", "methodName", "parameterName" },
+        properties = new
+        {
+            solutionPath = new
+            {
+                type = "string",
+                description = "Absolute path to the .sln or .csproj file"
+            },
+            sourceFile = new
+            {
+                type = "string",
+                description = "Absolute path to the source file containing the method"
+            },
+            methodName = new
+            {
+                type = "string",
+                description = "Name of the method to modify"
+            },
+            parameterName = new
+            {
+                type = "string",
+                description = "Name of the parameter to remove"
+            },
+            line = new
+            {
+                type = "integer",
+                description = "Line number for disambiguation if multiple methods have the same name (1-based)"
+            },
+            column = new
+            {
+                type = "integer",
+                description = "Column number for disambiguation (1-based)"
+            },
+            force = new
+            {
+                type = "boolean",
+                description = "Remove the parameter even if it is referenced in the method body",
+                @default = false
+            },
+            updateOverrides = new
+            {
+                type = "boolean",
+                description = "Update the virtual/override chain together",
+                @default = true
+            },
+            updateImplementations = new
+            {
+                type = "boolean",
+                description = "Update interface declarations and implementations together",
+                @default = true
+            },
+            preview = new
+            {
+                type = "boolean",
+                description = "Return computed changes without applying",
+                @default = false
+            }
+        },
+        additionalProperties = false
+    };
+
+    /// <inheritdoc />
+    public async Task<ToolResult> ExecuteAsync(JsonElement? arguments, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (arguments == null)
+            {
+                return ToolResult.Error("Arguments required");
+            }
+
+            var args = JsonSerializer.Deserialize<RemoveParameterArgs>(arguments.Value.GetRawText(), _jsonOptions);
+            if (args == null)
+            {
+                return ToolResult.Error("Failed to parse arguments");
+            }
+
+            using var context = await _workspaceProvider.CreateContextAsync(
+                args.SolutionPath,
+                cancellationToken);
+
+            var operation = new RemoveParameterOperation(context);
+            var @params = new RemoveParameterParams
+            {
+                SourceFile = args.SourceFile,
+                MethodName = args.MethodName,
+                ParameterName = args.ParameterName,
+                Line = args.Line,
+                Column = args.Column,
+                Force = args.Force ?? false,
+                UpdateOverrides = args.UpdateOverrides ?? true,
+                UpdateImplementations = args.UpdateImplementations ?? true,
+                Preview = args.Preview ?? false
+            };
+
+            var result = await operation.ExecuteAsync(@params, cancellationToken);
+
+            var json = JsonSerializer.Serialize(result, _jsonOptions);
+            return result.Success ? ToolResult.Success(json) : ToolResult.Error(json);
+        }
+        catch (RefactoringException ex)
+        {
+            var error = ex.ToError();
+            var json = JsonSerializer.Serialize(new { success = false, error }, _jsonOptions);
+            return ToolResult.Error(json);
+        }
+        catch (Exception ex)
+        {
+            var json = JsonSerializer.Serialize(new
+            {
+                success = false,
+                error = new { code = "INTERNAL_ERROR", message = ex.Message }
+            }, _jsonOptions);
+            return ToolResult.Error(json);
+        }
+    }
+
+    private sealed class RemoveParameterArgs
+    {
+        public string SolutionPath { get; init; } = "";
+        public string SourceFile { get; init; } = "";
+        public string MethodName { get; init; } = "";
+        public string ParameterName { get; init; } = "";
+        public int? Line { get; init; }
+        public int? Column { get; init; }
+        public bool? Force { get; init; }
+        public bool? UpdateOverrides { get; init; }
+        public bool? UpdateImplementations { get; init; }
+        public bool? Preview { get; init; }
+    }
+}

--- a/tests/RoslynMcp.Cli.Tests/HelpGeneratorTests.cs
+++ b/tests/RoslynMcp.Cli.Tests/HelpGeneratorTests.cs
@@ -15,11 +15,11 @@ public class HelpGeneratorTests
     }
 
     [Fact]
-    public void GenerateGlobalHelp_Lists55Tools()
+    public void GenerateGlobalHelp_Lists56Tools()
     {
         var registry = ToolRegistry.BuildDefault();
         var help = HelpGenerator.GenerateGlobalHelp(registry);
-        Assert.Contains("Total: 55 tools", help);
+        Assert.Contains("Total: 56 tools", help);
         Assert.Contains("pull-members-up", help);
         Assert.Contains("push-members-down", help);
         Assert.Contains("use-base-type", help);
@@ -33,6 +33,7 @@ public class HelpGeneratorTests
         Assert.Contains("implement-abstract", help);
         Assert.Contains("inline-constant", help);
         Assert.Contains("add-parameter", help);
+        Assert.Contains("remove-parameter", help);
     }
 
     [Fact]

--- a/tests/RoslynMcp.Cli.Tests/ToolRegistryTests.cs
+++ b/tests/RoslynMcp.Cli.Tests/ToolRegistryTests.cs
@@ -6,11 +6,11 @@ namespace RoslynMcp.Cli.Tests;
 public class ToolRegistryTests
 {
     [Fact]
-    public void BuildDefault_Registers55Tools()
+    public void BuildDefault_Registers56Tools()
     {
         var registry = ToolRegistry.BuildDefault();
         var tools = registry.GetAllTools();
-        Assert.Equal(55, tools.Count);
+        Assert.Equal(56, tools.Count);
     }
 
     [Fact]
@@ -86,6 +86,7 @@ public class ToolRegistryTests
     [InlineData("inline-method", "Refactoring")]
     [InlineData("inline-constant", "Refactoring")]
     [InlineData("add-parameter", "Refactoring")]
+    [InlineData("remove-parameter", "Refactoring")]
     [InlineData("pull-members-up", "Refactoring")]
     [InlineData("push-members-down", "Refactoring")]
     [InlineData("use-base-type", "Refactoring")]
@@ -115,11 +116,11 @@ public class ToolRegistryTests
     }
 
     [Fact]
-    public void RefactoringToolCount_Is42()
+    public void RefactoringToolCount_Is43()
     {
         var registry = ToolRegistry.BuildDefault();
         var count = registry.GetAllTools().Count(t => t.Category == "Refactoring");
-        Assert.Equal(42, count);
+        Assert.Equal(43, count);
     }
 
     [Fact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Signature/RemoveParameterOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Signature/RemoveParameterOperationTests.cs
@@ -272,7 +272,165 @@ public class RemoveParameterOperationTests
 
         var text = await File.ReadAllTextAsync(workspace.SourcePath);
         Assert.Contains("public int Process()", text);
-        Assert.Contains("return default;", text);
+        Assert.Contains("return default(int);", text);
+        Assert.DoesNotContain("int unused", text);
+    }
+
+    [SkippableFact]
+    public async Task RemoveParameter_ForceTrue_VarCopy_UsesTypedDefault()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public int Process(int unused)
+                {
+                    var copy = unused;
+                    return copy;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new RemoveParameterOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new RemoveParameterParams
+        {
+            SourceFile = workspace.SourcePath,
+            MethodName = "Process",
+            ParameterName = "unused",
+            Force = true
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Contains("public int Process()", text);
+        Assert.Contains("var copy = default(int);", text);
+        Assert.DoesNotContain("unused", text);
+    }
+
+    [SkippableFact]
+    public async Task RemoveParameter_ReducedExtensionCall_DropsExplicitArg()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public static class Exts
+            {
+                public static void Ext(this string value, int unused)
+                {
+                }
+            }
+
+            public class Worker
+            {
+                public void Run()
+                {
+                    var text = "hi";
+                    text.Ext(1);
+                    Exts.Ext(text, 2);
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new RemoveParameterOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new RemoveParameterParams
+        {
+            SourceFile = workspace.SourcePath,
+            MethodName = "Ext",
+            ParameterName = "unused"
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Contains("public static void Ext(this string value)", text);
+        Assert.Contains("text.Ext();", text);
+        Assert.Contains("Exts.Ext(text);", text);
+        Assert.DoesNotContain("text.Ext(1)", text);
+        Assert.DoesNotContain("Exts.Ext(text, 2)", text);
+        Assert.DoesNotContain("int unused", text);
+    }
+
+    [SkippableFact]
+    public async Task RemoveParameter_EscapedNamedArg_UsesValueText()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public void Process(int count, int @class)
+                {
+                    System.Console.WriteLine(count);
+                }
+
+                public void Run()
+                {
+                    Process(count: 3, @class: 1);
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new RemoveParameterOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new RemoveParameterParams
+        {
+            SourceFile = workspace.SourcePath,
+            MethodName = "Process",
+            ParameterName = "@class"
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Contains("public void Process(int count)", text);
+        Assert.Contains("Process(count: 3)", text);
+        Assert.DoesNotContain("@class", text);
+    }
+
+    [SkippableFact]
+    public async Task RemoveParameter_PreservesSurvivingSeparatorTrivia()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public void Process(int a, // explanation
+                    int b, int unused)
+                {
+                    System.Console.WriteLine(a + b);
+                }
+
+                public void Run()
+                {
+                    Process(1, 2, 3);
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new RemoveParameterOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new RemoveParameterParams
+        {
+            SourceFile = workspace.SourcePath,
+            MethodName = "Process",
+            ParameterName = "unused"
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Contains("explanation", text);
+        Assert.Contains("public void Process(int a, // explanation", text);
+        Assert.Contains("Process(1, 2)", text);
         Assert.DoesNotContain("int unused", text);
     }
 

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Signature/RemoveParameterOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Signature/RemoveParameterOperationTests.cs
@@ -1,0 +1,512 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using RoslynMcp.Contracts.Errors;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.Refactoring;
+using RoslynMcp.Core.Refactoring.Signature;
+using RoslynMcp.Core.Workspace;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Refactoring.Signature;
+
+/// <summary>
+/// Operation-level tests for <see cref="RemoveParameterOperation"/>.
+/// </summary>
+public class RemoveParameterOperationTests
+{
+    #region Input Validation
+
+    [Fact]
+    public void Validate_MissingSourceFile_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            RemoveParameterOperation.Validate(ValidParams(sourceFile: "")));
+
+        Assert.Equal(ErrorCodes.MissingRequiredParam, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_MissingMethodName_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            RemoveParameterOperation.Validate(ValidParams(methodName: "")));
+
+        Assert.Equal(ErrorCodes.MissingRequiredParam, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_MissingParameterName_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            RemoveParameterOperation.Validate(ValidParams(parameterName: "")));
+
+        Assert.Equal(ErrorCodes.MissingRequiredParam, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_RelativePath_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            RemoveParameterOperation.Validate(ValidParams(sourceFile: "Worker.cs")));
+
+        Assert.Equal(ErrorCodes.InvalidSourcePath, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_MissingFile_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            RemoveParameterOperation.Validate(ValidParams()));
+
+        Assert.Equal(ErrorCodes.SourceFileNotFound, ex.ErrorCode);
+    }
+
+    #endregion
+
+    #region Happy Path
+
+    [SkippableFact]
+    public async Task RemoveParameter_UnusedParam_RemovesDeclarationAndCallSiteArg()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public void Process(int count, bool unused)
+                {
+                    System.Console.WriteLine(count);
+                }
+
+                public void Run()
+                {
+                    Process(3, false);
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new RemoveParameterOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new RemoveParameterParams
+        {
+            SourceFile = workspace.SourcePath,
+            MethodName = "Process",
+            ParameterName = "unused"
+        });
+
+        Assert.True(result.Success);
+        Assert.False(result.Preview);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Contains("public void Process(int count)", text);
+        Assert.DoesNotContain("bool unused", text);
+        Assert.Contains("Process(3)", text);
+        Assert.DoesNotContain("Process(3, false)", text);
+    }
+
+    [SkippableFact]
+    public async Task RemoveParameter_NamedArgs_RemovesNamedArgument()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public void Process(int count, string name, bool unused)
+                {
+                    System.Console.WriteLine(count + name);
+                }
+
+                public void Run()
+                {
+                    Process(count: 3, name: "a", unused: false);
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new RemoveParameterOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new RemoveParameterParams
+        {
+            SourceFile = workspace.SourcePath,
+            MethodName = "Process",
+            ParameterName = "unused"
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Contains("public void Process(int count, string name)", text);
+        Assert.Contains("Process(count: 3, name: \"a\")", text);
+        Assert.DoesNotContain("unused", text);
+    }
+
+    [SkippableFact]
+    public async Task RemoveParameter_OverrideAndInterface_UpdatesChain()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public interface IWorker
+            {
+                void Process(int count, bool unused);
+            }
+
+            public class Worker : IWorker
+            {
+                public virtual void Process(int count, bool unused)
+                {
+                }
+            }
+
+            public class Derived : Worker
+            {
+                public override void Process(int count, bool unused)
+                {
+                }
+            }
+
+            public static class Runner
+            {
+                public static void Run(IWorker worker, Derived derived)
+                {
+                    worker.Process(1, false);
+                    derived.Process(2, true);
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new RemoveParameterOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new RemoveParameterParams
+        {
+            SourceFile = workspace.SourcePath,
+            MethodName = "Process",
+            ParameterName = "unused",
+            Line = 10
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Contains("void Process(int count);", text);
+        Assert.Contains("public virtual void Process(int count)", text);
+        Assert.Contains("public override void Process(int count)", text);
+        Assert.Contains("worker.Process(1)", text);
+        Assert.Contains("derived.Process(2)", text);
+        Assert.DoesNotContain("bool unused", text);
+    }
+
+    [SkippableFact]
+    public async Task RemoveParameter_Preview_ReturnsChangesAndWritesNothing()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public void Process(int count, bool unused)
+                {
+                }
+
+                public void Run() => Process(3, false);
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var original = await File.ReadAllTextAsync(workspace.SourcePath);
+        var operation = new RemoveParameterOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new RemoveParameterParams
+        {
+            SourceFile = workspace.SourcePath,
+            MethodName = "Process",
+            ParameterName = "unused",
+            Preview = true
+        });
+
+        Assert.True(result.Success);
+        Assert.True(result.Preview);
+        Assert.NotNull(result.PendingChanges);
+        Assert.NotEmpty(result.PendingChanges);
+        Assert.Contains(result.PendingChanges, c =>
+            c.AfterSnippet != null &&
+            c.AfterSnippet.Contains("public void Process(int count)") &&
+            c.AfterSnippet.Contains("Process(3)") &&
+            !c.AfterSnippet.Contains("bool unused"));
+
+        var after = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Equal(original, after);
+    }
+
+    [SkippableFact]
+    public async Task RemoveParameter_ForceTrue_ReplacesBodyUsages()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public int Process(int unused)
+                {
+                    return unused;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new RemoveParameterOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new RemoveParameterParams
+        {
+            SourceFile = workspace.SourcePath,
+            MethodName = "Process",
+            ParameterName = "unused",
+            Force = true
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Contains("public int Process()", text);
+        Assert.Contains("return default;", text);
+        Assert.DoesNotContain("int unused", text);
+    }
+
+    #endregion
+
+    #region Rejects
+
+    [SkippableFact]
+    public async Task RemoveParameter_UsedInBody_ForceFalse_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public int Process(int unused)
+                {
+                    return unused;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var original = await File.ReadAllTextAsync(workspace.SourcePath);
+        var operation = new RemoveParameterOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new RemoveParameterParams
+            {
+                SourceFile = workspace.SourcePath,
+                MethodName = "Process",
+                ParameterName = "unused"
+            }));
+
+        Assert.Equal(ErrorCodes.ParameterUsedInBody, ex.ErrorCode);
+        Assert.Equal("3131", ex.ErrorCode);
+        Assert.Equal(original, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [SkippableFact]
+    public async Task RemoveParameter_MethodGroup_ThrowsAndWritesNothing()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public int Process(int unused) => 0;
+
+                public void Run()
+                {
+                    System.Func<int, int> handler = Process;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var original = await File.ReadAllTextAsync(workspace.SourcePath);
+        var operation = new RemoveParameterOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new RemoveParameterParams
+            {
+                SourceFile = workspace.SourcePath,
+                MethodName = "Process",
+                ParameterName = "unused"
+            }));
+
+        Assert.Equal(ErrorCodes.UnsupportedCallSite, ex.ErrorCode);
+        Assert.Equal("3130", ex.ErrorCode);
+        Assert.Equal(original, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [SkippableFact]
+    public async Task RemoveParameter_ParameterNotFound_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public void Process(int count)
+                {
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new RemoveParameterOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new RemoveParameterParams
+            {
+                SourceFile = workspace.SourcePath,
+                MethodName = "Process",
+                ParameterName = "missing"
+            }));
+
+        Assert.Equal(ErrorCodes.ParameterNotFound, ex.ErrorCode);
+        Assert.Equal("2016", ex.ErrorCode);
+    }
+
+    [SkippableFact]
+    public async Task RemoveParameter_MissingMethod_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public void Process(int count)
+                {
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new RemoveParameterOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new RemoveParameterParams
+            {
+                SourceFile = workspace.SourcePath,
+                MethodName = "DoesNotExist",
+                ParameterName = "count"
+            }));
+
+        Assert.Equal(ErrorCodes.MethodNotFound, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void RemoveParameter_UneditableDocument_Throws()
+    {
+        var workspace = new AdhocWorkspace();
+        var project = workspace.AddProject("P", LanguageNames.CSharp);
+        var document = workspace.AddDocument(project.Id, "Generated.cs", SourceText.From("class C {}"));
+
+        var ex = Assert.Throws<RefactoringException>(() =>
+            RemoveParameterOperation.ValidateDocumentIsEditable(document, workspace));
+
+        Assert.Equal(ErrorCodes.DocumentNotEditable, ex.ErrorCode);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static RemoveParameterParams ValidParams(
+        string? sourceFile = null,
+        string methodName = "Process",
+        string parameterName = "unused") => new()
+        {
+            SourceFile = sourceFile ?? Path.Combine(Path.GetTempPath(), "RoslynMcpRemoveParameterMissing.cs"),
+            MethodName = methodName,
+            ParameterName = parameterName
+        };
+
+    private sealed class TempWorkspace : IAsyncDisposable
+    {
+        public required string DirectoryPath { get; init; }
+        public required string ProjectPath { get; init; }
+        public required string SourcePath { get; init; }
+        public required WorkspaceContext Context { get; init; }
+
+        public static async Task<TempWorkspace> CreateAsync(string source, string fileName = "Worker.cs")
+        {
+            Skip.IfNot(ModuleInitializer.MsBuildAvailable, ModuleInitializer.MsBuildError ?? "MSBuild not available");
+
+            var directory = Path.Combine(Path.GetTempPath(), "RoslynMcpRemoveParameter_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(directory);
+
+            var projectPath = Path.Combine(directory, "TestApp.csproj");
+            await File.WriteAllTextAsync(projectPath, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net9.0</TargetFramework>
+                    <Nullable>enable</Nullable>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var sourcePath = Path.Combine(directory, fileName);
+            await File.WriteAllTextAsync(sourcePath, source);
+
+            try
+            {
+                var provider = new MSBuildWorkspaceProvider();
+                var context = await provider.CreateContextAsync(projectPath);
+                if (context.GetDocumentByPath(sourcePath) == null)
+                {
+                    context.Dispose();
+                    throw new InvalidOperationException($"Workspace loaded but did not include {sourcePath}.");
+                }
+
+                return new TempWorkspace
+                {
+                    DirectoryPath = directory,
+                    ProjectPath = projectPath,
+                    SourcePath = sourcePath,
+                    Context = context
+                };
+            }
+            catch (Exception ex) when (ex is not SkipException)
+            {
+                try
+                {
+                    Directory.Delete(directory, recursive: true);
+                }
+                catch
+                {
+                    // ignore cleanup failures
+                }
+
+                Skip.If(true, $"Workspace load failed: {ex.Message}");
+                throw;
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            Context.Dispose();
+            await Task.Run(() =>
+            {
+                try
+                {
+                    Directory.Delete(DirectoryPath, recursive: true);
+                }
+                catch
+                {
+                    // ignore locked temp files
+                }
+            });
+        }
+    }
+
+    #endregion
+}

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Signature/RemoveParameterOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Signature/RemoveParameterOperationTests.cs
@@ -667,4 +667,5 @@ public class RemoveParameterOperationTests
     }
 
     #endregion
+
 }

--- a/tests/RoslynMcp.Server.Tests/Tools/RemoveParameterToolTests.cs
+++ b/tests/RoslynMcp.Server.Tests/Tools/RemoveParameterToolTests.cs
@@ -1,0 +1,140 @@
+using System.Text.Json;
+using RoslynMcp.Server.Tests.TestHelpers;
+using RoslynMcp.Server.Tools;
+using RoslynMcp.Server.Transport;
+using Xunit;
+
+namespace RoslynMcp.Server.Tests.Tools;
+
+/// <summary>
+/// Unit tests for RemoveParameterTool.
+/// Tests tool definition and argument validation.
+/// </summary>
+public class RemoveParameterToolTests
+{
+    private readonly RemoveParameterTool _tool;
+
+    public RemoveParameterToolTests()
+    {
+        // Fails loudly if workspace creation is attempted; argument validation is exercised via ExecuteAsync error paths.
+        _tool = new RemoveParameterTool(new ThrowingWorkspaceProvider());
+    }
+
+    #region GetDefinition Tests
+
+    [Fact]
+    public void GetDefinition_ReturnsCorrectName()
+    {
+        Assert.Equal("remove_parameter", _tool.Name);
+    }
+
+    [Fact]
+    public void GetDefinition_ReturnsNonEmptyDescription()
+    {
+        Assert.NotNull(_tool.Description);
+        Assert.NotEmpty(_tool.Description);
+    }
+
+    [Fact]
+    public void GetDefinition_ReturnsCorrectSchema()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.Equal("object", root.GetProperty("type").GetString());
+        Assert.True(root.TryGetProperty("properties", out _));
+        Assert.True(root.TryGetProperty("required", out _));
+    }
+
+    [Fact]
+    public void GetDefinition_HasRequiredFields()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var required = doc.RootElement.GetProperty("required");
+
+        var requiredFields = new List<string>();
+        foreach (var item in required.EnumerateArray())
+        {
+            requiredFields.Add(item.GetString()!);
+        }
+
+        Assert.Contains("solutionPath", requiredFields);
+        Assert.Contains("sourceFile", requiredFields);
+        Assert.Contains("methodName", requiredFields);
+        Assert.Contains("parameterName", requiredFields);
+    }
+
+    [Fact]
+    public void GetDefinition_HasProperties_ForAllParameters()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var properties = doc.RootElement.GetProperty("properties");
+
+        Assert.True(properties.TryGetProperty("solutionPath", out _));
+        Assert.True(properties.TryGetProperty("sourceFile", out _));
+        Assert.True(properties.TryGetProperty("methodName", out _));
+        Assert.True(properties.TryGetProperty("parameterName", out _));
+        Assert.True(properties.TryGetProperty("line", out _));
+        Assert.True(properties.TryGetProperty("column", out _));
+        Assert.True(properties.TryGetProperty("force", out _));
+        Assert.True(properties.TryGetProperty("updateOverrides", out _));
+        Assert.True(properties.TryGetProperty("updateImplementations", out _));
+        Assert.True(properties.TryGetProperty("preview", out _));
+    }
+
+    #endregion
+
+    #region ExecuteAsync Argument Validation Tests
+
+    [Fact]
+    public async Task ExecuteAsync_NullArguments_ReturnsError()
+    {
+        var result = await _tool.ExecuteAsync(null);
+
+        Assert.True(result.IsError);
+        Assert.Contains("Arguments required", GetResultText(result));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EmptyArguments_ReturnsError()
+    {
+        var args = JsonDocument.Parse("{}").RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MissingRequiredField_ReturnsError()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "solutionPath": "C:/test/test.sln",
+                "sourceFile": "C:/test/Test.cs",
+                "methodName": "DoWork"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static string GetResultText(ToolResult result)
+    {
+        return result.Content.FirstOrDefault()?.Text ?? string.Empty;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds leftover #62: `remove_parameter` / `RemoveParameterOperation`, a sibling of shipped `add_parameter` and `change_signature`.

The operation removes a named parameter from the selected method, drops the matching argument at symbol-resolved call sites (positional by index, named by name, trailing commas cleaned), and updates the override chain and interface implementations when those flags are true. Preview computes diffs and does not write files.

If the parameter is referenced in a method body and `force` is false, the operation rejects with unused code `3131`. If `force` is true, leftover-scope body handling replaces safe identifier reads with `default(T)` and rejects with `4004` when a usage cannot stay compiling (assignment target, member access, `ref`/`out`, `nameof`) or when the rewritten solution introduces new compiler errors. Method-group and other non-invocation references throw `UnsupportedCallSite` (`3130`) before any files are written. A missing parameter reuses `ParameterNotFound` (`2016`). New codes do not reuse 3060-3066 or 3080-3089.

Rewrite targets are only symbol-resolved declaration and invocation spans — no name/arity or name-only invocation fallbacks.

Review follow-up (same PR):
- Reduced extension calls offset the explicit argument list by one (`text.Ext(1)` drops `unused`).
- Force replacements emit `default(T)` and the changed solution is compile-checked before preview/commit.
- Named arguments match `Identifier.ValueText` so `M(@class: 1)` drops when removing `@class`.
- Surviving separators keep their trivia (comments on remaining commas).

MCP + CLI registration increments tool counts from 55 to 56 (CLI refactoring tools 42 to 43).

## Related Issues

Closes #62

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Test additions or updates

## Testing

`dotnet test --filter FullyQualifiedName~RemoveParameter` — 19 Core tests passed (0 skipped).

Coverage includes unused-param, named args, force=false used-in-body reject (no writes), method-group reject (no writes), override/interface chain, preview (no writes), force=true `default(T)` replacement including `var copy = unused`, reduced extension call, `@class` named arg, surviving separator trivia, missing parameter (`2016`), missing method, and uneditable documents.

**Test Configuration**:
- OS: Linux
- .NET Version: 9.0

## Additional Notes

Placement is `src/RoslynMcp.Core/Refactoring/Signature/` next to `AddParameterOperation`. Out of scope: `reorder_parameters`, undo, Dependabot, a second leftover.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-40e0fc38-ca8f-416c-b7a3-71267d174934?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40e0fc38-ca8f-416c-b7a3-71267d174934&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

