### PR TITLE
Add reorder_parameters refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - `inline_constant` — replace references to a `const` field with a formatted literal (typed null casts), optionally remove the declaration, with preview mode and rejects for non-constants (including static readonly), public API constants, attribute usages, missing symbols, and uneditable documents
 - `add_parameter` — add a named parameter to a method and update call sites, overrides, and interface implementations, with preview mode and rejects for duplicate names, invalid types, out-of-range positions, required-after-optional, params-not-last, missing methods, and uneditable documents
 - `remove_parameter` — remove a named parameter from a method and drop matching call-site arguments, with override/interface updates, preview mode, force-gated body handling that must stay compiling, and rejects for a missing parameter, used-in-body without force, method-group references, missing methods, and uneditable documents
+- `reorder_parameters` — reorder a method's parameters by a 0-based permutation and update positional call-site arguments, with override/interface updates, preview mode, and rejects for invalid permutations, params-not-last, optional-before-required, method-group references, missing methods, and uneditable documents
 
 ## [0.4.0] - 2026-02-23
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Let AI assistants like Claude safely refactor your C# codebase using the same Roslyn compiler platform that powers Visual Studio.
 
-Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that exposes **56 Roslyn-powered tools** to AI assistants and other MCP clients. It combines 32 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 5 code generation tools, and 8 code conversion tools -- giving your AI deep code intelligence, comprehensive refactoring, and modern C# syntax transformations with full solution-wide reference tracking and preview support.
+Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that exposes **57 Roslyn-powered tools** to AI assistants and other MCP clients. It combines 33 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 5 code generation tools, and 8 code conversion tools -- giving your AI deep code intelligence, comprehensive refactoring, and modern C# syntax transformations with full solution-wide reference tracking and preview support.
 
 ---
 
@@ -30,7 +30,7 @@ Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotoc
 
 ## Why RoslynMcpServer?
 
-- **56 tools** -- refactoring, navigation, analysis, generation, and conversion tools, the most comprehensive Roslyn MCP server available
+- **57 tools** -- refactoring, navigation, analysis, generation, and conversion tools, the most comprehensive Roslyn MCP server available
 - **Preview mode on every operation** -- see exactly what will change before applying
 - **Atomic file writes with rollback** -- if any file write fails, all changes are reverted
 - **Solution-wide reference updates** -- renames and moves propagate across your entire solution
@@ -102,7 +102,7 @@ Claude will use the `rename_symbol` tool to rename the class and update every re
 
 ## Standalone CLI
 
-All 56 tools are also available as a standalone CLI for use in scripts, CI/CD pipelines, and terminals without an AI assistant.
+All 57 tools are also available as a standalone CLI for use in scripts, CI/CD pipelines, and terminals without an AI assistant.
 
 ### Install
 
@@ -224,6 +224,7 @@ All tools accept a `solutionPath` parameter (absolute path to a `.sln`, `.slnx`,
 | `change_signature` | Add, remove, or reorder method parameters and update all call sites. | `sourceFile`, `methodName`, `parameters` (array of changes), `line` |
 | `add_parameter` | Add a named parameter to a method and update call sites, overrides, and interface implementations. | `sourceFile`, `methodName`, `parameterName`, `parameterType`, `defaultValue`, `position`, `line`, `column`, `updateOverrides`, `updateImplementations` |
 | `remove_parameter` | Remove a named parameter from a method and drop matching call-site arguments, updating overrides and interface implementations. | `sourceFile`, `methodName`, `parameterName`, `line`, `column`, `force`, `updateOverrides`, `updateImplementations` |
+| `reorder_parameters` | Reorder a method's parameters by a 0-based permutation and update positional call-site arguments, updating overrides and interface implementations. | `sourceFile`, `methodName`, `newOrder`, `line`, `column`, `updateOverrides`, `updateImplementations` |
 | `encapsulate_field` | Convert a field to a property with backing field. | `sourceFile`, `fieldName`, `propertyName`, `readOnly` |
 
 ### Generate

--- a/src/RoslynMcp.Cli/ToolRegistry.cs
+++ b/src/RoslynMcp.Cli/ToolRegistry.cs
@@ -47,7 +47,7 @@ public sealed class ToolEntry
 }
 
 /// <summary>
-/// Maps tool names to execution delegates for all 56 Roslyn tools.
+/// Maps tool names to execution delegates for all 57 Roslyn tools.
 /// </summary>
 public sealed class ToolRegistry
 {
@@ -139,7 +139,7 @@ public sealed class ToolRegistry
         _tools.Values.OrderBy(t => t.Category).ThenBy(t => t.Name).ToList();
 
     /// <summary>
-    /// Build the default registry with all 56 tools registered.
+    /// Build the default registry with all 57 tools registered.
     /// </summary>
     public static ToolRegistry BuildDefault()
     {
@@ -185,13 +185,15 @@ public sealed class ToolRegistry
         r.RegisterRefactoring<InlineConstantOperation, InlineConstantParams>(
             "inline-constant", "Inline a const field by replacing references with its literal value");
 
-        // ── Refactoring: Signature (3) ────────────────────────────────
+        // ── Refactoring: Signature (4) ────────────────────────────────
         r.RegisterRefactoring<ChangeSignatureOperation, ChangeSignatureParams>(
             "change-signature", "Add, remove, or reorder method parameters");
         r.RegisterRefactoring<AddParameterOperation, AddParameterParams>(
             "add-parameter", "Add a named parameter to a method and update call sites");
         r.RegisterRefactoring<RemoveParameterOperation, RemoveParameterParams>(
             "remove-parameter", "Remove a named parameter from a method and update call sites");
+        r.RegisterRefactoring<ReorderParametersOperation, ReorderParametersParams>(
+            "reorder-parameters", "Reorder a method's parameters by a 0-based permutation and update call sites");
 
         // ── Refactoring: Encapsulate (1) ──────────────────────────────
         r.RegisterRefactoring<EncapsulateFieldOperation, EncapsulateFieldParams>(

--- a/src/RoslynMcp.Contracts/Enums/RefactoringKind.cs
+++ b/src/RoslynMcp.Contracts/Enums/RefactoringKind.cs
@@ -73,6 +73,9 @@ public enum RefactoringKind
     /// <summary>Remove a parameter from a method and update call sites.</summary>
     RemoveParameter,
 
+    /// <summary>Reorder a method's parameters and update call sites.</summary>
+    ReorderParameters,
+
     // Generate Operations
     /// <summary>Generate constructor from fields/properties.</summary>
     GenerateConstructor,

--- a/src/RoslynMcp.Contracts/Errors/ErrorCodes.cs
+++ b/src/RoslynMcp.Contracts/Errors/ErrorCodes.cs
@@ -411,7 +411,7 @@ public static class ErrorCodes
     public const string NoUnimplementedAbstractMembers = "3126";
 
     // --------------------------------------------
-    // Signature Errors (3127-3131)
+    // Signature Errors (3127-3132)
     // 3060-3066 and 3080-3089 are already shipped for generate/async.
     // --------------------------------------------
 
@@ -429,6 +429,9 @@ public static class ErrorCodes
 
     /// <summary>Parameter is referenced in the method body and force is false.</summary>
     public const string ParameterUsedInBody = "3131";
+
+    /// <summary>Reordered signature matches an existing overload on the containing type.</summary>
+    public const string SignatureMatchesOverload = "3132";
 
 
     // ============================================

--- a/src/RoslynMcp.Contracts/Models/ReorderParametersParams.cs
+++ b/src/RoslynMcp.Contracts/Models/ReorderParametersParams.cs
@@ -1,0 +1,48 @@
+namespace RoslynMcp.Contracts.Models;
+
+/// <summary>
+/// Parameters for the reorder_parameters tool.
+/// </summary>
+public sealed class ReorderParametersParams
+{
+    /// <summary>
+    /// Absolute path to the source file containing the method.
+    /// </summary>
+    public required string SourceFile { get; init; }
+
+    /// <summary>
+    /// Name of the method to modify.
+    /// </summary>
+    public required string MethodName { get; init; }
+
+    /// <summary>
+    /// New parameter order as a 0-based permutation of 0..n-1.
+    /// <c>newOrder[i]</c> is the original index that moves to position <c>i</c>.
+    /// </summary>
+    public required int[] NewOrder { get; init; }
+
+    /// <summary>
+    /// Line number for disambiguation if multiple methods have the same name (1-based).
+    /// </summary>
+    public int? Line { get; init; }
+
+    /// <summary>
+    /// Column number for disambiguation (1-based).
+    /// </summary>
+    public int? Column { get; init; }
+
+    /// <summary>
+    /// Update the virtual/override chain together. Default: true.
+    /// </summary>
+    public bool UpdateOverrides { get; init; } = true;
+
+    /// <summary>
+    /// Update interface declarations and implementations together. Default: true.
+    /// </summary>
+    public bool UpdateImplementations { get; init; } = true;
+
+    /// <summary>
+    /// Return computed changes without applying. Default: false.
+    /// </summary>
+    public bool Preview { get; init; }
+}

--- a/src/RoslynMcp.Core/Refactoring/Signature/ReorderParametersOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Signature/ReorderParametersOperation.cs
@@ -120,11 +120,14 @@ public sealed class ReorderParametersOperation : RefactoringOperationBase<Reorde
             @params.UpdateImplementations,
             cancellationToken);
 
+        await ValidateRelatedSignaturesAsync(relatedMethods, newOrder, cancellationToken);
+
         var declarationTargets = await CollectDeclarationTargetsAsync(relatedMethods, cancellationToken);
         foreach (var target in declarationTargets)
             ValidateDocumentIsEditable(target.Document, Context.Workspace);
 
-        var callSites = await CollectCallSitesAsync(relatedMethods, cancellationToken);
+        var fallbackNames = methodSymbol.Parameters.Select(p => p.Name).ToArray();
+        var callSites = await CollectCallSitesAsync(relatedMethods, fallbackNames, cancellationToken);
         foreach (var callSite in callSites)
             ValidateDocumentIsEditable(callSite.Document, Context.Workspace);
 
@@ -132,7 +135,7 @@ public sealed class ReorderParametersOperation : RefactoringOperationBase<Reorde
             document,
             declarationTargets,
             callSites,
-            methodSymbol.Parameters.ToList(),
+            fallbackNames,
             newOrder,
             cancellationToken);
 
@@ -228,6 +231,26 @@ public sealed class ReorderParametersOperation : RefactoringOperationBase<Reorde
                 throw new RefactoringException(
                     ErrorCodes.RequiredAfterOptional,
                     "Required parameters cannot follow optional parameters.");
+            }
+        }
+    }
+
+    private static async Task ValidateRelatedSignaturesAsync(
+        IReadOnlyList<IMethodSymbol> methods,
+        int[] newOrder,
+        CancellationToken cancellationToken)
+    {
+        foreach (var method in methods)
+        {
+            foreach (var syntaxRef in method.DeclaringSyntaxReferences)
+            {
+                if (await syntaxRef.GetSyntaxAsync(cancellationToken) is not MethodDeclarationSyntax declaration)
+                    continue;
+
+                if (declaration.ParameterList.Parameters.Count != newOrder.Length)
+                    continue;
+
+                ValidateResultingSignature(declaration.ParameterList, method, newOrder);
             }
         }
     }
@@ -386,6 +409,7 @@ public sealed class ReorderParametersOperation : RefactoringOperationBase<Reorde
 
     private async Task<List<CallSite>> CollectCallSitesAsync(
         IReadOnlyList<IMethodSymbol> methods,
+        IReadOnlyList<string> fallbackParameterNames,
         CancellationToken cancellationToken)
     {
         var callSites = new List<CallSite>();
@@ -420,7 +444,11 @@ public sealed class ReorderParametersOperation : RefactoringOperationBase<Reorde
                         var invoked = model?.GetSymbolInfo(invocation, cancellationToken).Symbol as IMethodSymbol;
                         var isReduced = invoked?.MethodKind == MethodKind.ReducedExtension ||
                                         invoked?.ReducedFrom != null;
-                        callSites.Add(new CallSite(document, invocation.Span, isReduced));
+                        var sourceMethod = invoked?.ReducedFrom ?? invoked ?? method;
+                        var parameterNames = sourceMethod.Parameters.Length == fallbackParameterNames.Count
+                            ? sourceMethod.Parameters.Select(p => p.Name).ToArray()
+                            : fallbackParameterNames;
+                        callSites.Add(new CallSite(document, invocation.Span, isReduced, parameterNames));
                         continue;
                     }
 
@@ -441,7 +469,7 @@ public sealed class ReorderParametersOperation : RefactoringOperationBase<Reorde
         Document originatingDocument,
         IReadOnlyList<DeclarationTarget> declarations,
         IReadOnlyList<CallSite> callSites,
-        IReadOnlyList<IParameterSymbol> originalParams,
+        IReadOnlyList<string> fallbackParameterNames,
         int[] newOrder,
         CancellationToken cancellationToken)
     {
@@ -467,6 +495,9 @@ public sealed class ReorderParametersOperation : RefactoringOperationBase<Reorde
                 .Where(c => c.IsReducedExtension)
                 .Select(c => c.Span)
                 .ToHashSet();
+            var parameterNamesBySpan = documentCallSites
+                .GroupBy(c => c.Span)
+                .ToDictionary(g => g.Key, g => g.First().ParameterNames);
 
             var methods = root.DescendantNodes()
                 .OfType<MethodDeclarationSyntax>()
@@ -481,7 +512,8 @@ public sealed class ReorderParametersOperation : RefactoringOperationBase<Reorde
                 methods,
                 invocations,
                 reducedSpans,
-                originalParams,
+                parameterNamesBySpan,
+                fallbackParameterNames,
                 newOrder);
             root = rewriter.Visit(root)
                 ?? throw new RefactoringException(ErrorCodes.RoslynError, "Failed to rewrite reorder_parameters targets.");
@@ -502,14 +534,14 @@ public sealed class ReorderParametersOperation : RefactoringOperationBase<Reorde
 
     internal static InvocationExpressionSyntax UpdateInvocation(
         InvocationExpressionSyntax invocation,
-        IReadOnlyList<IParameterSymbol> originalParams,
+        IReadOnlyList<string> parameterNames,
         int[] newOrder,
         bool isReducedExtension = false)
     {
         var newArgs = ReorderArguments(
             invocation.ArgumentList,
             newOrder,
-            originalParams,
+            parameterNames,
             isReducedExtension);
         return invocation.WithArgumentList(newArgs);
     }
@@ -517,7 +549,7 @@ public sealed class ReorderParametersOperation : RefactoringOperationBase<Reorde
     internal static ArgumentListSyntax ReorderArguments(
         ArgumentListSyntax args,
         int[] newOrder,
-        IReadOnlyList<IParameterSymbol> originalParams,
+        IReadOnlyList<string> parameterNames,
         bool isReducedExtension = false)
     {
         var originalArgs = args.Arguments.ToList();
@@ -537,9 +569,9 @@ public sealed class ReorderParametersOperation : RefactoringOperationBase<Reorde
         var firstExplicitOrdinal = isReducedExtension ? 1 : 0;
         var positionalByOldIndex = new Dictionary<int, ArgumentSyntax>();
         var positionalIndex = 0;
-        for (var i = 0; i < originalParams.Count; i++)
+        for (var i = 0; i < parameterNames.Count; i++)
         {
-            if (namedOriginal.ContainsKey(originalParams[i].Name))
+            if (namedOriginal.ContainsKey(parameterNames[i]))
                 continue;
             if (i < firstExplicitOrdinal)
                 continue;
@@ -549,42 +581,59 @@ public sealed class ReorderParametersOperation : RefactoringOperationBase<Reorde
         }
 
         var leftoverPositionals = positionalOriginal.Skip(positionalIndex).ToList();
-
         var newArgs = new List<ArgumentSyntax>();
-        if (namedOriginal.Count == 0)
+        var seenOmittedBefore = false;
+
+        foreach (var oldIndex in newOrder)
         {
-            foreach (var oldIndex in newOrder)
+            if (oldIndex < firstExplicitOrdinal)
+                continue;
+
+            var name = parameterNames[oldIndex];
+            if (namedOriginal.TryGetValue(name, out var named))
             {
-                if (positionalByOldIndex.TryGetValue(oldIndex, out var positional))
-                    newArgs.Add(positional);
+                newArgs.Add(named);
+                continue;
             }
+
+            if (positionalByOldIndex.TryGetValue(oldIndex, out var positional))
+            {
+                newArgs.Add(seenOmittedBefore ? EnsureNamed(positional, name) : positional);
+                continue;
+            }
+
+            seenOmittedBefore = true;
         }
-        else
+
+        foreach (var leftover in namedOriginal.Values)
         {
-            foreach (var oldIndex in newOrder)
-            {
-                var originalParam = originalParams[oldIndex];
-                if (namedOriginal.TryGetValue(originalParam.Name, out var named))
-                {
-                    newArgs.Add(named);
-                    continue;
-                }
-
-                if (positionalByOldIndex.TryGetValue(oldIndex, out var positional))
-                    newArgs.Add(positional);
-            }
-
-            foreach (var leftover in namedOriginal.Values)
-            {
-                if (!newArgs.Contains(leftover))
-                    newArgs.Add(leftover);
-            }
+            if (!newArgs.Contains(leftover))
+                newArgs.Add(leftover);
         }
 
         newArgs.AddRange(leftoverPositionals);
 
         return SyntaxFactory.ArgumentList(ReorderPreservingSeparators(args.Arguments, newArgs))
             .WithTriviaFrom(args);
+    }
+
+    private static ArgumentSyntax EnsureNamed(ArgumentSyntax argument, string name)
+    {
+        if (argument.NameColon != null)
+            return argument;
+
+        return argument.WithNameColon(CreateNameColon(name));
+    }
+
+    private static NameColonSyntax CreateNameColon(string name)
+    {
+        var keywordKind = SyntaxFacts.GetKeywordKind(name);
+        var identifier = keywordKind != SyntaxKind.None
+            ? SyntaxFactory.VerbatimIdentifier(default, name, name, default)
+            : SyntaxFactory.Identifier(name);
+        return SyntaxFactory.NameColon(
+            SyntaxFactory.IdentifierName(identifier),
+            SyntaxFactory.Token(SyntaxKind.ColonToken).WithTrailingTrivia(SyntaxFactory.Space));
     }
 
     private static async Task<RefactoringResult> CreatePreviewResultAsync(
@@ -753,27 +802,34 @@ public sealed class ReorderParametersOperation : RefactoringOperationBase<Reorde
 
     private sealed record DeclarationTarget(Document Document, TextSpan Span);
 
-    private sealed record CallSite(Document Document, TextSpan Span, bool IsReducedExtension);
+    private sealed record CallSite(
+        Document Document,
+        TextSpan Span,
+        bool IsReducedExtension,
+        IReadOnlyList<string> ParameterNames);
 
     private sealed class ReorderParametersRewriter : CSharpSyntaxRewriter
     {
         private readonly HashSet<MethodDeclarationSyntax> _methods;
         private readonly HashSet<InvocationExpressionSyntax> _invocations;
         private readonly HashSet<TextSpan> _reducedSpans;
-        private readonly IReadOnlyList<IParameterSymbol> _originalParams;
+        private readonly IReadOnlyDictionary<TextSpan, IReadOnlyList<string>> _parameterNamesBySpan;
+        private readonly IReadOnlyList<string> _fallbackParameterNames;
         private readonly int[] _newOrder;
 
         public ReorderParametersRewriter(
             IReadOnlyList<MethodDeclarationSyntax> methods,
             IReadOnlyList<InvocationExpressionSyntax> invocations,
             HashSet<TextSpan> reducedSpans,
-            IReadOnlyList<IParameterSymbol> originalParams,
+            IReadOnlyDictionary<TextSpan, IReadOnlyList<string>> parameterNamesBySpan,
+            IReadOnlyList<string> fallbackParameterNames,
             int[] newOrder)
         {
             _methods = new HashSet<MethodDeclarationSyntax>(methods);
             _invocations = new HashSet<InvocationExpressionSyntax>(invocations);
             _reducedSpans = reducedSpans;
-            _originalParams = originalParams;
+            _parameterNamesBySpan = parameterNamesBySpan;
+            _fallbackParameterNames = fallbackParameterNames;
             _newOrder = newOrder;
         }
 
@@ -797,7 +853,10 @@ public sealed class ReorderParametersOperation : RefactoringOperationBase<Reorde
                 return visited;
 
             var isReduced = _reducedSpans.Contains(node.Span);
-            return UpdateInvocation(visited, _originalParams, _newOrder, isReduced);
+            var parameterNames = _parameterNamesBySpan.TryGetValue(node.Span, out var stored)
+                ? stored
+                : _fallbackParameterNames;
+            return UpdateInvocation(visited, parameterNames, _newOrder, isReduced);
         }
     }
 }

--- a/src/RoslynMcp.Core/Refactoring/Signature/ReorderParametersOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Signature/ReorderParametersOperation.cs
@@ -1,0 +1,803 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Text;
+using RoslynMcp.Contracts.Enums;
+using RoslynMcp.Contracts.Errors;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.FileSystem;
+using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Workspace;
+
+namespace RoslynMcp.Core.Refactoring.Signature;
+
+/// <summary>
+/// Reorders a method's parameters by a 0-based permutation and updates
+/// call sites, overrides, and interface implementations.
+/// </summary>
+public sealed class ReorderParametersOperation : RefactoringOperationBase<ReorderParametersParams>
+{
+    /// <summary>
+    /// Creates a new reorder parameters operation.
+    /// </summary>
+    public ReorderParametersOperation(WorkspaceContext context) : base(context)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override void ValidateParams(ReorderParametersParams @params) => Validate(@params);
+
+    /// <summary>
+    /// Validates reorder-parameter inputs. Internal so tests can exercise rules
+    /// without loading a workspace.
+    /// </summary>
+    internal static void Validate(ReorderParametersParams @params)
+    {
+        if (string.IsNullOrWhiteSpace(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "sourceFile is required.");
+
+        if (string.IsNullOrWhiteSpace(@params.MethodName))
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "methodName is required.");
+
+        if (@params.NewOrder is null || @params.NewOrder.Length == 0)
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "newOrder is required.");
+
+        if (!PathResolver.IsAbsolutePath(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.InvalidSourcePath, "sourceFile must be an absolute path.");
+
+        if (!PathResolver.IsValidCSharpFilePath(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.InvalidSourcePath, "sourceFile must be a .cs file.");
+
+        if (!File.Exists(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.SourceFileNotFound, $"Source file not found: {@params.SourceFile}");
+
+        if (@params.Line.HasValue && @params.Line.Value < 1)
+            throw new RefactoringException(ErrorCodes.InvalidLineNumber, "Line number must be >= 1.");
+
+        if (@params.Column.HasValue && @params.Column.Value < 1)
+            throw new RefactoringException(ErrorCodes.InvalidColumnNumber, "Column number must be >= 1.");
+
+        if (@params.NewOrder.Length < 2 || !IsPermutation(@params.NewOrder, @params.NewOrder.Length))
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidParameterPosition,
+                "newOrder must be a permutation of 0..n-1 for a method with at least two parameters.");
+        }
+    }
+
+    /// <summary>
+    /// Rejects documents that cannot receive source edits.
+    /// </summary>
+    internal static void ValidateDocumentIsEditable(Document document, Microsoft.CodeAnalysis.Workspace workspace)
+    {
+        if (document is SourceGeneratedDocument)
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable (source-generated).");
+        }
+
+        if (string.IsNullOrWhiteSpace(document.FilePath) || !File.Exists(document.FilePath))
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable.");
+        }
+
+        if (!workspace.CanApplyChange(ApplyChangesKind.ChangeDocument))
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable (workspace cannot apply changes).");
+        }
+    }
+
+    /// <inheritdoc />
+    protected override async Task<RefactoringResult> ExecuteCoreAsync(
+        Guid operationId,
+        ReorderParametersParams @params,
+        CancellationToken cancellationToken)
+    {
+        var document = GetDocumentOrThrow(@params.SourceFile);
+        ValidateDocumentIsEditable(document, Context.Workspace);
+
+        var root = await document.GetSyntaxRootAsync(cancellationToken);
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken);
+        if (root == null || semanticModel == null)
+            throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse file.");
+
+        var methodDecl = FindMethodDeclaration(root, @params);
+        var methodSymbol = semanticModel.GetDeclaredSymbol(methodDecl, cancellationToken)
+            ?? throw new RefactoringException(ErrorCodes.RoslynError, "Could not resolve method symbol.");
+
+        var newOrder = ValidateNewOrder(methodSymbol.Parameters.Length, @params.NewOrder);
+        ValidateResultingSignature(methodDecl.ParameterList, methodSymbol, newOrder);
+
+        var relatedMethods = await GetRelatedMethodsAsync(
+            methodSymbol,
+            @params.UpdateOverrides,
+            @params.UpdateImplementations,
+            cancellationToken);
+
+        var declarationTargets = await CollectDeclarationTargetsAsync(relatedMethods, cancellationToken);
+        foreach (var target in declarationTargets)
+            ValidateDocumentIsEditable(target.Document, Context.Workspace);
+
+        var callSites = await CollectCallSitesAsync(relatedMethods, cancellationToken);
+        foreach (var callSite in callSites)
+            ValidateDocumentIsEditable(callSite.Document, Context.Workspace);
+
+        var newSolution = await ApplyChangesAsync(
+            document,
+            declarationTargets,
+            callSites,
+            methodSymbol.Parameters.ToList(),
+            newOrder,
+            cancellationToken);
+
+        if (@params.Preview)
+        {
+            return await CreatePreviewResultAsync(
+                operationId,
+                @params,
+                document,
+                newSolution,
+                callSites.Count,
+                cancellationToken);
+        }
+
+        var commitResult = await CommitChangesAsync(newSolution, cancellationToken);
+
+        return RefactoringResult.Succeeded(
+            operationId,
+            new FileChanges
+            {
+                FilesModified = commitResult.FilesModified,
+                FilesCreated = commitResult.FilesCreated,
+                FilesDeleted = commitResult.FilesDeleted
+            },
+            new Contracts.Models.SymbolInfo
+            {
+                Name = @params.MethodName,
+                FullyQualifiedName = methodSymbol.ToDisplayString(),
+                Kind = Contracts.Enums.SymbolKind.Method
+            },
+            callSites.Count,
+            0);
+    }
+
+    /// <summary>
+    /// Validates that <paramref name="newOrder"/> is a permutation of 0..<paramref name="paramCount"/>-1.
+    /// </summary>
+    internal static int[] ValidateNewOrder(int paramCount, int[] newOrder)
+    {
+        if (newOrder is null || newOrder.Length == 0)
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "newOrder is required.");
+
+        if (paramCount < 2)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidParameterPosition,
+                "Method must have at least two parameters to reorder.");
+        }
+
+        if (newOrder.Length != paramCount || !IsPermutation(newOrder, paramCount))
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidParameterPosition,
+                $"newOrder must be a permutation of 0..{paramCount - 1}.");
+        }
+
+        return newOrder;
+    }
+
+    internal static void ValidateResultingSignature(
+        ParameterListSyntax original,
+        IMethodSymbol method,
+        int[] newOrder)
+    {
+        if (method.IsExtensionMethod && newOrder[0] != 0)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidParameterPosition,
+                "The this parameter of an extension method must remain first.");
+        }
+
+        var reordered = newOrder.Select(i => original.Parameters[i]).ToList();
+        var seenOptional = false;
+        for (var i = 0; i < reordered.Count; i++)
+        {
+            var parameter = reordered[i];
+            var isParams = IsParams(parameter);
+            var isOptional = IsOptional(parameter);
+
+            if (isParams && i != reordered.Count - 1)
+            {
+                throw new RefactoringException(
+                    ErrorCodes.ParamsNotLast,
+                    "A params parameter must remain last in the parameter list.");
+            }
+
+            if (isOptional)
+            {
+                seenOptional = true;
+            }
+            else if (seenOptional && !isParams)
+            {
+                throw new RefactoringException(
+                    ErrorCodes.RequiredAfterOptional,
+                    "Required parameters cannot follow optional parameters.");
+            }
+        }
+    }
+
+    internal static MethodDeclarationSyntax FindMethodDeclaration(SyntaxNode root, ReorderParametersParams @params)
+    {
+        var methods = root.DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .Where(m => m.Identifier.Text == @params.MethodName)
+            .ToList();
+
+        if (methods.Count == 0)
+        {
+            throw new RefactoringException(
+                ErrorCodes.MethodNotFound,
+                $"Method '{@params.MethodName}' not found.");
+        }
+
+        if (methods.Count == 1 && !@params.Line.HasValue && !@params.Column.HasValue)
+            return methods[0];
+
+        IEnumerable<MethodDeclarationSyntax> filtered = methods;
+        if (@params.Line.HasValue)
+        {
+            filtered = filtered.Where(m =>
+                m.GetLocation().GetLineSpan().StartLinePosition.Line + 1 == @params.Line.Value);
+        }
+
+        if (@params.Column.HasValue)
+        {
+            filtered = filtered.Where(m =>
+                m.GetLocation().GetLineSpan().StartLinePosition.Character + 1 == @params.Column.Value);
+        }
+
+        var matches = filtered.ToList();
+        if (matches.Count == 1)
+            return matches[0];
+
+        if (matches.Count == 0)
+        {
+            throw new RefactoringException(
+                ErrorCodes.MethodNotFound,
+                @params.Line.HasValue
+                    ? $"Method '{@params.MethodName}' not found at line {@params.Line}."
+                    : $"Method '{@params.MethodName}' not found.");
+        }
+
+        var lines = matches
+            .Select(m => m.GetLocation().GetLineSpan().StartLinePosition.Line + 1)
+            .ToList();
+        throw new RefactoringException(
+            ErrorCodes.SymbolAmbiguous,
+            $"Multiple methods named '{@params.MethodName}' found. Provide line number. Options: {string.Join(", ", lines)}");
+    }
+
+    private async Task<List<IMethodSymbol>> GetRelatedMethodsAsync(
+        IMethodSymbol method,
+        bool updateOverrides,
+        bool updateImplementations,
+        CancellationToken cancellationToken)
+    {
+        var results = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default) { method };
+
+        if (updateOverrides)
+        {
+            var current = method;
+            while (current.OverriddenMethod != null)
+            {
+                results.Add(current.OverriddenMethod);
+                current = current.OverriddenMethod;
+            }
+
+            foreach (var symbol in results.ToList())
+            {
+                var overrides = await SymbolFinder.FindOverridesAsync(
+                    symbol, Context.Solution, cancellationToken: cancellationToken);
+                foreach (var ov in overrides.OfType<IMethodSymbol>())
+                    results.Add(ov);
+            }
+        }
+
+        if (updateImplementations)
+        {
+            foreach (var candidate in results.ToList())
+            {
+                if (candidate.ContainingType.TypeKind == TypeKind.Interface)
+                {
+                    var implementations = await SymbolFinder.FindImplementationsAsync(
+                        candidate, Context.Solution, cancellationToken: cancellationToken);
+                    foreach (var impl in implementations.OfType<IMethodSymbol>())
+                        results.Add(impl);
+                    continue;
+                }
+
+                foreach (var iface in candidate.ContainingType.AllInterfaces)
+                {
+                    foreach (var ifaceMethod in iface.GetMembers(candidate.Name).OfType<IMethodSymbol>())
+                    {
+                        var impl = candidate.ContainingType.FindImplementationForInterfaceMember(ifaceMethod);
+                        if (impl is not IMethodSymbol implMethod ||
+                            !ShareOverrideRoot(implMethod, candidate))
+                        {
+                            continue;
+                        }
+
+                        results.Add(ifaceMethod);
+                        var otherImpls = await SymbolFinder.FindImplementationsAsync(
+                            ifaceMethod,
+                            Context.Solution,
+                            cancellationToken: cancellationToken);
+                        foreach (var other in otherImpls.OfType<IMethodSymbol>())
+                            results.Add(other);
+                    }
+                }
+            }
+        }
+
+        return results.Where(HasSourceDeclaration).ToList();
+    }
+
+    private async Task<List<DeclarationTarget>> CollectDeclarationTargetsAsync(
+        IReadOnlyList<IMethodSymbol> methods,
+        CancellationToken cancellationToken)
+    {
+        var targets = new List<DeclarationTarget>();
+
+        foreach (var method in methods)
+        {
+            foreach (var syntaxRef in method.DeclaringSyntaxReferences)
+            {
+                if (await syntaxRef.GetSyntaxAsync(cancellationToken) is not MethodDeclarationSyntax declaration)
+                {
+                    throw new RefactoringException(
+                        ErrorCodes.InvalidSelection,
+                        $"Method '{method.Name}' is an unsupported target for reorder_parameters.");
+                }
+
+                var document = Context.Solution.GetDocument(syntaxRef.SyntaxTree)
+                    ?? throw new RefactoringException(
+                        ErrorCodes.DocumentNotEditable,
+                        $"Could not locate the document for method '{method.Name}'.");
+
+                targets.Add(new DeclarationTarget(document, declaration.Span));
+            }
+        }
+
+        if (targets.Count == 0)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidSelection,
+                "The selected method is an unsupported target for reorder_parameters.");
+        }
+
+        return targets;
+    }
+
+    private async Task<List<CallSite>> CollectCallSitesAsync(
+        IReadOnlyList<IMethodSymbol> methods,
+        CancellationToken cancellationToken)
+    {
+        var callSites = new List<CallSite>();
+        var seen = new HashSet<(DocumentId Id, TextSpan Span)>();
+
+        foreach (var method in methods)
+        {
+            var references = await SymbolFinder.FindReferencesAsync(method, Context.Solution, cancellationToken);
+            foreach (var referenced in references)
+            {
+                foreach (var location in referenced.Locations)
+                {
+                    if (location.Location.Kind != LocationKind.SourceFile)
+                        continue;
+
+                    var document = location.Document;
+                    var root = await document.GetSyntaxRootAsync(cancellationToken);
+                    if (root == null)
+                        continue;
+
+                    var node = root.FindNode(location.Location.SourceSpan, getInnermostNodeForTie: true);
+                    if (IsDeclarationName(node, location.Location.SourceSpan))
+                        continue;
+
+                    var invocation = node.AncestorsAndSelf().OfType<InvocationExpressionSyntax>().FirstOrDefault();
+                    if (invocation != null && IsInvokedMethodName(invocation, location.Location.SourceSpan))
+                    {
+                        if (!seen.Add((document.Id, invocation.Span)))
+                            continue;
+
+                        var model = await document.GetSemanticModelAsync(cancellationToken);
+                        var invoked = model?.GetSymbolInfo(invocation, cancellationToken).Symbol as IMethodSymbol;
+                        var isReduced = invoked?.MethodKind == MethodKind.ReducedExtension ||
+                                        invoked?.ReducedFrom != null;
+                        callSites.Add(new CallSite(document, invocation.Span, isReduced));
+                        continue;
+                    }
+
+                    if (IsNameOfArgument(node))
+                        continue;
+
+                    throw new RefactoringException(
+                        ErrorCodes.UnsupportedCallSite,
+                        $"Method '{method.Name}' is used as a method group or other unsupported reference and cannot be updated automatically.");
+                }
+            }
+        }
+
+        return callSites;
+    }
+
+    private static async Task<Solution> ApplyChangesAsync(
+        Document originatingDocument,
+        IReadOnlyList<DeclarationTarget> declarations,
+        IReadOnlyList<CallSite> callSites,
+        IReadOnlyList<IParameterSymbol> originalParams,
+        int[] newOrder,
+        CancellationToken cancellationToken)
+    {
+        var solution = originatingDocument.Project.Solution;
+        var documentIds = declarations.Select(d => d.Document.Id)
+            .Concat(callSites.Select(c => c.Document.Id))
+            .ToHashSet();
+
+        foreach (var documentId in documentIds)
+        {
+            var document = solution.GetDocument(documentId)
+                ?? throw new RefactoringException(ErrorCodes.RoslynError, "Document disappeared from solution.");
+            var root = await document.GetSyntaxRootAsync(cancellationToken)
+                ?? throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse file.");
+
+            var declarationSpans = declarations
+                .Where(d => d.Document.Id == documentId)
+                .Select(d => d.Span)
+                .ToHashSet();
+            var documentCallSites = callSites.Where(c => c.Document.Id == documentId).ToList();
+            var invocationSpans = documentCallSites.Select(c => c.Span).ToHashSet();
+            var reducedSpans = documentCallSites
+                .Where(c => c.IsReducedExtension)
+                .Select(c => c.Span)
+                .ToHashSet();
+
+            var methods = root.DescendantNodes()
+                .OfType<MethodDeclarationSyntax>()
+                .Where(m => declarationSpans.Contains(m.Span))
+                .ToList();
+            var invocations = root.DescendantNodes()
+                .OfType<InvocationExpressionSyntax>()
+                .Where(i => invocationSpans.Contains(i.Span))
+                .ToList();
+
+            var rewriter = new ReorderParametersRewriter(
+                methods,
+                invocations,
+                reducedSpans,
+                originalParams,
+                newOrder);
+            root = rewriter.Visit(root)
+                ?? throw new RefactoringException(ErrorCodes.RoslynError, "Failed to rewrite reorder_parameters targets.");
+
+            solution = document.WithSyntaxRoot(root).Project.Solution;
+        }
+
+        return solution;
+    }
+
+    internal static ParameterListSyntax ReorderParameters(ParameterListSyntax list, int[] newOrder)
+    {
+        var original = list.Parameters;
+        var reordered = newOrder.Select(i => original[i]).ToList();
+        return SyntaxFactory.ParameterList(ReorderPreservingSeparators(original, reordered))
+            .WithTriviaFrom(list);
+    }
+
+    internal static InvocationExpressionSyntax UpdateInvocation(
+        InvocationExpressionSyntax invocation,
+        IReadOnlyList<IParameterSymbol> originalParams,
+        int[] newOrder,
+        bool isReducedExtension = false)
+    {
+        var newArgs = ReorderArguments(
+            invocation.ArgumentList,
+            newOrder,
+            originalParams,
+            isReducedExtension);
+        return invocation.WithArgumentList(newArgs);
+    }
+
+    internal static ArgumentListSyntax ReorderArguments(
+        ArgumentListSyntax args,
+        int[] newOrder,
+        IReadOnlyList<IParameterSymbol> originalParams,
+        bool isReducedExtension = false)
+    {
+        var originalArgs = args.Arguments.ToList();
+        var namedOriginal = new Dictionary<string, ArgumentSyntax>(StringComparer.Ordinal);
+        var positionalOriginal = new List<ArgumentSyntax>();
+        foreach (var arg in originalArgs)
+        {
+            if (arg.NameColon != null)
+                namedOriginal[arg.NameColon.Name.Identifier.ValueText] = arg;
+            else
+                positionalOriginal.Add(arg);
+        }
+
+        if (positionalOriginal.Count == 0)
+            return args;
+
+        var firstExplicitOrdinal = isReducedExtension ? 1 : 0;
+        var positionalByOldIndex = new Dictionary<int, ArgumentSyntax>();
+        var positionalIndex = 0;
+        for (var i = 0; i < originalParams.Count; i++)
+        {
+            if (namedOriginal.ContainsKey(originalParams[i].Name))
+                continue;
+            if (i < firstExplicitOrdinal)
+                continue;
+            if (positionalIndex >= positionalOriginal.Count)
+                continue;
+            positionalByOldIndex[i] = positionalOriginal[positionalIndex++];
+        }
+
+        var leftoverPositionals = positionalOriginal.Skip(positionalIndex).ToList();
+
+        var newArgs = new List<ArgumentSyntax>();
+        if (namedOriginal.Count == 0)
+        {
+            foreach (var oldIndex in newOrder)
+            {
+                if (positionalByOldIndex.TryGetValue(oldIndex, out var positional))
+                    newArgs.Add(positional);
+            }
+        }
+        else
+        {
+            foreach (var oldIndex in newOrder)
+            {
+                var originalParam = originalParams[oldIndex];
+                if (namedOriginal.TryGetValue(originalParam.Name, out var named))
+                {
+                    newArgs.Add(named);
+                    continue;
+                }
+
+                if (positionalByOldIndex.TryGetValue(oldIndex, out var positional))
+                    newArgs.Add(positional);
+            }
+
+            foreach (var leftover in namedOriginal.Values)
+            {
+                if (!newArgs.Contains(leftover))
+                    newArgs.Add(leftover);
+            }
+        }
+
+        newArgs.AddRange(leftoverPositionals);
+
+        return SyntaxFactory.ArgumentList(ReorderPreservingSeparators(args.Arguments, newArgs))
+            .WithTriviaFrom(args);
+    }
+
+    private static async Task<RefactoringResult> CreatePreviewResultAsync(
+        Guid operationId,
+        ReorderParametersParams @params,
+        Document originalDocument,
+        Solution newSolution,
+        int callSiteCount,
+        CancellationToken cancellationToken)
+    {
+        var pendingChanges = new List<PendingChange>();
+        var originalSolution = originalDocument.Project.Solution;
+
+        foreach (var projectChanges in newSolution.GetChanges(originalSolution).GetProjectChanges())
+        {
+            foreach (var docId in projectChanges.GetChangedDocuments())
+            {
+                var oldDoc = originalSolution.GetDocument(docId);
+                var newDoc = newSolution.GetDocument(docId);
+                if (oldDoc?.FilePath == null || newDoc == null)
+                    continue;
+
+                var before = await oldDoc.GetTextAsync(cancellationToken);
+                var after = await newDoc.GetTextAsync(cancellationToken);
+                pendingChanges.Add(new PendingChange
+                {
+                    File = oldDoc.FilePath,
+                    ChangeType = ChangeKind.Modify,
+                    Description = $"Reorder parameters of '{@params.MethodName}' ({callSiteCount} call site(s) to update)",
+                    BeforeSnippet = before.ToString(),
+                    AfterSnippet = after.ToString()
+                });
+            }
+        }
+
+        if (pendingChanges.Count == 0)
+        {
+            pendingChanges.Add(new PendingChange
+            {
+                File = @params.SourceFile,
+                ChangeType = ChangeKind.Modify,
+                Description = $"Reorder parameters of '{@params.MethodName}'",
+                BeforeSnippet = null,
+                AfterSnippet = null
+            });
+        }
+
+        return RefactoringResult.PreviewResult(operationId, pendingChanges);
+    }
+
+    private static bool IsDeclarationName(SyntaxNode node, TextSpan referenceSpan)
+    {
+        return node.AncestorsAndSelf().OfType<MethodDeclarationSyntax>()
+            .Any(m => m.Identifier.Span.IntersectsWith(referenceSpan));
+    }
+
+    private static bool IsInvokedMethodName(InvocationExpressionSyntax invocation, TextSpan referenceSpan)
+    {
+        if (invocation.ArgumentList.Span.Contains(referenceSpan))
+            return false;
+
+        return invocation.Expression switch
+        {
+            IdentifierNameSyntax identifier => identifier.Span.IntersectsWith(referenceSpan),
+            MemberAccessExpressionSyntax member => member.Name.Span.IntersectsWith(referenceSpan),
+            MemberBindingExpressionSyntax binding => binding.Name.Span.IntersectsWith(referenceSpan),
+            _ => invocation.Expression.Span.IntersectsWith(referenceSpan)
+        };
+    }
+
+    private static bool IsNameOfArgument(SyntaxNode node)
+    {
+        foreach (var invocation in node.AncestorsAndSelf().OfType<InvocationExpressionSyntax>())
+        {
+            if (invocation.Expression is IdentifierNameSyntax identifier &&
+                identifier.Identifier.Text == "nameof")
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasSourceDeclaration(IMethodSymbol method) =>
+        method.DeclaringSyntaxReferences.Length > 0 &&
+        method.Locations.Any(l => l.IsInSource);
+
+    private static bool ShareOverrideRoot(IMethodSymbol left, IMethodSymbol right) =>
+        SymbolEqualityComparer.Default.Equals(GetOverrideRoot(left), GetOverrideRoot(right));
+
+    private static IMethodSymbol GetOverrideRoot(IMethodSymbol method)
+    {
+        var current = method;
+        while (current.OverriddenMethod != null)
+            current = current.OverriddenMethod;
+        return current;
+    }
+
+    private static bool IsParams(ParameterSyntax parameter) =>
+        parameter.Modifiers.Any(m => m.IsKind(SyntaxKind.ParamsKeyword));
+
+    private static bool IsOptional(ParameterSyntax parameter) =>
+        parameter.Default != null;
+
+    private static bool IsPermutation(int[] order, int count)
+    {
+        if (order.Length != count)
+            return false;
+
+        var seen = new bool[count];
+        foreach (var index in order)
+        {
+            if (index < 0 || index >= count || seen[index])
+                return false;
+            seen[index] = true;
+        }
+
+        return true;
+    }
+
+    internal static SeparatedSyntaxList<T> ReorderPreservingSeparators<T>(
+        SeparatedSyntaxList<T> original,
+        IReadOnlyList<T> reordered)
+        where T : SyntaxNode
+    {
+        if (reordered.Count == 0)
+            return SyntaxFactory.SeparatedList<T>();
+
+        var originalNodes = original.ToList();
+        var separators = original.GetSeparators().ToList();
+        var newIndices = new List<int>(reordered.Count);
+        foreach (var node in reordered)
+        {
+            var index = originalNodes.IndexOf(node);
+            if (index < 0)
+                return SyntaxFactory.SeparatedList(reordered, DefaultCommaSeparators(reordered.Count));
+
+            newIndices.Add(index);
+        }
+
+        var newSeparators = new List<SyntaxToken>();
+        for (var i = 0; i < newIndices.Count - 1; i++)
+        {
+            var from = newIndices[i];
+            var to = newIndices[i + 1];
+            if (to == from + 1 && from < separators.Count)
+                newSeparators.Add(separators[from]);
+            else
+                newSeparators.Add(CommaWithSpace());
+        }
+
+        return SyntaxFactory.SeparatedList(reordered, newSeparators);
+    }
+
+    private static IReadOnlyList<SyntaxToken> DefaultCommaSeparators(int nodeCount)
+    {
+        if (nodeCount <= 1)
+            return Array.Empty<SyntaxToken>();
+
+        return Enumerable.Repeat(CommaWithSpace(), nodeCount - 1).ToArray();
+    }
+
+    private static SyntaxToken CommaWithSpace() =>
+        SyntaxFactory.Token(SyntaxKind.CommaToken).WithTrailingTrivia(SyntaxFactory.Space);
+
+    private sealed record DeclarationTarget(Document Document, TextSpan Span);
+
+    private sealed record CallSite(Document Document, TextSpan Span, bool IsReducedExtension);
+
+    private sealed class ReorderParametersRewriter : CSharpSyntaxRewriter
+    {
+        private readonly HashSet<MethodDeclarationSyntax> _methods;
+        private readonly HashSet<InvocationExpressionSyntax> _invocations;
+        private readonly HashSet<TextSpan> _reducedSpans;
+        private readonly IReadOnlyList<IParameterSymbol> _originalParams;
+        private readonly int[] _newOrder;
+
+        public ReorderParametersRewriter(
+            IReadOnlyList<MethodDeclarationSyntax> methods,
+            IReadOnlyList<InvocationExpressionSyntax> invocations,
+            HashSet<TextSpan> reducedSpans,
+            IReadOnlyList<IParameterSymbol> originalParams,
+            int[] newOrder)
+        {
+            _methods = new HashSet<MethodDeclarationSyntax>(methods);
+            _invocations = new HashSet<InvocationExpressionSyntax>(invocations);
+            _reducedSpans = reducedSpans;
+            _originalParams = originalParams;
+            _newOrder = newOrder;
+        }
+
+        public override SyntaxNode? VisitMethodDeclaration(MethodDeclarationSyntax node)
+        {
+            var visited = (MethodDeclarationSyntax)base.VisitMethodDeclaration(node)!;
+            var original = _methods.FirstOrDefault(m => m.Span == node.Span && m.Identifier.Text == node.Identifier.Text);
+            if (original == null)
+                return visited;
+
+            if (visited.ParameterList.Parameters.Count != _newOrder.Length)
+                return visited;
+
+            return visited.WithParameterList(ReorderParameters(visited.ParameterList, _newOrder));
+        }
+
+        public override SyntaxNode? VisitInvocationExpression(InvocationExpressionSyntax node)
+        {
+            var visited = (InvocationExpressionSyntax)base.VisitInvocationExpression(node)!;
+            if (!_invocations.Contains(node) && !_invocations.Any(i => i.Span == node.Span))
+                return visited;
+
+            var isReduced = _reducedSpans.Contains(node.Span);
+            return UpdateInvocation(visited, _originalParams, _newOrder, isReduced);
+        }
+    }
+}

--- a/src/RoslynMcp.Core/Refactoring/Signature/ReorderParametersOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Signature/ReorderParametersOperation.cs
@@ -252,7 +252,87 @@ public sealed class ReorderParametersOperation : RefactoringOperationBase<Reorde
 
                 ValidateResultingSignature(declaration.ParameterList, method, newOrder);
             }
+
+            ValidateNoOverloadCollision(method, newOrder);
         }
+    }
+
+    internal static void ValidateNoOverloadCollision(IMethodSymbol method, int[] newOrder)
+    {
+        if (method.ContainingType == null || newOrder.Length != method.Parameters.Length)
+            return;
+
+        foreach (var candidate in method.ContainingType.GetMembers(method.Name).OfType<IMethodSymbol>())
+        {
+            if (SymbolEqualityComparer.Default.Equals(candidate, method))
+                continue;
+            if (candidate.Parameters.Length != method.Parameters.Length)
+                continue;
+            if (candidate.TypeParameters.Length != method.TypeParameters.Length)
+                continue;
+            if (!ParameterTypesMatch(method, newOrder, candidate))
+                continue;
+
+            throw new RefactoringException(
+                ErrorCodes.SignatureMatchesOverload,
+                $"Reordering parameters of '{method.Name}' would match an existing overload.");
+        }
+    }
+
+    private static bool ParameterTypesMatch(IMethodSymbol method, int[] newOrder, IMethodSymbol other)
+    {
+        for (var i = 0; i < newOrder.Length; i++)
+        {
+            var reordered = method.Parameters[newOrder[i]];
+            var existing = other.Parameters[i];
+            if (reordered.RefKind != existing.RefKind)
+                return false;
+            if (!TypesEquivalent(reordered.Type, existing.Type))
+                return false;
+        }
+
+        return true;
+    }
+
+    private static bool TypesEquivalent(ITypeSymbol left, ITypeSymbol right)
+    {
+        if (SymbolEqualityComparer.Default.Equals(left, right))
+            return true;
+
+        if (left is ITypeParameterSymbol leftTypeParameter &&
+            right is ITypeParameterSymbol rightTypeParameter)
+        {
+            return leftTypeParameter.TypeParameterKind == rightTypeParameter.TypeParameterKind &&
+                   leftTypeParameter.Ordinal == rightTypeParameter.Ordinal &&
+                   (leftTypeParameter.TypeParameterKind != TypeParameterKind.Type ||
+                    SymbolEqualityComparer.Default.Equals(
+                        leftTypeParameter.ContainingType,
+                        rightTypeParameter.ContainingType));
+        }
+
+        if (left is IArrayTypeSymbol leftArray && right is IArrayTypeSymbol rightArray)
+        {
+            return leftArray.Rank == rightArray.Rank &&
+                   TypesEquivalent(leftArray.ElementType, rightArray.ElementType);
+        }
+
+        if (left is INamedTypeSymbol leftNamed && right is INamedTypeSymbol rightNamed)
+        {
+            if (!SymbolEqualityComparer.Default.Equals(leftNamed.OriginalDefinition, rightNamed.OriginalDefinition))
+                return false;
+            if (leftNamed.TypeArguments.Length != rightNamed.TypeArguments.Length)
+                return false;
+
+            for (var i = 0; i < leftNamed.TypeArguments.Length; i++)
+            {
+                if (!TypesEquivalent(leftNamed.TypeArguments[i], rightNamed.TypeArguments[i]))
+                    return false;
+            }
+
+            return true;
+        }
+
+        return false;
     }
 
     internal static MethodDeclarationSyntax FindMethodDeclaration(SyntaxNode root, ReorderParametersParams @params)

--- a/src/RoslynMcp.Server/McpServerHost.cs
+++ b/src/RoslynMcp.Server/McpServerHost.cs
@@ -50,6 +50,7 @@ public sealed class McpServerHost : IAsyncDisposable
         _toolRegistry.Register(new ChangeSignatureTool(workspaceProvider));
         _toolRegistry.Register(new AddParameterTool(workspaceProvider));
         _toolRegistry.Register(new RemoveParameterTool(workspaceProvider));
+        _toolRegistry.Register(new ReorderParametersTool(workspaceProvider));
         _toolRegistry.Register(new EncapsulateFieldTool(workspaceProvider));
         _toolRegistry.Register(new ConvertToAsyncTool(workspaceProvider));
         _toolRegistry.Register(new ExtractBaseClassTool(workspaceProvider));

--- a/src/RoslynMcp.Server/Tools/ReorderParametersTool.cs
+++ b/src/RoslynMcp.Server/Tools/ReorderParametersTool.cs
@@ -1,0 +1,164 @@
+using System.Text.Json;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.Refactoring;
+using RoslynMcp.Core.Refactoring.Signature;
+using RoslynMcp.Core.Workspace;
+using RoslynMcp.Server.Transport;
+
+namespace RoslynMcp.Server.Tools;
+
+/// <summary>
+/// MCP tool handler for reorder_parameters operation.
+/// </summary>
+public sealed class ReorderParametersTool : IToolHandler
+{
+    private readonly IWorkspaceProvider _workspaceProvider;
+    private readonly JsonSerializerOptions _jsonOptions;
+
+    /// <summary>
+    /// Creates a new reorder parameters tool.
+    /// </summary>
+    public ReorderParametersTool(IWorkspaceProvider workspaceProvider)
+    {
+        _workspaceProvider = workspaceProvider;
+        _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = false
+        };
+    }
+
+    /// <inheritdoc />
+    public string Name => "reorder_parameters";
+
+    /// <inheritdoc />
+    public string Description => "Reorder a method's parameters by a 0-based permutation and update call sites, overrides, and interface implementations.";
+
+    /// <inheritdoc />
+    public object InputSchema => new
+    {
+        type = "object",
+        required = new[] { "solutionPath", "sourceFile", "methodName", "newOrder" },
+        properties = new
+        {
+            solutionPath = new
+            {
+                type = "string",
+                description = "Absolute path to the .sln or .csproj file"
+            },
+            sourceFile = new
+            {
+                type = "string",
+                description = "Absolute path to the source file containing the method"
+            },
+            methodName = new
+            {
+                type = "string",
+                description = "Name of the method to modify"
+            },
+            newOrder = new
+            {
+                type = "array",
+                items = new { type = "integer" },
+                description = "New parameter order as a 0-based permutation of 0..n-1"
+            },
+            line = new
+            {
+                type = "integer",
+                description = "Line number for disambiguation if multiple methods have the same name (1-based)"
+            },
+            column = new
+            {
+                type = "integer",
+                description = "Column number for disambiguation (1-based)"
+            },
+            updateOverrides = new
+            {
+                type = "boolean",
+                description = "Update the virtual/override chain together",
+                @default = true
+            },
+            updateImplementations = new
+            {
+                type = "boolean",
+                description = "Update interface declarations and implementations together",
+                @default = true
+            },
+            preview = new
+            {
+                type = "boolean",
+                description = "Return computed changes without applying",
+                @default = false
+            }
+        },
+        additionalProperties = false
+    };
+
+    /// <inheritdoc />
+    public async Task<ToolResult> ExecuteAsync(JsonElement? arguments, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (arguments == null)
+            {
+                return ToolResult.Error("Arguments required");
+            }
+
+            var args = JsonSerializer.Deserialize<ReorderParametersArgs>(arguments.Value.GetRawText(), _jsonOptions);
+            if (args == null)
+            {
+                return ToolResult.Error("Failed to parse arguments");
+            }
+
+            using var context = await _workspaceProvider.CreateContextAsync(
+                args.SolutionPath,
+                cancellationToken);
+
+            var operation = new ReorderParametersOperation(context);
+            var @params = new ReorderParametersParams
+            {
+                SourceFile = args.SourceFile,
+                MethodName = args.MethodName,
+                NewOrder = args.NewOrder ?? Array.Empty<int>(),
+                Line = args.Line,
+                Column = args.Column,
+                UpdateOverrides = args.UpdateOverrides ?? true,
+                UpdateImplementations = args.UpdateImplementations ?? true,
+                Preview = args.Preview ?? false
+            };
+
+            var result = await operation.ExecuteAsync(@params, cancellationToken);
+
+            var json = JsonSerializer.Serialize(result, _jsonOptions);
+            return result.Success ? ToolResult.Success(json) : ToolResult.Error(json);
+        }
+        catch (RefactoringException ex)
+        {
+            var error = ex.ToError();
+            var json = JsonSerializer.Serialize(new { success = false, error }, _jsonOptions);
+            return ToolResult.Error(json);
+        }
+        catch (Exception ex)
+        {
+            var json = JsonSerializer.Serialize(new
+            {
+                success = false,
+                error = new { code = "INTERNAL_ERROR", message = ex.Message }
+            }, _jsonOptions);
+            return ToolResult.Error(json);
+        }
+    }
+
+    private sealed class ReorderParametersArgs
+    {
+        public string SolutionPath { get; init; } = "";
+        public string SourceFile { get; init; } = "";
+        public string MethodName { get; init; } = "";
+        public int[]? NewOrder { get; init; }
+        public int? Line { get; init; }
+        public int? Column { get; init; }
+        public bool? UpdateOverrides { get; init; }
+        public bool? UpdateImplementations { get; init; }
+        public bool? Preview { get; init; }
+    }
+}

--- a/tests/RoslynMcp.Cli.Tests/HelpGeneratorTests.cs
+++ b/tests/RoslynMcp.Cli.Tests/HelpGeneratorTests.cs
@@ -15,11 +15,11 @@ public class HelpGeneratorTests
     }
 
     [Fact]
-    public void GenerateGlobalHelp_Lists56Tools()
+    public void GenerateGlobalHelp_Lists57Tools()
     {
         var registry = ToolRegistry.BuildDefault();
         var help = HelpGenerator.GenerateGlobalHelp(registry);
-        Assert.Contains("Total: 56 tools", help);
+        Assert.Contains("Total: 57 tools", help);
         Assert.Contains("pull-members-up", help);
         Assert.Contains("push-members-down", help);
         Assert.Contains("use-base-type", help);
@@ -34,6 +34,7 @@ public class HelpGeneratorTests
         Assert.Contains("inline-constant", help);
         Assert.Contains("add-parameter", help);
         Assert.Contains("remove-parameter", help);
+        Assert.Contains("reorder-parameters", help);
     }
 
     [Fact]

--- a/tests/RoslynMcp.Cli.Tests/ToolRegistryTests.cs
+++ b/tests/RoslynMcp.Cli.Tests/ToolRegistryTests.cs
@@ -85,7 +85,7 @@ public class ToolRegistryTests
     [InlineData("extract-method", "Refactoring")]
     [InlineData("inline-method", "Refactoring")]
     [InlineData("inline-constant", "Refactoring")]
-            [InlineData("add-parameter", "Refactoring")]
+    [InlineData("add-parameter", "Refactoring")]
     [InlineData("remove-parameter", "Refactoring")]
     [InlineData("reorder-parameters", "Refactoring")]
     [InlineData("pull-members-up", "Refactoring")]

--- a/tests/RoslynMcp.Cli.Tests/ToolRegistryTests.cs
+++ b/tests/RoslynMcp.Cli.Tests/ToolRegistryTests.cs
@@ -6,11 +6,11 @@ namespace RoslynMcp.Cli.Tests;
 public class ToolRegistryTests
 {
     [Fact]
-    public void BuildDefault_Registers56Tools()
+    public void BuildDefault_Registers57Tools()
     {
         var registry = ToolRegistry.BuildDefault();
         var tools = registry.GetAllTools();
-        Assert.Equal(56, tools.Count);
+        Assert.Equal(57, tools.Count);
     }
 
     [Fact]
@@ -85,8 +85,9 @@ public class ToolRegistryTests
     [InlineData("extract-method", "Refactoring")]
     [InlineData("inline-method", "Refactoring")]
     [InlineData("inline-constant", "Refactoring")]
-    [InlineData("add-parameter", "Refactoring")]
+            [InlineData("add-parameter", "Refactoring")]
     [InlineData("remove-parameter", "Refactoring")]
+    [InlineData("reorder-parameters", "Refactoring")]
     [InlineData("pull-members-up", "Refactoring")]
     [InlineData("push-members-down", "Refactoring")]
     [InlineData("use-base-type", "Refactoring")]
@@ -116,11 +117,11 @@ public class ToolRegistryTests
     }
 
     [Fact]
-    public void RefactoringToolCount_Is43()
+    public void RefactoringToolCount_Is44()
     {
         var registry = ToolRegistry.BuildDefault();
         var count = registry.GetAllTools().Count(t => t.Category == "Refactoring");
-        Assert.Equal(43, count);
+        Assert.Equal(44, count);
     }
 
     [Fact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Signature/ReorderParametersOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Signature/ReorderParametersOperationTests.cs
@@ -544,6 +544,42 @@ public class ReorderParametersOperationTests
     }
 
     [SkippableFact]
+    public async Task ReorderParameters_OverloadCollision_ThrowsAndWritesNothing()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public void Process(int count, string name)
+                {
+                }
+
+                public void Process(string name, int count)
+                {
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var original = await File.ReadAllTextAsync(workspace.SourcePath);
+        var operation = new ReorderParametersOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new ReorderParametersParams
+            {
+                SourceFile = workspace.SourcePath,
+                MethodName = "Process",
+                NewOrder = new[] { 1, 0 },
+                Line = 5
+            }));
+
+        Assert.Equal(ErrorCodes.SignatureMatchesOverload, ex.ErrorCode);
+        Assert.Equal("3132", ex.ErrorCode);
+        Assert.Equal(original, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [SkippableFact]
     public async Task ReorderParameters_ParamsNotLast_Throws()
     {
         const string source = """

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Signature/ReorderParametersOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Signature/ReorderParametersOperationTests.cs
@@ -1,0 +1,691 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using RoslynMcp.Contracts.Errors;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.Refactoring;
+using RoslynMcp.Core.Refactoring.Signature;
+using RoslynMcp.Core.Workspace;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Refactoring.Signature;
+
+/// <summary>
+/// Operation-level tests for <see cref="ReorderParametersOperation"/>.
+/// </summary>
+public class ReorderParametersOperationTests
+{
+    #region Input Validation
+
+    [Fact]
+    public void Validate_MissingSourceFile_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            ReorderParametersOperation.Validate(ValidParams(sourceFile: "")));
+
+        Assert.Equal(ErrorCodes.MissingRequiredParam, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_MissingMethodName_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            ReorderParametersOperation.Validate(ValidParams(methodName: "")));
+
+        Assert.Equal(ErrorCodes.MissingRequiredParam, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_MissingNewOrder_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            ReorderParametersOperation.Validate(ValidParams(newOrder: Array.Empty<int>())));
+
+        Assert.Equal(ErrorCodes.MissingRequiredParam, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_RelativePath_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            ReorderParametersOperation.Validate(ValidParams(sourceFile: "Worker.cs")));
+
+        Assert.Equal(ErrorCodes.InvalidSourcePath, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_MissingFile_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            ReorderParametersOperation.Validate(ValidParams()));
+
+        Assert.Equal(ErrorCodes.SourceFileNotFound, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_InvalidPermutation_Throws()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "RoslynMcpReorderInvalidPerm.cs");
+        File.WriteAllText(path, "class C {}");
+        try
+        {
+            var ex = Assert.Throws<RefactoringException>(() =>
+                ReorderParametersOperation.Validate(ValidParams(sourceFile: path, newOrder: new[] { 0, 0 })));
+
+            Assert.Equal(ErrorCodes.InvalidParameterPosition, ex.ErrorCode);
+            Assert.Equal("1011", ex.ErrorCode);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void ValidateNewOrder_LengthMismatch_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            ReorderParametersOperation.ValidateNewOrder(3, new[] { 1, 0 }));
+
+        Assert.Equal(ErrorCodes.InvalidParameterPosition, ex.ErrorCode);
+    }
+
+    #endregion
+
+    #region Happy Path
+
+    [SkippableFact]
+    public async Task ReorderParameters_SimpleSwap_ReordersDeclarationAndCallSite()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public void Process(int count, string name)
+                {
+                    System.Console.WriteLine(count + name);
+                }
+
+                public void Run()
+                {
+                    Process(3, "a");
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ReorderParametersOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new ReorderParametersParams
+        {
+            SourceFile = workspace.SourcePath,
+            MethodName = "Process",
+            NewOrder = new[] { 1, 0 }
+        });
+
+        Assert.True(result.Success);
+        Assert.False(result.Preview);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Contains("public void Process(string name, int count)", text);
+        Assert.Contains("Process(\"a\", 3)", text);
+        Assert.DoesNotContain("Process(3, \"a\")", text);
+    }
+
+    [SkippableFact]
+    public async Task ReorderParameters_NamedArgs_LeftInPlace()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public void Process(int count, string name, bool flag)
+                {
+                    System.Console.WriteLine(count + name + flag);
+                }
+
+                public void Run()
+                {
+                    Process(count: 3, name: "a", flag: false);
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ReorderParametersOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new ReorderParametersParams
+        {
+            SourceFile = workspace.SourcePath,
+            MethodName = "Process",
+            NewOrder = new[] { 2, 0, 1 }
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Contains("public void Process(bool flag, int count, string name)", text);
+        Assert.Contains("Process(count: 3, name: \"a\", flag: false)", text);
+    }
+
+    [SkippableFact]
+    public async Task ReorderParameters_MixedNamedAndPositional_ReordersPositionalLeavesNamed()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public void Process(int count, string name)
+                {
+                    System.Console.WriteLine(count + name);
+                }
+
+                public void Run()
+                {
+                    Process(3, name: "a");
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ReorderParametersOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new ReorderParametersParams
+        {
+            SourceFile = workspace.SourcePath,
+            MethodName = "Process",
+            NewOrder = new[] { 1, 0 }
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Contains("public void Process(string name, int count)", text);
+        Assert.Contains("Process(name: \"a\", 3)", text);
+    }
+
+    [SkippableFact]
+    public async Task ReorderParameters_OverrideAndInterface_UpdatesChain()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public interface IWorker
+            {
+                void Process(int count, string name);
+            }
+
+            public class Worker : IWorker
+            {
+                public virtual void Process(int count, string name)
+                {
+                }
+            }
+
+            public class Derived : Worker
+            {
+                public override void Process(int count, string name)
+                {
+                }
+            }
+
+            public static class Runner
+            {
+                public static void Run(IWorker worker, Derived derived)
+                {
+                    worker.Process(1, "a");
+                    derived.Process(2, "b");
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ReorderParametersOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new ReorderParametersParams
+        {
+            SourceFile = workspace.SourcePath,
+            MethodName = "Process",
+            NewOrder = new[] { 1, 0 },
+            Line = 10
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Contains("void Process(string name, int count);", text);
+        Assert.Contains("public virtual void Process(string name, int count)", text);
+        Assert.Contains("public override void Process(string name, int count)", text);
+        Assert.Contains("worker.Process(\"a\", 1)", text);
+        Assert.Contains("derived.Process(\"b\", 2)", text);
+    }
+
+    [SkippableFact]
+    public async Task ReorderParameters_ReducedExtensionCall_OffsetsThis()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public static class Exts
+            {
+                public static void Ext(this string value, int first, int second)
+                {
+                }
+            }
+
+            public class Worker
+            {
+                public void Run()
+                {
+                    var text = "hi";
+                    text.Ext(1, 2);
+                    Exts.Ext(text, 1, 2);
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ReorderParametersOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new ReorderParametersParams
+        {
+            SourceFile = workspace.SourcePath,
+            MethodName = "Ext",
+            NewOrder = new[] { 0, 2, 1 }
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Contains("public static void Ext(this string value, int second, int first)", text);
+        Assert.Contains("text.Ext(2, 1)", text);
+        Assert.Contains("Exts.Ext(text, 2, 1)", text);
+        Assert.DoesNotContain("text.Ext(1, 2)", text);
+        Assert.DoesNotContain("Exts.Ext(text, 1, 2)", text);
+    }
+
+    [SkippableFact]
+    public async Task ReorderParameters_EscapedNamedArg_UsesValueText()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public void Process(int count, int @class)
+                {
+                    System.Console.WriteLine(count + @class);
+                }
+
+                public void Run()
+                {
+                    Process(count: 3, @class: 1);
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ReorderParametersOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new ReorderParametersParams
+        {
+            SourceFile = workspace.SourcePath,
+            MethodName = "Process",
+            NewOrder = new[] { 1, 0 }
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Contains("public void Process(int @class, int count)", text);
+        Assert.Contains("Process(count: 3, @class: 1)", text);
+    }
+
+    [SkippableFact]
+    public async Task ReorderParameters_PreservesSurvivingSeparatorTrivia()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public void Process(int a, // explanation
+                    int b, int c)
+                {
+                    System.Console.WriteLine(a + b + c);
+                }
+
+                public void Run()
+                {
+                    Process(1, 2, 3);
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ReorderParametersOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new ReorderParametersParams
+        {
+            SourceFile = workspace.SourcePath,
+            MethodName = "Process",
+            NewOrder = new[] { 0, 1, 2 }
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Contains("explanation", text);
+        Assert.Contains("public void Process(int a, // explanation", text);
+        Assert.Contains("Process(1, 2, 3)", text);
+    }
+
+    [SkippableFact]
+    public async Task ReorderParameters_Preview_ReturnsChangesAndWritesNothing()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public void Process(int count, string name)
+                {
+                }
+
+                public void Run() => Process(3, "a");
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var original = await File.ReadAllTextAsync(workspace.SourcePath);
+        var operation = new ReorderParametersOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new ReorderParametersParams
+        {
+            SourceFile = workspace.SourcePath,
+            MethodName = "Process",
+            NewOrder = new[] { 1, 0 },
+            Preview = true
+        });
+
+        Assert.True(result.Success);
+        Assert.True(result.Preview);
+        Assert.NotNull(result.PendingChanges);
+        Assert.NotEmpty(result.PendingChanges);
+        Assert.Contains(result.PendingChanges, c =>
+            c.AfterSnippet != null &&
+            c.AfterSnippet.Contains("public void Process(string name, int count)") &&
+            c.AfterSnippet.Contains("Process(\"a\", 3)"));
+
+        var after = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Equal(original, after);
+    }
+
+    #endregion
+
+    #region Rejects
+
+    [SkippableFact]
+    public async Task ReorderParameters_InvalidPermutation_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public void Process(int count, string name)
+                {
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var original = await File.ReadAllTextAsync(workspace.SourcePath);
+        var operation = new ReorderParametersOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new ReorderParametersParams
+            {
+                SourceFile = workspace.SourcePath,
+                MethodName = "Process",
+                NewOrder = new[] { 0, 2 }
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidParameterPosition, ex.ErrorCode);
+        Assert.Equal("1011", ex.ErrorCode);
+        Assert.Equal(original, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [SkippableFact]
+    public async Task ReorderParameters_ParamsNotLast_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public void Process(int count, params int[] values)
+                {
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var original = await File.ReadAllTextAsync(workspace.SourcePath);
+        var operation = new ReorderParametersOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new ReorderParametersParams
+            {
+                SourceFile = workspace.SourcePath,
+                MethodName = "Process",
+                NewOrder = new[] { 1, 0 }
+            }));
+
+        Assert.Equal(ErrorCodes.ParamsNotLast, ex.ErrorCode);
+        Assert.Equal("3129", ex.ErrorCode);
+        Assert.Equal(original, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [SkippableFact]
+    public async Task ReorderParameters_OptionalBeforeRequired_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public void Process(int count, string name = "a")
+                {
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var original = await File.ReadAllTextAsync(workspace.SourcePath);
+        var operation = new ReorderParametersOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new ReorderParametersParams
+            {
+                SourceFile = workspace.SourcePath,
+                MethodName = "Process",
+                NewOrder = new[] { 1, 0 }
+            }));
+
+        Assert.Equal(ErrorCodes.RequiredAfterOptional, ex.ErrorCode);
+        Assert.Equal("3128", ex.ErrorCode);
+        Assert.Equal(original, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [SkippableFact]
+    public async Task ReorderParameters_MethodGroup_ThrowsAndWritesNothing()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public int Process(int count, string name) => 0;
+
+                public void Run()
+                {
+                    System.Func<int, string, int> handler = Process;
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var original = await File.ReadAllTextAsync(workspace.SourcePath);
+        var operation = new ReorderParametersOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new ReorderParametersParams
+            {
+                SourceFile = workspace.SourcePath,
+                MethodName = "Process",
+                NewOrder = new[] { 1, 0 }
+            }));
+
+        Assert.Equal(ErrorCodes.UnsupportedCallSite, ex.ErrorCode);
+        Assert.Equal("3130", ex.ErrorCode);
+        Assert.Equal(original, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [SkippableFact]
+    public async Task ReorderParameters_MissingMethod_Throws()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public void Process(int count, string name)
+                {
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ReorderParametersOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new ReorderParametersParams
+            {
+                SourceFile = workspace.SourcePath,
+                MethodName = "DoesNotExist",
+                NewOrder = new[] { 1, 0 }
+            }));
+
+        Assert.Equal(ErrorCodes.MethodNotFound, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void ReorderParameters_UneditableDocument_Throws()
+    {
+        var workspace = new AdhocWorkspace();
+        var project = workspace.AddProject("P", LanguageNames.CSharp);
+        var document = workspace.AddDocument(project.Id, "Generated.cs", SourceText.From("class C {}"));
+
+        var ex = Assert.Throws<RefactoringException>(() =>
+            ReorderParametersOperation.ValidateDocumentIsEditable(document, workspace));
+
+        Assert.Equal(ErrorCodes.DocumentNotEditable, ex.ErrorCode);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static ReorderParametersParams ValidParams(
+        string? sourceFile = null,
+        string methodName = "Process",
+        int[]? newOrder = null) => new()
+        {
+            SourceFile = sourceFile ?? Path.Combine(Path.GetTempPath(), "RoslynMcpReorderParametersMissing.cs"),
+            MethodName = methodName,
+            NewOrder = newOrder ?? new[] { 1, 0 }
+        };
+
+    private sealed class TempWorkspace : IAsyncDisposable
+    {
+        public required string DirectoryPath { get; init; }
+        public required string ProjectPath { get; init; }
+        public required string SourcePath { get; init; }
+        public required WorkspaceContext Context { get; init; }
+
+        public static async Task<TempWorkspace> CreateAsync(string source, string fileName = "Worker.cs")
+        {
+            Skip.IfNot(ModuleInitializer.MsBuildAvailable, ModuleInitializer.MsBuildError ?? "MSBuild not available");
+
+            var directory = Path.Combine(Path.GetTempPath(), "RoslynMcpReorderParameters_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(directory);
+
+            var projectPath = Path.Combine(directory, "TestApp.csproj");
+            await File.WriteAllTextAsync(projectPath, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net9.0</TargetFramework>
+                    <Nullable>enable</Nullable>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            var sourcePath = Path.Combine(directory, fileName);
+            await File.WriteAllTextAsync(sourcePath, source);
+
+            try
+            {
+                var provider = new MSBuildWorkspaceProvider();
+                var context = await provider.CreateContextAsync(projectPath);
+                if (context.GetDocumentByPath(sourcePath) == null)
+                {
+                    context.Dispose();
+                    throw new InvalidOperationException($"Workspace loaded but did not include {sourcePath}.");
+                }
+
+                return new TempWorkspace
+                {
+                    DirectoryPath = directory,
+                    ProjectPath = projectPath,
+                    SourcePath = sourcePath,
+                    Context = context
+                };
+            }
+            catch (Exception ex) when (ex is not SkipException)
+            {
+                try
+                {
+                    Directory.Delete(directory, recursive: true);
+                }
+                catch
+                {
+                    // ignore cleanup failures
+                }
+
+                Skip.If(true, $"Workspace load failed: {ex.Message}");
+                throw;
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            Context.Dispose();
+            await Task.Run(() =>
+            {
+                try
+                {
+                    Directory.Delete(DirectoryPath, recursive: true);
+                }
+                catch
+                {
+                    // ignore locked temp files
+                }
+            });
+        }
+    }
+
+    #endregion
+}

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Signature/ReorderParametersOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Signature/ReorderParametersOperationTests.cs
@@ -423,6 +423,91 @@ public class ReorderParametersOperationTests
         Assert.Equal(original, after);
     }
 
+    [SkippableFact]
+    public async Task ReorderParameters_OmittedOptional_ConvertsPositionalToNamed()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public class Worker
+            {
+                public void Process(int a = 1, int b = 2)
+                {
+                    System.Console.WriteLine(a + b);
+                }
+
+                public void Run()
+                {
+                    Process(3);
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ReorderParametersOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new ReorderParametersParams
+        {
+            SourceFile = workspace.SourcePath,
+            MethodName = "Process",
+            NewOrder = new[] { 1, 0 }
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Contains("public void Process(int b = 2, int a = 1)", text);
+        Assert.Contains("Process(a: 3)", text);
+        Assert.DoesNotContain("Process(3)", text);
+    }
+
+    [SkippableFact]
+    public async Task ReorderParameters_ImplNamedArgs_UseInvokedParameterNames()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public interface IWorker
+            {
+                void Process(int count, string name);
+            }
+
+            public class Worker : IWorker
+            {
+                public void Process(int value, string text)
+                {
+                    System.Console.WriteLine(value + text);
+                }
+            }
+
+            public static class Runner
+            {
+                public static void Run(Worker worker)
+                {
+                    worker.Process(1, text: "x");
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new ReorderParametersOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new ReorderParametersParams
+        {
+            SourceFile = workspace.SourcePath,
+            MethodName = "Process",
+            NewOrder = new[] { 1, 0 },
+            Line = 5
+        });
+
+        Assert.True(result.Success);
+
+        var text = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Contains("void Process(string name, int count);", text);
+        Assert.Contains("public void Process(string text, int value)", text);
+        Assert.Contains("worker.Process(text: \"x\", 1)", text);
+    }
+
     #endregion
 
     #region Rejects
@@ -551,6 +636,42 @@ public class ReorderParametersOperationTests
 
         Assert.Equal(ErrorCodes.UnsupportedCallSite, ex.ErrorCode);
         Assert.Equal("3130", ex.ErrorCode);
+        Assert.Equal(original, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [SkippableFact]
+    public async Task ReorderParameters_RelatedInterfaceOptional_ThrowsAndWritesNothing()
+    {
+        const string source = """
+            namespace TestApp;
+
+            public interface IWorker
+            {
+                void Process(int required, int optional = 0);
+            }
+
+            public class Worker : IWorker
+            {
+                public void Process(int required, int optional)
+                {
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var original = await File.ReadAllTextAsync(workspace.SourcePath);
+        var operation = new ReorderParametersOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new ReorderParametersParams
+            {
+                SourceFile = workspace.SourcePath,
+                MethodName = "Process",
+                NewOrder = new[] { 1, 0 },
+                Line = 10
+            }));
+
+        Assert.Equal(ErrorCodes.RequiredAfterOptional, ex.ErrorCode);
         Assert.Equal(original, await File.ReadAllTextAsync(workspace.SourcePath));
     }
 

--- a/tests/RoslynMcp.Server.Tests/Tools/ReorderParametersToolTests.cs
+++ b/tests/RoslynMcp.Server.Tests/Tools/ReorderParametersToolTests.cs
@@ -1,0 +1,140 @@
+using System.Text.Json;
+using RoslynMcp.Server.Tests.TestHelpers;
+using RoslynMcp.Server.Tools;
+using RoslynMcp.Server.Transport;
+using Xunit;
+
+namespace RoslynMcp.Server.Tests.Tools;
+
+/// <summary>
+/// Unit tests for ReorderParametersTool.
+/// Tests tool definition and argument validation.
+/// </summary>
+public class ReorderParametersToolTests
+{
+    private readonly ReorderParametersTool _tool;
+
+    public ReorderParametersToolTests()
+    {
+        // Fails loudly if workspace creation is attempted; argument validation is exercised via ExecuteAsync error paths.
+        _tool = new ReorderParametersTool(new ThrowingWorkspaceProvider());
+    }
+
+    #region GetDefinition Tests
+
+    [Fact]
+    public void GetDefinition_ReturnsCorrectName()
+    {
+        Assert.Equal("reorder_parameters", _tool.Name);
+    }
+
+    [Fact]
+    public void GetDefinition_ReturnsNonEmptyDescription()
+    {
+        Assert.NotNull(_tool.Description);
+        Assert.NotEmpty(_tool.Description);
+    }
+
+    [Fact]
+    public void GetDefinition_ReturnsCorrectSchema()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.Equal("object", root.GetProperty("type").GetString());
+        Assert.True(root.TryGetProperty("properties", out _));
+        Assert.True(root.TryGetProperty("required", out _));
+    }
+
+    [Fact]
+    public void GetDefinition_HasRequiredFields()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var required = doc.RootElement.GetProperty("required");
+
+        var requiredFields = new List<string>();
+        foreach (var item in required.EnumerateArray())
+        {
+            requiredFields.Add(item.GetString()!);
+        }
+
+        Assert.Contains("solutionPath", requiredFields);
+        Assert.Contains("sourceFile", requiredFields);
+        Assert.Contains("methodName", requiredFields);
+        Assert.Contains("newOrder", requiredFields);
+    }
+
+    [Fact]
+    public void GetDefinition_HasProperties_ForAllParameters()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var properties = doc.RootElement.GetProperty("properties");
+
+        Assert.True(properties.TryGetProperty("solutionPath", out _));
+        Assert.True(properties.TryGetProperty("sourceFile", out _));
+        Assert.True(properties.TryGetProperty("methodName", out _));
+        Assert.True(properties.TryGetProperty("newOrder", out var newOrder));
+        Assert.Equal("array", newOrder.GetProperty("type").GetString());
+        Assert.True(properties.TryGetProperty("line", out _));
+        Assert.True(properties.TryGetProperty("column", out _));
+        Assert.True(properties.TryGetProperty("updateOverrides", out _));
+        Assert.True(properties.TryGetProperty("updateImplementations", out _));
+        Assert.True(properties.TryGetProperty("preview", out _));
+    }
+
+    #endregion
+
+    #region ExecuteAsync Argument Validation Tests
+
+    [Fact]
+    public async Task ExecuteAsync_NullArguments_ReturnsError()
+    {
+        var result = await _tool.ExecuteAsync(null);
+
+        Assert.True(result.IsError);
+        Assert.Contains("Arguments required", GetResultText(result));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EmptyArguments_ReturnsError()
+    {
+        var args = JsonDocument.Parse("{}").RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MissingRequiredField_ReturnsError()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "solutionPath": "C:/test/test.sln",
+                "sourceFile": "C:/test/Test.cs",
+                "methodName": "DoWork"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static string GetResultText(ToolResult result)
+    {
+        return result.Content.FirstOrDefault()?.Text ?? string.Empty;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Implements leftover `reorder_parameters` / `ReorderParametersOperation` from Phase 2 signature operations (UC-S3). Reorders a method's parameters by a 0-based permutation and updates positional call-site arguments so semantics stay the same.

Mirrors shipped `AddParameterOperation` and `RemoveParameterOperation`:
- Rewrite only symbol-resolved declaration and invocation spans (no name/arity fallbacks)
- Offset reduced extension invocations (`this` is not argument 0)
- Match named arguments with identifier `ValueText`
- Preserve trivia on surviving separators
- Reject method-group / delegate references before writing files (`UnsupportedCallSite` 3130)
- Preview does not write files
- Override chain and interface implementations update when those flags are true
- `params` stays last; optional parameters cannot precede required ones
- Signature rules are checked on every related declaration, not just the selected method
- Positional arguments that would rebind after an omitted optional moves ahead become named
- Each call site uses the invoked method's parameter names (overrides/impls may differ)
- Reorders that would match another overload on the same containing type are rejected before writes (`SignatureMatchesOverload` 3132)

Invalid permutations reuse `InvalidParameterPosition` (1011). Params-not-last and required-after-optional reuse the unused signature codes already shipped (`3129`, `3128`). No 3060–3066 or 3080–3089 codes.

MCP and CLI registration increment tool/refactoring counts by 1 (56→57 tools, 43→44 CLI refactorings).

## Related Issues

Closes #64

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Test additions or updates
- [x] Documentation update

## Testing

- [x] Reorder operation tests 25/25 (includes overload-collision reject)
- [x] Reorder tool tests 8/8
- [x] `dotnet format --verify-no-changes` clean

**Test Configuration**:
- OS: Linux
- .NET Version: 9.0.317

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d817acb-dcd1-4c68-82ec-682bc8c48fd6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d817acb-dcd1-4c68-82ec-682bc8c48fd6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

