### PR TITLE
Add rename_namespace refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - `convert_anonymous_to_class` — convert an anonymous type (`new { ... }`) to a named class or record with matching public properties, replace same-shape anonymous creations in the solution, with preview mode and rejects for non-anonymous locations, invalid type names, name conflicts, missing files, and uneditable documents
 - `convert_tuple_to_struct` — convert a C# tuple / `ValueTuple` creation to a named struct with matching public members, replace same-shape tuple creations in the solution, with preview mode and rejects for non-tuple locations, invalid type names, name conflicts, missing files, uneditable documents, less-accessible member types, and method type-parameters
 - `rename_file_to_match_type` — rename a source file so its name matches the primary type declared in it (preserve directory), without renaming the type, constructors, or references, with preview mode and rejects for already-matching names, no type, multiple types without disambiguation, destination-exists, missing files, and uneditable documents
+- `rename_namespace` — rename a namespace across the solution, updating declarations, using directives, and qualified name references, with preview mode and rejects for same name, invalid namespace name, missing namespace, name conflicts, missing files, uneditable documents, and folder updates (not implemented)
 
 ## [0.4.0] - 2026-02-23
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Let AI assistants like Claude safely refactor your C# codebase using the same Roslyn compiler platform that powers Visual Studio.
 
-Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that exposes **61 Roslyn-powered tools** to AI assistants and other MCP clients. It combines 35 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 5 code generation tools, and 10 code conversion tools -- giving your AI deep code intelligence, comprehensive refactoring, and modern C# syntax transformations with full solution-wide reference tracking and preview support.
+Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that exposes **62 Roslyn-powered tools** to AI assistants and other MCP clients. It combines 36 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 5 code generation tools, and 10 code conversion tools -- giving your AI deep code intelligence, comprehensive refactoring, and modern C# syntax transformations with full solution-wide reference tracking and preview support.
 
 ---
 
@@ -30,7 +30,7 @@ Roslyn MCP Server is a [Model Context Protocol (MCP)](https://modelcontextprotoc
 
 ## Why RoslynMcpServer?
 
-- **61 tools** -- refactoring, navigation, analysis, generation, and conversion tools, the most comprehensive Roslyn MCP server available
+- **62 tools** -- refactoring, navigation, analysis, generation, and conversion tools, the most comprehensive Roslyn MCP server available
 - **Preview mode on every operation** -- see exactly what will change before applying
 - **Atomic file writes with rollback** -- if any file write fails, all changes are reverted
 - **Solution-wide reference updates** -- renames and moves propagate across your entire solution
@@ -102,7 +102,7 @@ Claude will use the `rename_symbol` tool to rename the class and update every re
 
 ## Standalone CLI
 
-All 61 tools are also available as a standalone CLI for use in scripts, CI/CD pipelines, and terminals without an AI assistant.
+All 62 tools are also available as a standalone CLI for use in scripts, CI/CD pipelines, and terminals without an AI assistant.
 
 ### Install
 
@@ -192,6 +192,7 @@ All tools accept a `solutionPath` parameter (absolute path to a `.sln`, `.slnx`,
 | `move_type_to_namespace` | Change the namespace of a C# type. Updates all using directives and qualified references. | `sourceFile`, `symbolName`, `targetNamespace`, `updateFileLocation` |
 | `rename_symbol` | Rename any C# symbol (type, method, property, field, variable, etc.) with automatic reference updates across the solution. | `sourceFile`, `symbolName`, `newName`, `line`, `column`, `renameOverloads`, `renameFile` |
 | `rename_file_to_match_type` | Rename a source file so its name matches the primary type declared in it, without renaming the type or its references. | `sourceFile`, `typeName`, `line`, `column` |
+| `rename_namespace` | Rename a C# namespace across the solution, updating declarations, using directives, and qualified name references. Does not move folders by default. | `sourceFile`, `namespaceName`, `newName`, `line`, `column`, `updateFolders` |
 
 ### Extract
 

--- a/src/RoslynMcp.Cli/ToolRegistry.cs
+++ b/src/RoslynMcp.Cli/ToolRegistry.cs
@@ -47,7 +47,7 @@ public sealed class ToolEntry
 }
 
 /// <summary>
-/// Maps tool names to execution delegates for all 61 Roslyn tools.
+/// Maps tool names to execution delegates for all 62 Roslyn tools.
 /// </summary>
 public sealed class ToolRegistry
 {
@@ -139,7 +139,7 @@ public sealed class ToolRegistry
         _tools.Values.OrderBy(t => t.Category).ThenBy(t => t.Name).ToList();
 
     /// <summary>
-    /// Build the default registry with all 61 tools registered.
+    /// Build the default registry with all 62 tools registered.
     /// </summary>
     public static ToolRegistry BuildDefault()
     {
@@ -173,11 +173,13 @@ public sealed class ToolRegistry
         r.RegisterRefactoring<MakeNonStaticOperation, MakeNonStaticParams>(
             "make-non-static", "Make a selected static method an instance method when a valid instance receiver exists");
 
-        // ── Refactoring: Rename (2) ───────────────────────────────────
+        // ── Refactoring: Rename (3) ───────────────────────────────────
         r.RegisterRefactoring<RenameSymbolOperation, RenameSymbolParams>(
             "rename-symbol", "Rename any C# symbol with automatic reference updates");
         r.RegisterRefactoring<RenameFileToMatchTypeOperation, RenameFileToMatchTypeParams>(
             "rename-file-to-match-type", "Rename a file so its name matches the primary type declared in it");
+        r.RegisterRefactoring<RenameNamespaceOperation, RenameNamespaceParams>(
+            "rename-namespace", "Rename a namespace across the solution, updating declarations and references");
 
         // ── Refactoring: Inline (3) ───────────────────────────────────
         r.RegisterRefactoring<InlineVariableOperation, InlineVariableParams>(

--- a/src/RoslynMcp.Contracts/Errors/ErrorCodes.cs
+++ b/src/RoslynMcp.Contracts/Errors/ErrorCodes.cs
@@ -445,7 +445,8 @@ public static class ErrorCodes
     /// <summary>Async methods and Task/ValueTask return types are out of leftover scope.</summary>
     public const string AsyncReturnTypeUnsupported = "3135";
 
-
+    /// <summary>Folder layout updates are not implemented for this operation.</summary>
+    public const string FolderUpdateNotSupported = "3136";
 
     // ============================================
     // System Errors (4xxx)

--- a/src/RoslynMcp.Contracts/Models/RenameNamespaceParams.cs
+++ b/src/RoslynMcp.Contracts/Models/RenameNamespaceParams.cs
@@ -1,0 +1,43 @@
+namespace RoslynMcp.Contracts.Models;
+
+/// <summary>
+/// Parameters for the rename_namespace tool.
+/// </summary>
+public sealed class RenameNamespaceParams
+{
+    /// <summary>
+    /// Absolute path to a source file that declares the namespace.
+    /// </summary>
+    public required string SourceFile { get; init; }
+
+    /// <summary>
+    /// Current namespace name (simple or fully qualified).
+    /// </summary>
+    public required string NamespaceName { get; init; }
+
+    /// <summary>
+    /// New namespace name (simple or fully qualified).
+    /// </summary>
+    public required string NewName { get; init; }
+
+    /// <summary>
+    /// 1-based line number used to select a namespace declaration when the file has more than one.
+    /// </summary>
+    public int? Line { get; init; }
+
+    /// <summary>
+    /// 1-based column number used with <see cref="Line"/> when multiple declarations share a line.
+    /// </summary>
+    public int? Column { get; init; }
+
+    /// <summary>
+    /// Also move folders to match the new namespace. Default: false.
+    /// Folder moves are not implemented; <c>true</c> is rejected.
+    /// </summary>
+    public bool UpdateFolders { get; init; }
+
+    /// <summary>
+    /// Return computed changes without applying. Default: false.
+    /// </summary>
+    public bool Preview { get; init; }
+}

--- a/src/RoslynMcp.Core/Refactoring/Rename/RenameNamespaceOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Rename/RenameNamespaceOperation.cs
@@ -214,7 +214,7 @@ public sealed class RenameNamespaceOperation : RefactoringOperationBase<RenameNa
 
             foreach (var candidate in EnumerateNamespaceChain(declared))
             {
-                if (NamespaceMatches(candidate, declaration, requested))
+                if (NamespaceMatches(candidate, declaration, requested, declared))
                     matches.Add((candidate, declaration));
             }
         }
@@ -274,7 +274,8 @@ public sealed class RenameNamespaceOperation : RefactoringOperationBase<RenameNa
     internal static bool NamespaceMatches(
         INamespaceSymbol symbol,
         BaseNamespaceDeclarationSyntax declaration,
-        string requested)
+        string requested,
+        INamespaceSymbol declaredSymbol)
     {
         if (symbol.IsGlobalNamespace)
             return false;
@@ -285,8 +286,8 @@ public sealed class RenameNamespaceOperation : RefactoringOperationBase<RenameNa
         if (string.Equals(symbol.Name, requested, StringComparison.Ordinal))
             return true;
 
-        var written = declaration.Name.ToString();
-        return string.Equals(written, requested, StringComparison.Ordinal);
+        return SymbolEqualityComparer.Default.Equals(symbol, declaredSymbol)
+               && string.Equals(declaration.Name.ToString(), requested, StringComparison.Ordinal);
     }
 
     /// <summary>
@@ -326,6 +327,69 @@ public sealed class RenameNamespaceOperation : RefactoringOperationBase<RenameNa
     internal static bool IsLastSegmentRename(string oldFullName, string newFullName) =>
         string.Equals(GetParentName(oldFullName), GetParentName(newFullName), StringComparison.Ordinal)
         && !string.Equals(GetLastSegment(oldFullName), GetLastSegment(newFullName), StringComparison.Ordinal);
+
+    /// <summary>
+    /// True when <paramref name="prefix"/> is a proper dotted prefix of <paramref name="fullName"/>.
+    /// </summary>
+    internal static bool IsPrefixOfNamespace(string prefix, string fullName) =>
+        !string.IsNullOrEmpty(prefix)
+        && fullName.StartsWith(prefix + ".", StringComparison.Ordinal);
+
+    /// <summary>
+    /// Declaration name to write inside <paramref name="enclosingFullName"/> so the
+    /// resulting fully qualified name is <paramref name="fullName"/>.
+    /// </summary>
+    internal static string GetRelativeNamespaceName(string fullName, string enclosingFullName)
+    {
+        if (string.IsNullOrEmpty(enclosingFullName))
+            return fullName;
+
+        if (IsPrefixOfNamespace(enclosingFullName, fullName))
+            return fullName[(enclosingFullName.Length + 1)..];
+
+        if (string.Equals(fullName, enclosingFullName, StringComparison.Ordinal))
+            return GetLastSegment(fullName);
+
+        return fullName;
+    }
+
+    /// <summary>
+    /// Maps an ancestor declaration of <paramref name="oldFullName"/> onto the
+    /// corresponding prefix of <paramref name="newFullName"/>.
+    /// </summary>
+    internal static string GetCorrespondingPrefix(string oldFullName, string newFullName, string declaredFullName)
+    {
+        if (string.Equals(declaredFullName, oldFullName, StringComparison.Ordinal)
+            || IsPrefixOfNamespace(oldFullName, declaredFullName))
+        {
+            return RewriteFullName(declaredFullName, oldFullName, newFullName);
+        }
+
+        if (!IsPrefixOfNamespace(declaredFullName, oldFullName))
+            return declaredFullName;
+
+        var declaredSegments = SplitNamespace(declaredFullName);
+        var newSegments = SplitNamespace(newFullName);
+        if (declaredSegments.Length >= newSegments.Length)
+            return newFullName;
+
+        return string.Join(".", newSegments.Take(declaredSegments.Length));
+    }
+
+    /// <summary>
+    /// Replaces <paramref name="oldFullName"/> (or that prefix) in <paramref name="current"/>
+    /// with <paramref name="newFullName"/>.
+    /// </summary>
+    internal static string RewriteFullName(string current, string oldFullName, string newFullName)
+    {
+        if (string.Equals(current, oldFullName, StringComparison.Ordinal))
+            return newFullName;
+
+        if (IsPrefixOfNamespace(oldFullName, current))
+            return newFullName + current[oldFullName.Length..];
+
+        return current;
+    }
 
     internal static bool SpanCoversLine(FileLinePositionSpan span, int line, int? column)
     {
@@ -376,20 +440,49 @@ public sealed class RenameNamespaceOperation : RefactoringOperationBase<RenameNa
                     suggestions: ["Choose a different new name"]);
             }
 
-            if (member is INamespaceSymbol existing && HasTypeNameCollision(source, existing))
+            if (member is INamespaceSymbol existing && HasNamespaceCollision(source, existing))
             {
                 throw new RefactoringException(
                     ErrorCodes.NameConflictScope,
-                    $"Namespace '{newFullName}' already contains a type that would collide with a type in '{GetFullName(source)}'.",
+                    $"Namespace '{newFullName}' already contains a type or namespace that would collide with '{GetFullName(source)}'.",
                     suggestions: ["Rename the conflicting type first", "Choose a different new name"]);
             }
         }
     }
 
-    private static bool HasTypeNameCollision(INamespaceSymbol source, INamespaceSymbol target)
+    /// <summary>
+    /// True when merging <paramref name="source"/> into <paramref name="target"/> would
+    /// create duplicate types or namespace/type name clashes, including descendants.
+    /// </summary>
+    internal static bool HasNamespaceCollision(INamespaceSymbol source, INamespaceSymbol target)
     {
-        var targetNames = target.GetTypeMembers().Select(t => t.Name).ToHashSet(StringComparer.Ordinal);
-        return source.GetTypeMembers().Any(t => targetNames.Contains(t.Name));
+        if (SymbolEqualityComparer.Default.Equals(source, target))
+            return false;
+
+        var targetTypeNames = target.GetTypeMembers().Select(t => t.Name).ToHashSet(StringComparer.Ordinal);
+        var targetNamespaceNames = target.GetNamespaceMembers().Select(n => n.Name).ToHashSet(StringComparer.Ordinal);
+
+        if (source.GetTypeMembers().Any(t =>
+                targetTypeNames.Contains(t.Name) || targetNamespaceNames.Contains(t.Name)))
+        {
+            return true;
+        }
+
+        if (target.GetTypeMembers().Any(t =>
+                source.GetNamespaceMembers().Any(n => string.Equals(n.Name, t.Name, StringComparison.Ordinal))))
+        {
+            return true;
+        }
+
+        foreach (var sourceChild in source.GetNamespaceMembers())
+        {
+            var targetChild = target.GetNamespaceMembers()
+                .FirstOrDefault(n => string.Equals(n.Name, sourceChild.Name, StringComparison.Ordinal));
+            if (targetChild != null && HasNamespaceCollision(sourceChild, targetChild))
+                return true;
+        }
+
+        return false;
     }
 
     private static INamespaceSymbol? FindNamespace(INamespaceSymbol current, string fullName)
@@ -433,6 +526,21 @@ public sealed class RenameNamespaceOperation : RefactoringOperationBase<RenameNa
         return await RewriteFullNamespaceAsync(namespaceSymbol, oldFullName, newFullName, cancellationToken);
     }
 
+    /// <summary>
+    /// Rewrites namespace declarations and references in <paramref name="root"/>.
+    /// Exposed for tests that must exercise the rewriter without MSBuild.
+    /// </summary>
+    internal static SyntaxNode RewriteNamespaceNames(
+        SemanticModel semanticModel,
+        SyntaxNode root,
+        INamespaceSymbol target,
+        string oldFullName,
+        string newFullName)
+    {
+        var rewriter = new NamespaceNameRewriter(semanticModel, target, oldFullName, newFullName);
+        return rewriter.Visit(root) ?? root;
+    }
+
     private async Task<Solution> RewriteFullNamespaceAsync(
         INamespaceSymbol namespaceSymbol,
         string oldFullName,
@@ -469,6 +577,15 @@ public sealed class RenameNamespaceOperation : RefactoringOperationBase<RenameNa
         CancellationToken cancellationToken)
     {
         var documentIds = new HashSet<DocumentId>();
+
+        foreach (var project in Context.Solution.Projects)
+        {
+            foreach (var document in project.Documents)
+            {
+                if (document.SupportsSyntaxTree)
+                    documentIds.Add(document.Id);
+            }
+        }
 
         foreach (var symbol in EnumerateSelfAndDescendants(namespaceSymbol))
         {
@@ -626,30 +743,22 @@ public sealed class RenameNamespaceOperation : RefactoringOperationBase<RenameNa
 
         public override SyntaxNode? VisitFileScopedNamespaceDeclaration(FileScopedNamespaceDeclarationSyntax node)
         {
-            var declared = _semanticModel.GetDeclaredSymbol(node);
-            if (IsTargetOrDescendant(declared))
-            {
-                var rewritten = RewriteFullName(GetFullName(declared!));
-                node = node.WithName(SyntaxFactory.ParseName(rewritten).WithTriviaFrom(node.Name));
-                return node.WithMembers(VisitList(node.Members));
-            }
-
-            return base.VisitFileScopedNamespaceDeclaration(node);
+            var writeName = TryGetDeclarationWriteName(node);
+            var members = VisitList(node.Members);
+            if (writeName != null)
+                node = node.WithName(SyntaxFactory.ParseName(writeName).WithTriviaFrom(node.Name));
+            return node.WithMembers(members);
         }
 
         public override SyntaxNode? VisitNamespaceDeclaration(NamespaceDeclarationSyntax node)
         {
-            var declared = _semanticModel.GetDeclaredSymbol(node);
-            if (IsTargetOrDescendant(declared))
-            {
-                var rewritten = RewriteFullName(GetFullName(declared!));
-                node = node.WithName(SyntaxFactory.ParseName(rewritten).WithTriviaFrom(node.Name));
-                return node.WithMembers(VisitList(node.Members))
-                    .WithUsings(VisitList(node.Usings))
-                    .WithExterns(VisitList(node.Externs));
-            }
-
-            return base.VisitNamespaceDeclaration(node);
+            var writeName = TryGetDeclarationWriteName(node);
+            var members = VisitList(node.Members);
+            var usings = VisitList(node.Usings);
+            var externs = VisitList(node.Externs);
+            if (writeName != null)
+                node = node.WithName(SyntaxFactory.ParseName(writeName).WithTriviaFrom(node.Name));
+            return node.WithMembers(members).WithUsings(usings).WithExterns(externs);
         }
 
         public override SyntaxNode? VisitUsingDirective(UsingDirectiveSyntax node)
@@ -660,25 +769,132 @@ public sealed class RenameNamespaceOperation : RefactoringOperationBase<RenameNa
             var symbol = _semanticModel.GetSymbolInfo(node.Name).Symbol as INamespaceSymbol;
             if (IsTargetOrDescendant(symbol))
             {
-                var rewritten = RewriteFullName(GetFullName(symbol!));
+                var rewritten = RewriteFullName(GetFullName(symbol!), _oldFullName, _newFullName);
                 return node.WithName(SyntaxFactory.ParseName(rewritten).WithTriviaFrom(node.Name));
             }
 
             return base.VisitUsingDirective(node);
         }
 
+        public override SyntaxNode? VisitQualifiedName(QualifiedNameSyntax node)
+        {
+            if (node.Parent is BaseNamespaceDeclarationSyntax or UsingDirectiveSyntax)
+                return node;
+
+            // Rewrite the containing qualified name. A dotted replacement must
+            // never be substituted into Right (a SimpleNameSyntax slot).
+            if (TryRewriteReferencedName(node) is { } rewritten)
+                return rewritten;
+
+            return base.VisitQualifiedName(node);
+        }
+
+        public override SyntaxNode? VisitMemberAccessExpression(MemberAccessExpressionSyntax node)
+        {
+            if (TryRewriteReferencedName(node) is { } rewritten)
+                return rewritten;
+
+            return base.VisitMemberAccessExpression(node);
+        }
+
         public override SyntaxNode? VisitIdentifierName(IdentifierNameSyntax node)
         {
-            if (node.Parent is BaseNamespaceDeclarationSyntax ns && ns.Name == node)
+            if (node.Parent is QualifiedNameSyntax or MemberAccessExpressionSyntax)
                 return node;
-            if (node.Parent is UsingDirectiveSyntax usingDirective && usingDirective.Name == node)
+            if (node.Parent is BaseNamespaceDeclarationSyntax or UsingDirectiveSyntax)
                 return node;
 
-            var symbol = _semanticModel.GetSymbolInfo(node).Symbol;
+            var symbol = GetReferencedSymbol(node);
             if (symbol is INamespaceSymbol nsSymbol && SymbolEqualityComparer.Default.Equals(nsSymbol, _target))
-                return SyntaxFactory.ParseName(_newFullName).WithTriviaFrom(node);
+            {
+                var replacement = SyntaxFactory.ParseName(_newFullName);
+                // IdentifierName is a SimpleName slot: only a single identifier fits.
+                if (replacement is SimpleNameSyntax simple)
+                    return simple.WithTriviaFrom(node);
+                return node;
+            }
 
             return base.VisitIdentifierName(node);
+        }
+
+        /// <summary>
+        /// Replaces the namespace prefix of a qualified type or namespace name.
+        /// Uses the bound symbol's containing namespace because intermediate
+        /// name nodes often have no <see cref="INamespaceSymbol"/> of their own.
+        /// </summary>
+        private NameSyntax? TryRewriteReferencedName(ExpressionSyntax node)
+        {
+            var symbol = GetReferencedSymbol(node);
+            var ns = symbol as INamespaceSymbol ?? symbol?.ContainingNamespace;
+            if (!IsTargetOrDescendant(ns))
+                return null;
+
+            var written = GetDottedNameText(node);
+            var rewritten = RewriteFullName(written, _oldFullName, _newFullName);
+            if (string.Equals(rewritten, written, StringComparison.Ordinal))
+            {
+                if (symbol is not INamespaceSymbol onlyNs)
+                    return null;
+
+                rewritten = RewriteFullName(GetFullName(onlyNs), _oldFullName, _newFullName);
+                if (string.Equals(rewritten, GetFullName(onlyNs), StringComparison.Ordinal))
+                    return null;
+            }
+
+            return SyntaxFactory.ParseName(rewritten).WithTriviaFrom(node);
+        }
+
+        private ISymbol? GetReferencedSymbol(SyntaxNode node)
+        {
+            var info = _semanticModel.GetSymbolInfo(node);
+            if (info.Symbol != null)
+                return info.Symbol;
+            if (info.CandidateSymbols.Length > 0)
+                return info.CandidateSymbols[0];
+
+            var type = _semanticModel.GetTypeInfo(node).Type;
+            if (type is { SpecialType: not SpecialType.System_Void } and not IErrorTypeSymbol)
+                return type;
+
+            return _semanticModel.GetDeclaredSymbol(node);
+        }
+
+        private static string GetDottedNameText(ExpressionSyntax node) =>
+            string.Join(".", node.ToString().Split('.', StringSplitOptions.TrimEntries));
+
+        private string? TryGetDeclarationWriteName(BaseNamespaceDeclarationSyntax node)
+        {
+            if (_semanticModel.GetDeclaredSymbol(node) is not INamespaceSymbol declared)
+                return null;
+
+            var declaredFull = GetFullName(declared);
+            string newFull;
+            if (IsTargetOrDescendant(declared))
+                newFull = RewriteFullName(declaredFull, _oldFullName, _newFullName);
+            else if (IsPrefixOfNamespace(declaredFull, _oldFullName))
+                newFull = GetCorrespondingPrefix(_oldFullName, _newFullName, declaredFull);
+            else
+                return null;
+
+            var enclosing = node.Parent as BaseNamespaceDeclarationSyntax;
+            var enclosingNew = GetEnclosingNewFullName(enclosing);
+            return GetRelativeNamespaceName(newFull, enclosingNew);
+        }
+
+        private string GetEnclosingNewFullName(BaseNamespaceDeclarationSyntax? enclosing)
+        {
+            if (enclosing == null)
+                return string.Empty;
+
+            if (_semanticModel.GetDeclaredSymbol(enclosing) is not INamespaceSymbol declared)
+                return string.Empty;
+
+            var declaredFull = GetFullName(declared);
+            if (IsTargetOrDescendant(declared))
+                return RewriteFullName(declaredFull, _oldFullName, _newFullName);
+            if (IsPrefixOfNamespace(declaredFull, _oldFullName))
+                return GetCorrespondingPrefix(_oldFullName, _newFullName, declaredFull);
+            return declaredFull;
         }
 
         private bool IsTargetOrDescendant(INamespaceSymbol? symbol)
@@ -693,17 +909,6 @@ public sealed class RenameNamespaceOperation : RefactoringOperationBase<RenameNa
             }
 
             return false;
-        }
-
-        private string RewriteFullName(string current)
-        {
-            if (string.Equals(current, _oldFullName, StringComparison.Ordinal))
-                return _newFullName;
-
-            if (current.StartsWith(_oldFullName + ".", StringComparison.Ordinal))
-                return _newFullName + current[_oldFullName.Length..];
-
-            return current;
         }
     }
 }

--- a/src/RoslynMcp.Core/Refactoring/Rename/RenameNamespaceOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Rename/RenameNamespaceOperation.cs
@@ -548,6 +548,9 @@ public sealed class RenameNamespaceOperation : RefactoringOperationBase<RenameNa
         CancellationToken cancellationToken)
     {
         var documentIds = await CollectDocumentsToRewriteAsync(namespaceSymbol, cancellationToken);
+        // Bind every document against the original compilation. Updating the
+        // solution incrementally would produce a new compilation whose
+        // INamespaceSymbols no longer equal the resolved source symbol.
         var originalSolution = Context.Solution;
         var updates = new List<(DocumentId Id, SyntaxNode Root)>();
 

--- a/src/RoslynMcp.Core/Refactoring/Rename/RenameNamespaceOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Rename/RenameNamespaceOperation.cs
@@ -209,8 +209,7 @@ public sealed class RenameNamespaceOperation : RefactoringOperationBase<RenameNa
 
         foreach (var declaration in declarations)
         {
-            var declared = semanticModel.GetDeclaredSymbol(declaration, cancellationToken);
-            if (declared == null)
+            if (semanticModel.GetDeclaredSymbol(declaration, cancellationToken) is not INamespaceSymbol declared)
                 continue;
 
             foreach (var candidate in EnumerateNamespaceChain(declared))
@@ -400,9 +399,10 @@ public sealed class RenameNamespaceOperation : RefactoringOperationBase<RenameNa
 
         foreach (var segment in SplitNamespace(fullName))
         {
-            current = current.GetNamespaceMembers().FirstOrDefault(n => n.Name == segment);
-            if (current == null)
+            var next = current.GetNamespaceMembers().FirstOrDefault(n => n.Name == segment);
+            if (next == null)
                 return null;
+            current = next;
         }
 
         return current;

--- a/src/RoslynMcp.Core/Refactoring/Rename/RenameNamespaceOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Rename/RenameNamespaceOperation.cs
@@ -1,0 +1,709 @@
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Rename;
+using RoslynMcp.Contracts.Enums;
+using RoslynMcp.Contracts.Errors;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.FileSystem;
+using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Workspace;
+
+namespace RoslynMcp.Core.Refactoring.Rename;
+
+/// <summary>
+/// Renames a namespace across the solution, updating declarations,
+/// using directives, and qualified name references.
+/// </summary>
+public sealed class RenameNamespaceOperation : RefactoringOperationBase<RenameNamespaceParams>
+{
+    private static readonly Regex NamespacePattern = new(
+        @"^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// Creates a new rename-namespace operation.
+    /// </summary>
+    public RenameNamespaceOperation(WorkspaceContext context) : base(context)
+    {
+    }
+
+    /// <inheritdoc />
+    protected override void ValidateParams(RenameNamespaceParams @params) => Validate(@params);
+
+    /// <summary>
+    /// Validates rename-namespace inputs. Internal so tests can exercise
+    /// rules without loading a workspace.
+    /// </summary>
+    internal static void Validate(RenameNamespaceParams @params)
+    {
+        if (string.IsNullOrWhiteSpace(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "sourceFile is required.");
+
+        if (string.IsNullOrWhiteSpace(@params.NamespaceName))
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "namespaceName is required.");
+
+        if (string.IsNullOrWhiteSpace(@params.NewName))
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "newName is required.");
+
+        if (!PathResolver.IsAbsolutePath(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.InvalidSourcePath, "sourceFile must be an absolute path.");
+
+        if (!PathResolver.IsValidCSharpFilePath(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.InvalidSourcePath, "sourceFile must be a .cs file.");
+
+        if (!File.Exists(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.SourceFileNotFound, $"Source file not found: {@params.SourceFile}");
+
+        if (@params.Line.HasValue && @params.Line.Value < 1)
+            throw new RefactoringException(ErrorCodes.InvalidLineNumber, "line must be >= 1.");
+
+        if (@params.Column.HasValue && @params.Column.Value < 1)
+            throw new RefactoringException(ErrorCodes.InvalidColumnNumber, "column must be >= 1.");
+
+        if (!IsValidNamespaceName(@params.NamespaceName))
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidNamespace,
+                $"'{@params.NamespaceName}' is not a valid namespace name.");
+        }
+
+        if (!IsValidNamespaceName(@params.NewName))
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidNamespace,
+                $"'{@params.NewName}' is not a valid namespace name.");
+        }
+
+        foreach (var segment in SplitNamespace(@params.NewName))
+        {
+            if (SyntaxFacts.GetKeywordKind(segment) != SyntaxKind.None)
+            {
+                throw new RefactoringException(
+                    ErrorCodes.ReservedKeyword,
+                    $"'{segment}' is a C# reserved keyword.");
+            }
+        }
+
+        if (string.Equals(@params.NamespaceName.Trim(), @params.NewName.Trim(), StringComparison.Ordinal))
+        {
+            throw new RefactoringException(
+                ErrorCodes.SameLocation,
+                "New name is the same as current name.");
+        }
+
+        if (@params.UpdateFolders)
+        {
+            throw new RefactoringException(
+                ErrorCodes.FolderUpdateNotSupported,
+                "updateFolders is not implemented. Leave updateFolders false to rename the namespace without moving folders.");
+        }
+    }
+
+    /// <summary>
+    /// True when <paramref name="name"/> is a dotted sequence of C# identifiers.
+    /// </summary>
+    internal static bool IsValidNamespaceName(string name) =>
+        !string.IsNullOrWhiteSpace(name) && NamespacePattern.IsMatch(name.Trim());
+
+    /// <summary>
+    /// Rejects documents that cannot receive source edits.
+    /// </summary>
+    internal static void ValidateDocumentIsEditable(Document document, Microsoft.CodeAnalysis.Workspace workspace)
+    {
+        if (document is SourceGeneratedDocument)
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable (source-generated).");
+        }
+
+        if (string.IsNullOrWhiteSpace(document.FilePath) || !File.Exists(document.FilePath))
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable.");
+        }
+
+        if (!workspace.CanApplyChange(ApplyChangesKind.ChangeDocument))
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Document '{document.Name}' is not editable (workspace cannot apply changes).");
+        }
+    }
+
+    /// <inheritdoc />
+    protected override async Task<RefactoringResult> ExecuteCoreAsync(
+        Guid operationId,
+        RenameNamespaceParams @params,
+        CancellationToken cancellationToken)
+    {
+        var document = GetDocumentOrThrow(@params.SourceFile);
+        ValidateDocumentIsEditable(document, Context.Workspace);
+
+        var namespaceSymbol = await FindNamespaceAsync(document, @params, cancellationToken);
+        var oldFullName = GetFullName(namespaceSymbol);
+        var newFullName = @params.NewName.Trim();
+
+        if (string.Equals(oldFullName, newFullName, StringComparison.Ordinal))
+        {
+            throw new RefactoringException(
+                ErrorCodes.SameLocation,
+                "New name is the same as current name.");
+        }
+
+        var compilation = await document.Project.GetCompilationAsync(cancellationToken)
+            ?? throw new RefactoringException(ErrorCodes.RoslynError, "Could not get compilation.");
+
+        ValidateNoNameConflict(namespaceSymbol, newFullName, compilation);
+
+        var references = await ReferenceTracker.FindAllReferencesAsync(namespaceSymbol, cancellationToken);
+        var newSolution = await ComputeRenamedSolutionAsync(
+            namespaceSymbol,
+            oldFullName,
+            newFullName,
+            cancellationToken);
+
+        ValidateChangedDocumentsAreEditable(Context.Solution, newSolution);
+
+        if (@params.Preview)
+        {
+            return CreatePreviewResult(operationId, Context.Solution, newSolution, oldFullName, newFullName);
+        }
+
+        var commitResult = await CommitChangesAsync(newSolution, cancellationToken);
+
+        return RefactoringResult.Succeeded(
+            operationId,
+            new FileChanges
+            {
+                FilesModified = commitResult.FilesModified,
+                FilesCreated = commitResult.FilesCreated,
+                FilesDeleted = commitResult.FilesDeleted
+            },
+            CreateSymbolInfo(namespaceSymbol, oldFullName, newFullName, document.FilePath),
+            references.TotalReferenceCount,
+            0);
+    }
+
+    /// <summary>
+    /// Resolves the namespace declared in <paramref name="document"/> that matches
+    /// <see cref="RenameNamespaceParams.NamespaceName"/>.
+    /// </summary>
+    internal static async Task<INamespaceSymbol> FindNamespaceAsync(
+        Document document,
+        RenameNamespaceParams @params,
+        CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken);
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken);
+        if (root == null || semanticModel == null)
+            throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse file.");
+
+        var requested = @params.NamespaceName.Trim();
+        var declarations = root.DescendantNodes().OfType<BaseNamespaceDeclarationSyntax>().ToList();
+        var matches = new List<(INamespaceSymbol Symbol, BaseNamespaceDeclarationSyntax Declaration)>();
+
+        foreach (var declaration in declarations)
+        {
+            var declared = semanticModel.GetDeclaredSymbol(declaration, cancellationToken);
+            if (declared == null)
+                continue;
+
+            foreach (var candidate in EnumerateNamespaceChain(declared))
+            {
+                if (NamespaceMatches(candidate, declaration, requested))
+                    matches.Add((candidate, declaration));
+            }
+        }
+
+        matches = matches
+            .DistinctBy(m => (GetFullName(m.Symbol), m.Declaration.SpanStart))
+            .ToList();
+
+        if (@params.Line.HasValue)
+        {
+            var atLocation = matches
+                .Where(m => SpanCoversLine(m.Declaration.GetLocation().GetLineSpan(), @params.Line.Value, @params.Column))
+                .ToList();
+
+            if (atLocation.Count == 1)
+                return atLocation[0].Symbol;
+
+            if (atLocation.Count == 0)
+            {
+                throw new RefactoringException(
+                    ErrorCodes.SymbolNotFound,
+                    $"No namespace named '{requested}' found at line {@params.Line}.");
+            }
+
+            var distinct = atLocation.Select(m => GetFullName(m.Symbol)).Distinct(StringComparer.Ordinal).ToList();
+            if (distinct.Count == 1)
+                return atLocation[0].Symbol;
+
+            throw new RefactoringException(
+                ErrorCodes.SymbolAmbiguous,
+                $"Multiple namespaces named '{requested}' found at line {@params.Line}. Provide column.");
+        }
+
+        if (matches.Count == 0)
+        {
+            throw new RefactoringException(
+                ErrorCodes.SymbolNotFound,
+                $"No namespace named '{requested}' found in file.");
+        }
+
+        var unique = matches.Select(m => m.Symbol).DistinctBy(GetFullName).ToList();
+        if (unique.Count == 1)
+            return unique[0];
+
+        throw new RefactoringException(
+            ErrorCodes.SymbolAmbiguous,
+            $"Multiple namespaces named '{requested}' found. Provide line number to disambiguate.",
+            new Dictionary<string, object>
+            {
+                ["candidateCount"] = unique.Count
+            });
+    }
+
+    /// <summary>
+    /// True when the declared or containing namespace matches <paramref name="requested"/>.
+    /// </summary>
+    internal static bool NamespaceMatches(
+        INamespaceSymbol symbol,
+        BaseNamespaceDeclarationSyntax declaration,
+        string requested)
+    {
+        if (symbol.IsGlobalNamespace)
+            return false;
+
+        if (string.Equals(GetFullName(symbol), requested, StringComparison.Ordinal))
+            return true;
+
+        if (string.Equals(symbol.Name, requested, StringComparison.Ordinal))
+            return true;
+
+        var written = declaration.Name.ToString();
+        return string.Equals(written, requested, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Display name of a namespace, empty for the global namespace.
+    /// </summary>
+    internal static string GetFullName(INamespaceSymbol symbol) =>
+        symbol.IsGlobalNamespace ? string.Empty : symbol.ToDisplayString();
+
+    /// <summary>
+    /// Splits a dotted namespace into identifier segments.
+    /// </summary>
+    internal static string[] SplitNamespace(string name) =>
+        name.Trim().Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+    /// <summary>
+    /// Parent path of a dotted namespace, or empty when it is a single segment.
+    /// </summary>
+    internal static string GetParentName(string fullName)
+    {
+        var lastDot = fullName.LastIndexOf('.');
+        return lastDot < 0 ? string.Empty : fullName[..lastDot];
+    }
+
+    /// <summary>
+    /// Last identifier of a dotted namespace.
+    /// </summary>
+    internal static string GetLastSegment(string fullName)
+    {
+        var lastDot = fullName.LastIndexOf('.');
+        return lastDot < 0 ? fullName : fullName[(lastDot + 1)..];
+    }
+
+    /// <summary>
+    /// True when <paramref name="oldFullName"/> and <paramref name="newFullName"/> share
+    /// a parent path so only the last identifier needs to change.
+    /// </summary>
+    internal static bool IsLastSegmentRename(string oldFullName, string newFullName) =>
+        string.Equals(GetParentName(oldFullName), GetParentName(newFullName), StringComparison.Ordinal)
+        && !string.Equals(GetLastSegment(oldFullName), GetLastSegment(newFullName), StringComparison.Ordinal);
+
+    internal static bool SpanCoversLine(FileLinePositionSpan span, int line, int? column)
+    {
+        var startLine = span.StartLinePosition.Line + 1;
+        var endLine = span.EndLinePosition.Line + 1;
+        if (line < startLine || line > endLine)
+            return false;
+
+        if (!column.HasValue)
+            return true;
+
+        var startCol = span.StartLinePosition.Character + 1;
+        var endCol = span.EndLinePosition.Character + 1;
+        if (line == startLine && column.Value < startCol)
+            return false;
+        if (line == endLine && column.Value > endCol)
+            return false;
+        return true;
+    }
+
+    private static IEnumerable<INamespaceSymbol> EnumerateNamespaceChain(INamespaceSymbol symbol)
+    {
+        for (var current = symbol; current is { IsGlobalNamespace: false }; current = current.ContainingNamespace)
+            yield return current;
+    }
+
+    private static void ValidateNoNameConflict(
+        INamespaceSymbol source,
+        string newFullName,
+        Compilation compilation)
+    {
+        var targetParentName = GetParentName(newFullName);
+        var targetLast = GetLastSegment(newFullName);
+        var targetParent = FindNamespace(compilation.GlobalNamespace, targetParentName);
+        if (targetParent == null)
+            return;
+
+        foreach (var member in targetParent.GetMembers(targetLast))
+        {
+            if (SymbolEqualityComparer.Default.Equals(member, source))
+                continue;
+
+            if (member is INamedTypeSymbol type)
+            {
+                throw new RefactoringException(
+                    ErrorCodes.NameConflictScope,
+                    $"New namespace name '{newFullName}' conflicts with type '{type.ToDisplayString()}'.",
+                    suggestions: ["Choose a different new name"]);
+            }
+
+            if (member is INamespaceSymbol existing && HasTypeNameCollision(source, existing))
+            {
+                throw new RefactoringException(
+                    ErrorCodes.NameConflictScope,
+                    $"Namespace '{newFullName}' already contains a type that would collide with a type in '{GetFullName(source)}'.",
+                    suggestions: ["Rename the conflicting type first", "Choose a different new name"]);
+            }
+        }
+    }
+
+    private static bool HasTypeNameCollision(INamespaceSymbol source, INamespaceSymbol target)
+    {
+        var targetNames = target.GetTypeMembers().Select(t => t.Name).ToHashSet(StringComparer.Ordinal);
+        return source.GetTypeMembers().Any(t => targetNames.Contains(t.Name));
+    }
+
+    private static INamespaceSymbol? FindNamespace(INamespaceSymbol current, string fullName)
+    {
+        if (string.IsNullOrEmpty(fullName))
+            return current;
+
+        foreach (var segment in SplitNamespace(fullName))
+        {
+            current = current.GetNamespaceMembers().FirstOrDefault(n => n.Name == segment);
+            if (current == null)
+                return null;
+        }
+
+        return current;
+    }
+
+    private async Task<Solution> ComputeRenamedSolutionAsync(
+        INamespaceSymbol namespaceSymbol,
+        string oldFullName,
+        string newFullName,
+        CancellationToken cancellationToken)
+    {
+        if (IsLastSegmentRename(oldFullName, newFullName))
+        {
+            var options = new SymbolRenameOptions(
+                RenameOverloads: false,
+                RenameInStrings: false,
+                RenameInComments: false,
+                RenameFile: false);
+
+            return await Renamer.RenameSymbolAsync(
+                Context.Solution,
+                namespaceSymbol,
+                options,
+                GetLastSegment(newFullName),
+                cancellationToken);
+        }
+
+        return await RewriteFullNamespaceAsync(namespaceSymbol, oldFullName, newFullName, cancellationToken);
+    }
+
+    private async Task<Solution> RewriteFullNamespaceAsync(
+        INamespaceSymbol namespaceSymbol,
+        string oldFullName,
+        string newFullName,
+        CancellationToken cancellationToken)
+    {
+        var documentIds = await CollectDocumentsToRewriteAsync(namespaceSymbol, cancellationToken);
+        var solution = Context.Solution;
+
+        foreach (var documentId in documentIds)
+        {
+            var document = solution.GetDocument(documentId);
+            if (document == null)
+                continue;
+
+            ValidateDocumentIsEditable(document, Context.Workspace);
+
+            var root = await document.GetSyntaxRootAsync(cancellationToken);
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken);
+            if (root == null || semanticModel == null)
+                continue;
+
+            var rewriter = new NamespaceNameRewriter(semanticModel, namespaceSymbol, oldFullName, newFullName);
+            var newRoot = rewriter.Visit(root);
+            if (newRoot != null && newRoot != root)
+                solution = solution.WithDocumentSyntaxRoot(documentId, newRoot);
+        }
+
+        return solution;
+    }
+
+    private async Task<HashSet<DocumentId>> CollectDocumentsToRewriteAsync(
+        INamespaceSymbol namespaceSymbol,
+        CancellationToken cancellationToken)
+    {
+        var documentIds = new HashSet<DocumentId>();
+
+        foreach (var symbol in EnumerateSelfAndDescendants(namespaceSymbol))
+        {
+            foreach (var syntaxRef in symbol.DeclaringSyntaxReferences)
+            {
+                var document = Context.Solution.GetDocument(syntaxRef.SyntaxTree);
+                if (document != null)
+                    documentIds.Add(document.Id);
+            }
+        }
+
+        var references = await SymbolFinder.FindReferencesAsync(
+            namespaceSymbol,
+            Context.Solution,
+            cancellationToken);
+
+        foreach (var referenced in references)
+        {
+            foreach (var location in referenced.Locations)
+            {
+                if (location.Document != null)
+                    documentIds.Add(location.Document.Id);
+            }
+        }
+
+        return documentIds;
+    }
+
+    private static IEnumerable<INamespaceSymbol> EnumerateSelfAndDescendants(INamespaceSymbol symbol)
+    {
+        yield return symbol;
+        foreach (var child in symbol.GetNamespaceMembers())
+        {
+            foreach (var descendant in EnumerateSelfAndDescendants(child))
+                yield return descendant;
+        }
+    }
+
+    private void ValidateChangedDocumentsAreEditable(Solution oldSolution, Solution newSolution)
+    {
+        foreach (var projectChange in newSolution.GetChanges(oldSolution).GetProjectChanges())
+        {
+            foreach (var documentId in projectChange.GetChangedDocuments())
+            {
+                var document = oldSolution.GetDocument(documentId);
+                if (document != null)
+                    ValidateDocumentIsEditable(document, Context.Workspace);
+            }
+        }
+    }
+
+    private static RefactoringResult CreatePreviewResult(
+        Guid operationId,
+        Solution oldSolution,
+        Solution newSolution,
+        string oldFullName,
+        string newFullName)
+    {
+        var pending = new List<PendingChange>();
+        foreach (var projectChange in newSolution.GetChanges(oldSolution).GetProjectChanges())
+        {
+            foreach (var documentId in projectChange.GetChangedDocuments())
+            {
+                var document = oldSolution.GetDocument(documentId);
+                pending.Add(new PendingChange
+                {
+                    File = document?.FilePath ?? document?.Name ?? "(unknown)",
+                    ChangeType = ChangeKind.Modify,
+                    Description = $"Rename namespace '{oldFullName}' to '{newFullName}'"
+                });
+            }
+        }
+
+        if (pending.Count == 0)
+        {
+            pending.Add(new PendingChange
+            {
+                File = "(solution)",
+                ChangeType = ChangeKind.Modify,
+                Description = $"Rename namespace '{oldFullName}' to '{newFullName}'"
+            });
+        }
+
+        return RefactoringResult.PreviewResult(operationId, pending);
+    }
+
+    private static Contracts.Models.SymbolInfo CreateSymbolInfo(
+        INamespaceSymbol symbol,
+        string oldFullName,
+        string newFullName,
+        string? sourceFile)
+    {
+        var location = symbol.Locations.FirstOrDefault(l => l.IsInSource);
+        FileLinePositionSpan? lineSpan = null;
+        if (location is { IsInSource: true })
+        {
+            try
+            {
+                lineSpan = location.GetLineSpan();
+            }
+            catch (InvalidOperationException)
+            {
+                // Location can be invalid after some workspace states.
+            }
+        }
+
+        SymbolLocation? previous = null;
+        SymbolLocation? next = null;
+        if (sourceFile != null && lineSpan.HasValue)
+        {
+            previous = new SymbolLocation
+            {
+                File = sourceFile,
+                Line = lineSpan.Value.StartLinePosition.Line + 1,
+                Column = lineSpan.Value.StartLinePosition.Character + 1
+            };
+            next = new SymbolLocation
+            {
+                File = sourceFile,
+                Line = previous.Line,
+                Column = previous.Column
+            };
+        }
+
+        return new Contracts.Models.SymbolInfo
+        {
+            Name = GetLastSegment(newFullName),
+            FullyQualifiedName = newFullName,
+            Kind = Contracts.Enums.SymbolKind.Namespace,
+            PreviousLocation = previous,
+            NewLocation = next,
+            PreviousNamespace = oldFullName,
+            NewNamespace = newFullName
+        };
+    }
+
+    private sealed class NamespaceNameRewriter : CSharpSyntaxRewriter
+    {
+        private readonly SemanticModel _semanticModel;
+        private readonly INamespaceSymbol _target;
+        private readonly string _oldFullName;
+        private readonly string _newFullName;
+
+        public NamespaceNameRewriter(
+            SemanticModel semanticModel,
+            INamespaceSymbol target,
+            string oldFullName,
+            string newFullName)
+        {
+            _semanticModel = semanticModel;
+            _target = target;
+            _oldFullName = oldFullName;
+            _newFullName = newFullName;
+        }
+
+        public override SyntaxNode? VisitFileScopedNamespaceDeclaration(FileScopedNamespaceDeclarationSyntax node)
+        {
+            var declared = _semanticModel.GetDeclaredSymbol(node);
+            if (IsTargetOrDescendant(declared))
+            {
+                var rewritten = RewriteFullName(GetFullName(declared!));
+                node = node.WithName(SyntaxFactory.ParseName(rewritten).WithTriviaFrom(node.Name));
+                return node.WithMembers(VisitList(node.Members));
+            }
+
+            return base.VisitFileScopedNamespaceDeclaration(node);
+        }
+
+        public override SyntaxNode? VisitNamespaceDeclaration(NamespaceDeclarationSyntax node)
+        {
+            var declared = _semanticModel.GetDeclaredSymbol(node);
+            if (IsTargetOrDescendant(declared))
+            {
+                var rewritten = RewriteFullName(GetFullName(declared!));
+                node = node.WithName(SyntaxFactory.ParseName(rewritten).WithTriviaFrom(node.Name));
+                return node.WithMembers(VisitList(node.Members))
+                    .WithUsings(VisitList(node.Usings))
+                    .WithExterns(VisitList(node.Externs));
+            }
+
+            return base.VisitNamespaceDeclaration(node);
+        }
+
+        public override SyntaxNode? VisitUsingDirective(UsingDirectiveSyntax node)
+        {
+            if (node.Name == null)
+                return base.VisitUsingDirective(node);
+
+            var symbol = _semanticModel.GetSymbolInfo(node.Name).Symbol as INamespaceSymbol;
+            if (IsTargetOrDescendant(symbol))
+            {
+                var rewritten = RewriteFullName(GetFullName(symbol!));
+                return node.WithName(SyntaxFactory.ParseName(rewritten).WithTriviaFrom(node.Name));
+            }
+
+            return base.VisitUsingDirective(node);
+        }
+
+        public override SyntaxNode? VisitIdentifierName(IdentifierNameSyntax node)
+        {
+            if (node.Parent is BaseNamespaceDeclarationSyntax ns && ns.Name == node)
+                return node;
+            if (node.Parent is UsingDirectiveSyntax usingDirective && usingDirective.Name == node)
+                return node;
+
+            var symbol = _semanticModel.GetSymbolInfo(node).Symbol;
+            if (symbol is INamespaceSymbol nsSymbol && SymbolEqualityComparer.Default.Equals(nsSymbol, _target))
+                return SyntaxFactory.ParseName(_newFullName).WithTriviaFrom(node);
+
+            return base.VisitIdentifierName(node);
+        }
+
+        private bool IsTargetOrDescendant(INamespaceSymbol? symbol)
+        {
+            if (symbol == null || symbol.IsGlobalNamespace)
+                return false;
+
+            for (var current = symbol; current is { IsGlobalNamespace: false }; current = current.ContainingNamespace)
+            {
+                if (SymbolEqualityComparer.Default.Equals(current, _target))
+                    return true;
+            }
+
+            return false;
+        }
+
+        private string RewriteFullName(string current)
+        {
+            if (string.Equals(current, _oldFullName, StringComparison.Ordinal))
+                return _newFullName;
+
+            if (current.StartsWith(_oldFullName + ".", StringComparison.Ordinal))
+                return _newFullName + current[_oldFullName.Length..];
+
+            return current;
+        }
+    }
+}

--- a/src/RoslynMcp.Core/Refactoring/Rename/RenameNamespaceOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Rename/RenameNamespaceOperation.cs
@@ -548,11 +548,12 @@ public sealed class RenameNamespaceOperation : RefactoringOperationBase<RenameNa
         CancellationToken cancellationToken)
     {
         var documentIds = await CollectDocumentsToRewriteAsync(namespaceSymbol, cancellationToken);
-        var solution = Context.Solution;
+        var originalSolution = Context.Solution;
+        var updates = new List<(DocumentId Id, SyntaxNode Root)>();
 
         foreach (var documentId in documentIds)
         {
-            var document = solution.GetDocument(documentId);
+            var document = originalSolution.GetDocument(documentId);
             if (document == null)
                 continue;
 
@@ -566,8 +567,12 @@ public sealed class RenameNamespaceOperation : RefactoringOperationBase<RenameNa
             var rewriter = new NamespaceNameRewriter(semanticModel, namespaceSymbol, oldFullName, newFullName);
             var newRoot = rewriter.Visit(root);
             if (newRoot != null && newRoot != root)
-                solution = solution.WithDocumentSyntaxRoot(documentId, newRoot);
+                updates.Add((documentId, newRoot));
         }
+
+        var solution = originalSolution;
+        foreach (var (documentId, newRoot) in updates)
+            solution = solution.WithDocumentSyntaxRoot(documentId, newRoot);
 
         return solution;
     }
@@ -901,6 +906,13 @@ public sealed class RenameNamespaceOperation : RefactoringOperationBase<RenameNa
         {
             if (symbol == null || symbol.IsGlobalNamespace)
                 return false;
+
+            var full = GetFullName(symbol);
+            if (string.Equals(full, _oldFullName, StringComparison.Ordinal)
+                || IsPrefixOfNamespace(_oldFullName, full))
+            {
+                return true;
+            }
 
             for (var current = symbol; current is { IsGlobalNamespace: false }; current = current.ContainingNamespace)
             {

--- a/src/RoslynMcp.Server/McpServerHost.cs
+++ b/src/RoslynMcp.Server/McpServerHost.cs
@@ -32,6 +32,7 @@ public sealed class McpServerHost : IAsyncDisposable
         // Phase 1 - Tier 1 Operations
         _toolRegistry.Register(new RenameSymbolTool(workspaceProvider));
         _toolRegistry.Register(new RenameFileToMatchTypeTool(workspaceProvider));
+        _toolRegistry.Register(new RenameNamespaceTool(workspaceProvider));
         _toolRegistry.Register(new ExtractMethodTool(workspaceProvider));
         _toolRegistry.Register(new AddMissingUsingsTool(workspaceProvider));
         _toolRegistry.Register(new RemoveUnusedUsingsTool(workspaceProvider));

--- a/src/RoslynMcp.Server/Tools/RenameNamespaceTool.cs
+++ b/src/RoslynMcp.Server/Tools/RenameNamespaceTool.cs
@@ -1,0 +1,158 @@
+using System.Text.Json;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.Refactoring;
+using RoslynMcp.Core.Refactoring.Rename;
+using RoslynMcp.Core.Workspace;
+using RoslynMcp.Server.Transport;
+
+namespace RoslynMcp.Server.Tools;
+
+/// <summary>
+/// MCP tool handler for rename_namespace operation.
+/// </summary>
+public sealed class RenameNamespaceTool : IToolHandler
+{
+    private readonly IWorkspaceProvider _workspaceProvider;
+    private readonly JsonSerializerOptions _jsonOptions;
+
+    /// <summary>
+    /// Creates a new rename-namespace tool.
+    /// </summary>
+    public RenameNamespaceTool(IWorkspaceProvider workspaceProvider)
+    {
+        _workspaceProvider = workspaceProvider;
+        _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = false
+        };
+    }
+
+    /// <inheritdoc />
+    public string Name => "rename_namespace";
+
+    /// <inheritdoc />
+    public string Description =>
+        "Rename a C# namespace across the solution, updating declarations, using directives, and qualified name references. Does not move folders unless updateFolders is true (not implemented in this version).";
+
+    /// <inheritdoc />
+    public object InputSchema => new
+    {
+        type = "object",
+        required = new[] { "solutionPath", "sourceFile", "namespaceName", "newName" },
+        properties = new
+        {
+            solutionPath = new
+            {
+                type = "string",
+                description = "Absolute path to the .sln or .csproj file"
+            },
+            sourceFile = new
+            {
+                type = "string",
+                description = "Absolute path to a source file that declares the namespace"
+            },
+            namespaceName = new
+            {
+                type = "string",
+                description = "Current namespace name (simple or fully qualified)"
+            },
+            newName = new
+            {
+                type = "string",
+                description = "New namespace name (simple or fully qualified)"
+            },
+            line = new
+            {
+                type = "integer",
+                description = "1-based line number used to select a namespace declaration when the file has more than one",
+                minimum = 1
+            },
+            column = new
+            {
+                type = "integer",
+                description = "1-based column number used with line when multiple declarations share a line",
+                minimum = 1
+            },
+            updateFolders = new
+            {
+                type = "boolean",
+                description = "Also move folders to match the new namespace. Default false. True is rejected because folder moves are not implemented.",
+                @default = false
+            },
+            preview = new
+            {
+                type = "boolean",
+                description = "Return computed changes without applying",
+                @default = false
+            }
+        },
+        additionalProperties = false
+    };
+
+    /// <inheritdoc />
+    public async Task<ToolResult> ExecuteAsync(JsonElement? arguments, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (arguments == null)
+            {
+                return ToolResult.Error("Arguments required");
+            }
+
+            var args = JsonSerializer.Deserialize<RenameNamespaceArgs>(arguments.Value.GetRawText(), _jsonOptions);
+            if (args == null)
+            {
+                return ToolResult.Error("Failed to parse arguments");
+            }
+
+            using var context = await _workspaceProvider.CreateContextAsync(
+                args.SolutionPath,
+                cancellationToken);
+
+            var operation = new RenameNamespaceOperation(context);
+            var @params = new RenameNamespaceParams
+            {
+                SourceFile = args.SourceFile,
+                NamespaceName = args.NamespaceName,
+                NewName = args.NewName,
+                Line = args.Line,
+                Column = args.Column,
+                UpdateFolders = args.UpdateFolders ?? false,
+                Preview = args.Preview ?? false
+            };
+
+            var result = await operation.ExecuteAsync(@params, cancellationToken);
+
+            var json = JsonSerializer.Serialize(result, _jsonOptions);
+            return result.Success ? ToolResult.Success(json) : ToolResult.Error(json);
+        }
+        catch (RefactoringException ex)
+        {
+            var error = ex.ToError();
+            var json = JsonSerializer.Serialize(new { success = false, error }, _jsonOptions);
+            return ToolResult.Error(json);
+        }
+        catch (Exception ex)
+        {
+            var json = JsonSerializer.Serialize(new
+            {
+                success = false,
+                error = new { code = "INTERNAL_ERROR", message = ex.Message }
+            }, _jsonOptions);
+            return ToolResult.Error(json);
+        }
+    }
+
+    private sealed class RenameNamespaceArgs
+    {
+        public string SolutionPath { get; init; } = "";
+        public string SourceFile { get; init; } = "";
+        public string NamespaceName { get; init; } = "";
+        public string NewName { get; init; } = "";
+        public int? Line { get; init; }
+        public int? Column { get; init; }
+        public bool? UpdateFolders { get; init; }
+        public bool? Preview { get; init; }
+    }
+}

--- a/tests/RoslynMcp.Cli.Tests/HelpGeneratorTests.cs
+++ b/tests/RoslynMcp.Cli.Tests/HelpGeneratorTests.cs
@@ -15,11 +15,11 @@ public class HelpGeneratorTests
     }
 
     [Fact]
-    public void GenerateGlobalHelp_Lists61Tools()
+    public void GenerateGlobalHelp_Lists62Tools()
     {
         var registry = ToolRegistry.BuildDefault();
         var help = HelpGenerator.GenerateGlobalHelp(registry);
-        Assert.Contains("Total: 61 tools", help);
+        Assert.Contains("Total: 62 tools", help);
         Assert.Contains("pull-members-up", help);
         Assert.Contains("push-members-down", help);
         Assert.Contains("use-base-type", help);
@@ -39,6 +39,7 @@ public class HelpGeneratorTests
         Assert.Contains("convert-anonymous-to-class", help);
         Assert.Contains("convert-tuple-to-struct", help);
         Assert.Contains("rename-file-to-match-type", help);
+        Assert.Contains("rename-namespace", help);
     }
 
     [Fact]

--- a/tests/RoslynMcp.Cli.Tests/ToolRegistryTests.cs
+++ b/tests/RoslynMcp.Cli.Tests/ToolRegistryTests.cs
@@ -6,11 +6,11 @@ namespace RoslynMcp.Cli.Tests;
 public class ToolRegistryTests
 {
     [Fact]
-    public void BuildDefault_Registers61Tools()
+    public void BuildDefault_Registers62Tools()
     {
         var registry = ToolRegistry.BuildDefault();
         var tools = registry.GetAllTools();
-        Assert.Equal(61, tools.Count);
+        Assert.Equal(62, tools.Count);
     }
 
     [Fact]
@@ -104,6 +104,7 @@ public class ToolRegistryTests
     [InlineData("convert-anonymous-to-class", "Refactoring")]
     [InlineData("convert-tuple-to-struct", "Refactoring")]
     [InlineData("rename-file-to-match-type", "Refactoring")]
+    [InlineData("rename-namespace", "Refactoring")]
     [InlineData("convert-to-block-body", "Refactoring")]
     [InlineData("generate-constructor", "Refactoring")]
     [InlineData("generate-property", "Refactoring")]
@@ -121,11 +122,11 @@ public class ToolRegistryTests
     }
 
     [Fact]
-    public void RefactoringToolCount_Is48()
+    public void RefactoringToolCount_Is49()
     {
         var registry = ToolRegistry.BuildDefault();
         var count = registry.GetAllTools().Count(t => t.Category == "Refactoring");
-        Assert.Equal(48, count);
+        Assert.Equal(49, count);
     }
 
     [Fact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Rename/RenameNamespaceOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Rename/RenameNamespaceOperationTests.cs
@@ -1,3 +1,5 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
@@ -135,6 +137,114 @@ public class RenameNamespaceOperationTests
         Assert.Equal("Core", RenameNamespaceOperation.GetLastSegment("MyApp.Services.Core"));
     }
 
+    [Fact]
+    public void GetRelativeNamespaceName_StripsEnclosingPrefix()
+    {
+        Assert.Equal("X.Y", RenameNamespaceOperation.GetRelativeNamespaceName("X.Y", ""));
+        Assert.Equal("Y", RenameNamespaceOperation.GetRelativeNamespaceName("X.Y", "X"));
+        Assert.Equal("C", RenameNamespaceOperation.GetRelativeNamespaceName("X.Y.C", "X.Y"));
+        Assert.Equal("Y.C", RenameNamespaceOperation.GetRelativeNamespaceName("X.Y.C", "X"));
+    }
+
+    [Fact]
+    public void GetCorrespondingPrefix_MapsAncestorOntoNewPath()
+    {
+        Assert.Equal("X", RenameNamespaceOperation.GetCorrespondingPrefix("A.B", "X.Y", "A"));
+        Assert.Equal("X.Y", RenameNamespaceOperation.GetCorrespondingPrefix("A.B", "X.Y", "A.B"));
+        Assert.Equal("X.Y.C", RenameNamespaceOperation.GetCorrespondingPrefix("A.B", "X.Y", "A.B.C"));
+    }
+
+    [Fact]
+    public void HasNamespaceCollision_DescendantTypes_IsDetected()
+    {
+        var compilation = CreateCompilation("""
+            namespace Old.Sub { public class Foo {} }
+            namespace Dest.New.Sub { public class Foo {} }
+            """);
+
+        Assert.True(RenameNamespaceOperation.HasNamespaceCollision(
+            FindCompilationNamespace(compilation, "Old"),
+            FindCompilationNamespace(compilation, "Dest.New")));
+    }
+
+    [Fact]
+    public void HasNamespaceCollision_NamespaceVersusType_IsDetected()
+    {
+        var compilation = CreateCompilation("""
+            namespace Old { public class Sub {} }
+            namespace Dest.New.Sub { public class Bar {} }
+            """);
+
+        Assert.True(RenameNamespaceOperation.HasNamespaceCollision(
+            FindCompilationNamespace(compilation, "Old"),
+            FindCompilationNamespace(compilation, "Dest.New")));
+    }
+
+    [Fact]
+    public void HasNamespaceCollision_NoOverlap_ReturnsFalse()
+    {
+        var compilation = CreateCompilation("""
+            namespace Old.Sub { public class Foo {} }
+            namespace Dest.New.Sub { public class Bar {} }
+            """);
+
+        Assert.False(RenameNamespaceOperation.HasNamespaceCollision(
+            FindCompilationNamespace(compilation, "Old"),
+            FindCompilationNamespace(compilation, "Dest.New")));
+    }
+
+    [Fact]
+    public void Rewriter_NestedDeclaration_WritesRelativeName()
+    {
+        var compilation = CreateCompilation("""
+            namespace A
+            {
+                namespace B
+                {
+                    public class Foo {}
+                }
+            }
+            """);
+        var tree = compilation.SyntaxTrees.Single();
+        var rewritten = RenameNamespaceOperation.RewriteNamespaceNames(
+            compilation.GetSemanticModel(tree),
+            tree.GetRoot(),
+            FindCompilationNamespace(compilation, "A.B"),
+            "A.B",
+            "X.Y");
+        var text = rewritten.ToFullString();
+
+        Assert.Contains("namespace X", text);
+        Assert.Contains("namespace Y", text);
+        Assert.DoesNotContain("namespace X.Y", text);
+        Assert.DoesNotContain("namespace A", text);
+        Assert.DoesNotContain("namespace B", text);
+    }
+
+    [Fact]
+    public void Rewriter_QualifiedTypeName_RewritesContainingNameWithoutThrowing()
+    {
+        var compilation = CreateCompilation("""
+            namespace A.B { public class Foo {} }
+            class C
+            {
+                A.B.Foo f = new A.B.Foo();
+            }
+            """);
+        var tree = compilation.SyntaxTrees.Single();
+        var rewritten = RenameNamespaceOperation.RewriteNamespaceNames(
+            compilation.GetSemanticModel(tree),
+            tree.GetRoot(),
+            FindCompilationNamespace(compilation, "A.B"),
+            "A.B",
+            "X.Y");
+        var text = rewritten.ToFullString();
+
+        Assert.Contains("namespace X.Y", text);
+        Assert.Contains("X.Y.Foo", text);
+        Assert.DoesNotContain("A.B.Foo", text);
+    }
+
     #endregion
 
     #region Happy Path
@@ -242,6 +352,124 @@ public class RenameNamespaceOperationTests
         Assert.Contains("using OldNs;", await File.ReadAllTextAsync(workspace.SecondarySourcePath));
     }
 
+    [SkippableFact]
+    public async Task RenameNamespace_NestedDeclaration_PreservesRelativeName()
+    {
+        const string source = """
+            namespace A
+            {
+                namespace B
+                {
+                    public class Foo
+                    {
+                    }
+                }
+            }
+            """;
+        const string consumer = """
+            namespace Other;
+
+            public class Consumer
+            {
+                public A.B.Foo Create() => new A.B.Foo();
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(
+            ("Foo.cs", source),
+            ("Consumer.cs", consumer));
+        var originalSource = await File.ReadAllTextAsync(workspace.SourcePath);
+        var originalConsumer = await File.ReadAllTextAsync(workspace.SecondarySourcePath);
+        var operation = new RenameNamespaceOperation(workspace.Context);
+
+        var preview = await operation.ExecuteAsync(new RenameNamespaceParams
+        {
+            SourceFile = workspace.SourcePath,
+            NamespaceName = "A.B",
+            NewName = "X.Y",
+            Preview = true
+        });
+
+        Assert.True(preview.Success);
+        Assert.True(preview.Preview);
+        Assert.Equal(originalSource, await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Equal(originalConsumer, await File.ReadAllTextAsync(workspace.SecondarySourcePath));
+
+        var result = await operation.ExecuteAsync(new RenameNamespaceParams
+        {
+            SourceFile = workspace.SourcePath,
+            NamespaceName = "A.B",
+            NewName = "X.Y"
+        });
+
+        Assert.True(result.Success);
+
+        var declaration = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.DoesNotContain("namespace X.Y", declaration);
+        Assert.Contains("namespace X", declaration);
+        Assert.Contains("namespace Y", declaration);
+        Assert.DoesNotContain("namespace A", declaration);
+        Assert.DoesNotContain("namespace B", declaration);
+        Assert.Contains("public class Foo", declaration);
+
+        var usages = await File.ReadAllTextAsync(workspace.SecondarySourcePath);
+        Assert.Contains("X.Y.Foo", usages);
+        Assert.DoesNotContain("A.B.Foo", usages);
+    }
+
+    [SkippableFact]
+    public async Task RenameNamespace_QualifiedName_DottedRename_DoesNotThrow()
+    {
+        const string source = """
+            namespace A.B;
+
+            public class Foo
+            {
+            }
+            """;
+        const string consumer = """
+            namespace Other;
+
+            public class Consumer
+            {
+                public A.B.Foo Create() => new A.B.Foo();
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(
+            ("Foo.cs", source),
+            ("Consumer.cs", consumer));
+        var originalSource = await File.ReadAllTextAsync(workspace.SourcePath);
+        var originalConsumer = await File.ReadAllTextAsync(workspace.SecondarySourcePath);
+        var operation = new RenameNamespaceOperation(workspace.Context);
+
+        var preview = await operation.ExecuteAsync(new RenameNamespaceParams
+        {
+            SourceFile = workspace.SourcePath,
+            NamespaceName = "A.B",
+            NewName = "X.Y",
+            Preview = true
+        });
+
+        Assert.True(preview.Success);
+        Assert.True(preview.Preview);
+        Assert.Equal(originalSource, await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Equal(originalConsumer, await File.ReadAllTextAsync(workspace.SecondarySourcePath));
+
+        var result = await operation.ExecuteAsync(new RenameNamespaceParams
+        {
+            SourceFile = workspace.SourcePath,
+            NamespaceName = "A.B",
+            NewName = "X.Y"
+        });
+
+        Assert.True(result.Success);
+        Assert.Contains("namespace X.Y;", await File.ReadAllTextAsync(workspace.SourcePath));
+        var usages = await File.ReadAllTextAsync(workspace.SecondarySourcePath);
+        Assert.Contains("X.Y.Foo", usages);
+        Assert.DoesNotContain("A.B.Foo", usages);
+    }
+
     #endregion
 
     #region Rejects
@@ -339,6 +567,44 @@ public class RenameNamespaceOperationTests
         Assert.Equal(originalExisting, await File.ReadAllTextAsync(workspace.SecondarySourcePath));
     }
 
+    [SkippableFact]
+    public async Task RenameNamespace_DescendantCollision_ThrowsNameConflictScope()
+    {
+        const string source = """
+            namespace Old.Sub;
+
+            public class Foo
+            {
+            }
+            """;
+        const string existing = """
+            namespace Dest.New.Sub;
+
+            public class Foo
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(
+            ("Foo.cs", source),
+            ("Existing.cs", existing));
+        var originalSource = await File.ReadAllTextAsync(workspace.SourcePath);
+        var originalExisting = await File.ReadAllTextAsync(workspace.SecondarySourcePath);
+        var operation = new RenameNamespaceOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new RenameNamespaceParams
+            {
+                SourceFile = workspace.SourcePath,
+                NamespaceName = "Old",
+                NewName = "Dest.New"
+            }));
+
+        Assert.Equal(ErrorCodes.NameConflictScope, ex.ErrorCode);
+        Assert.Equal(originalSource, await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Equal(originalExisting, await File.ReadAllTextAsync(workspace.SecondarySourcePath));
+    }
+
     #endregion
 
     #region Helpers
@@ -356,6 +622,26 @@ public class RenameNamespaceOperationTests
             Line = line,
             UpdateFolders = updateFolders
         };
+
+    private static CSharpCompilation CreateCompilation(string source)
+    {
+        var tree = CSharpSyntaxTree.ParseText(source);
+        return CSharpCompilation.Create(
+            "RenameNamespaceCollisionTest",
+            [tree],
+            [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)]);
+    }
+
+    private static INamespaceSymbol FindCompilationNamespace(Compilation compilation, string fullName)
+    {
+        INamespaceSymbol current = compilation.GlobalNamespace;
+        foreach (var segment in fullName.Split('.'))
+        {
+            current = current.GetNamespaceMembers().Single(n => n.Name == segment);
+        }
+
+        return current;
+    }
 
     private sealed class TempWorkspace : IAsyncDisposable
     {

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Rename/RenameNamespaceOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Rename/RenameNamespaceOperationTests.cs
@@ -1,0 +1,460 @@
+using RoslynMcp.Contracts.Errors;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.Refactoring;
+using RoslynMcp.Core.Refactoring.Rename;
+using RoslynMcp.Core.Workspace;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Refactoring.Rename;
+
+/// <summary>
+/// Operation-level tests for <see cref="RenameNamespaceOperation"/>.
+/// </summary>
+public class RenameNamespaceOperationTests
+{
+    #region Validation
+
+    [Fact]
+    public void Validate_MissingSourceFile_ThrowsMissingRequiredParam()
+    {
+        var ex = Assert.Throws<RefactoringException>(
+            () => RenameNamespaceOperation.Validate(ValidParams(sourceFile: "")));
+        Assert.Equal(ErrorCodes.MissingRequiredParam, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_RelativeSourceFile_ThrowsInvalidSourcePath()
+    {
+        var ex = Assert.Throws<RefactoringException>(
+            () => RenameNamespaceOperation.Validate(ValidParams(sourceFile: "Foo.cs")));
+        Assert.Equal(ErrorCodes.InvalidSourcePath, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_MissingFile_ThrowsSourceFileNotFound()
+    {
+        var ex = Assert.Throws<RefactoringException>(
+            () => RenameNamespaceOperation.Validate(ValidParams()));
+        Assert.Equal(ErrorCodes.SourceFileNotFound, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_InvalidNamespaceName_ThrowsInvalidNamespace()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "RoslynMcpRenameNsInvalidName.cs");
+        File.WriteAllText(path, "namespace OldNs;");
+        try
+        {
+            var ex = Assert.Throws<RefactoringException>(
+                () => RenameNamespaceOperation.Validate(ValidParams(sourceFile: path, newName: "123Bad")));
+            Assert.Equal(ErrorCodes.InvalidNamespace, ex.ErrorCode);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Validate_SameName_ThrowsSameLocation()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "RoslynMcpRenameNsSameName.cs");
+        File.WriteAllText(path, "namespace OldNs;");
+        try
+        {
+            var ex = Assert.Throws<RefactoringException>(
+                () => RenameNamespaceOperation.Validate(ValidParams(sourceFile: path, newName: "OldNs")));
+            Assert.Equal(ErrorCodes.SameLocation, ex.ErrorCode);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Validate_UpdateFoldersTrue_ThrowsFolderUpdateNotSupported()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "RoslynMcpRenameNsFolders.cs");
+        File.WriteAllText(path, "namespace OldNs;");
+        try
+        {
+            var ex = Assert.Throws<RefactoringException>(
+                () => RenameNamespaceOperation.Validate(ValidParams(sourceFile: path, updateFolders: true)));
+            Assert.Equal(ErrorCodes.FolderUpdateNotSupported, ex.ErrorCode);
+            Assert.Equal("3136", ex.ErrorCode);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Validate_InvalidLine_ThrowsInvalidLineNumber()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "RoslynMcpRenameNsInvalidLine.cs");
+        File.WriteAllText(path, "namespace OldNs;");
+        try
+        {
+            var ex = Assert.Throws<RefactoringException>(
+                () => RenameNamespaceOperation.Validate(ValidParams(sourceFile: path, line: 0)));
+            Assert.Equal(ErrorCodes.InvalidLineNumber, ex.ErrorCode);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void IsValidNamespaceName_AcceptsDottedAndSimpleNames()
+    {
+        Assert.True(RenameNamespaceOperation.IsValidNamespaceName("OldNs"));
+        Assert.True(RenameNamespaceOperation.IsValidNamespaceName("MyApp.Services"));
+        Assert.False(RenameNamespaceOperation.IsValidNamespaceName("123Bad"));
+        Assert.False(RenameNamespaceOperation.IsValidNamespaceName("Has Space"));
+        Assert.False(RenameNamespaceOperation.IsValidNamespaceName(""));
+    }
+
+    [Fact]
+    public void IsLastSegmentRename_DetectsSharedParent()
+    {
+        Assert.True(RenameNamespaceOperation.IsLastSegmentRename("OldNs", "NewNs"));
+        Assert.True(RenameNamespaceOperation.IsLastSegmentRename("MyApp.Old", "MyApp.New"));
+        Assert.False(RenameNamespaceOperation.IsLastSegmentRename("MyApp.Old", "Other.New"));
+        Assert.False(RenameNamespaceOperation.IsLastSegmentRename("OldNs", "OldNs"));
+    }
+
+    [Fact]
+    public void GetParentAndLastSegment_SplitDottedNames()
+    {
+        Assert.Equal("", RenameNamespaceOperation.GetParentName("OldNs"));
+        Assert.Equal("OldNs", RenameNamespaceOperation.GetLastSegment("OldNs"));
+        Assert.Equal("MyApp.Services", RenameNamespaceOperation.GetParentName("MyApp.Services.Core"));
+        Assert.Equal("Core", RenameNamespaceOperation.GetLastSegment("MyApp.Services.Core"));
+    }
+
+    #endregion
+
+    #region Happy Path
+
+    [SkippableFact]
+    public async Task RenameNamespace_Simple_UpdatesDeclarationAndUsings()
+    {
+        const string source = """
+            namespace OldNs;
+
+            public class Foo
+            {
+                public int Value { get; set; }
+            }
+            """;
+        const string consumer = """
+            using OldNs;
+
+            namespace Other;
+
+            public class Consumer
+            {
+                public Foo Create() => new Foo();
+                public OldNs.Foo Qualified() => new OldNs.Foo();
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(
+            ("Foo.cs", source),
+            ("Consumer.cs", consumer));
+        var operation = new RenameNamespaceOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new RenameNamespaceParams
+        {
+            SourceFile = workspace.SourcePath,
+            NamespaceName = "OldNs",
+            NewName = "NewNs"
+        });
+
+        Assert.True(result.Success);
+        Assert.False(result.Preview);
+
+        var declaration = await File.ReadAllTextAsync(workspace.SourcePath);
+        Assert.Contains("namespace NewNs;", declaration);
+        Assert.DoesNotContain("namespace OldNs;", declaration);
+        Assert.Contains("public class Foo", declaration);
+
+        var usages = await File.ReadAllTextAsync(workspace.SecondarySourcePath);
+        Assert.Contains("using NewNs;", usages);
+        Assert.DoesNotContain("using OldNs;", usages);
+        Assert.Contains("new Foo()", usages);
+        Assert.Contains("NewNs.Foo", usages);
+        Assert.DoesNotContain("OldNs.Foo", usages);
+
+        Assert.Contains(workspace.SourcePath, result.Changes!.FilesModified);
+        Assert.Contains(workspace.SecondarySourcePath, result.Changes.FilesModified);
+        Assert.Equal("NewNs", result.Symbol!.FullyQualifiedName);
+        Assert.True(result.ReferencesUpdated >= 0);
+    }
+
+    [SkippableFact]
+    public async Task RenameNamespace_Preview_ReturnsChangesAndWritesNothing()
+    {
+        const string source = """
+            namespace OldNs;
+
+            public class Foo
+            {
+            }
+            """;
+        const string consumer = """
+            using OldNs;
+
+            namespace Other;
+
+            public class Consumer
+            {
+                public Foo Create() => new Foo();
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(
+            ("Foo.cs", source),
+            ("Consumer.cs", consumer));
+        var originalSource = await File.ReadAllTextAsync(workspace.SourcePath);
+        var originalConsumer = await File.ReadAllTextAsync(workspace.SecondarySourcePath);
+        var operation = new RenameNamespaceOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new RenameNamespaceParams
+        {
+            SourceFile = workspace.SourcePath,
+            NamespaceName = "OldNs",
+            NewName = "NewNs",
+            Preview = true
+        });
+
+        Assert.True(result.Success);
+        Assert.True(result.Preview);
+        Assert.NotNull(result.PendingChanges);
+        Assert.NotEmpty(result.PendingChanges);
+
+        Assert.Equal(originalSource, await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Equal(originalConsumer, await File.ReadAllTextAsync(workspace.SecondarySourcePath));
+        Assert.Contains("namespace OldNs;", await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("using OldNs;", await File.ReadAllTextAsync(workspace.SecondarySourcePath));
+    }
+
+    #endregion
+
+    #region Rejects
+
+    [SkippableFact]
+    public async Task RenameNamespace_SameName_ThrowsSameLocation()
+    {
+        const string source = """
+            namespace OldNs;
+
+            public class Foo
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source, "Foo.cs");
+        var original = await File.ReadAllTextAsync(workspace.SourcePath);
+        var operation = new RenameNamespaceOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new RenameNamespaceParams
+            {
+                SourceFile = workspace.SourcePath,
+                NamespaceName = "OldNs",
+                NewName = "OldNs"
+            }));
+
+        Assert.Equal(ErrorCodes.SameLocation, ex.ErrorCode);
+        Assert.Equal(original, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [SkippableFact]
+    public async Task RenameNamespace_MissingNamespace_ThrowsSymbolNotFound()
+    {
+        const string source = """
+            namespace OldNs;
+
+            public class Foo
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source, "Foo.cs");
+        var original = await File.ReadAllTextAsync(workspace.SourcePath);
+        var operation = new RenameNamespaceOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new RenameNamespaceParams
+            {
+                SourceFile = workspace.SourcePath,
+                NamespaceName = "DoesNotExist",
+                NewName = "NewNs"
+            }));
+
+        Assert.Equal(ErrorCodes.SymbolNotFound, ex.ErrorCode);
+        Assert.Equal(original, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [SkippableFact]
+    public async Task RenameNamespace_NameConflict_ThrowsNameConflictScope()
+    {
+        const string source = """
+            namespace OldNs;
+
+            public class Foo
+            {
+            }
+            """;
+        const string existing = """
+            namespace NewNs;
+
+            public class Foo
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(
+            ("Foo.cs", source),
+            ("Existing.cs", existing));
+        var originalSource = await File.ReadAllTextAsync(workspace.SourcePath);
+        var originalExisting = await File.ReadAllTextAsync(workspace.SecondarySourcePath);
+        var operation = new RenameNamespaceOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new RenameNamespaceParams
+            {
+                SourceFile = workspace.SourcePath,
+                NamespaceName = "OldNs",
+                NewName = "NewNs"
+            }));
+
+        Assert.Equal(ErrorCodes.NameConflictScope, ex.ErrorCode);
+        Assert.Equal("3010", ex.ErrorCode);
+        Assert.Equal(originalSource, await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Equal(originalExisting, await File.ReadAllTextAsync(workspace.SecondarySourcePath));
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static RenameNamespaceParams ValidParams(
+        string? sourceFile = null,
+        string namespaceName = "OldNs",
+        string newName = "NewNs",
+        int? line = null,
+        bool updateFolders = false) => new()
+        {
+            SourceFile = sourceFile ?? Path.Combine(Path.GetTempPath(), "RoslynMcpRenameNsMissing.cs"),
+            NamespaceName = namespaceName,
+            NewName = newName,
+            Line = line,
+            UpdateFolders = updateFolders
+        };
+
+    private sealed class TempWorkspace : IAsyncDisposable
+    {
+        public required string DirectoryPath { get; init; }
+        public required string ProjectPath { get; init; }
+        public required string SourcePath { get; init; }
+        public required WorkspaceContext Context { get; init; }
+        public string SecondarySourcePath { get; init; } = "";
+
+        public static Task<TempWorkspace> CreateAsync(string source, string fileName = "Foo.cs") =>
+            CreateAsync((fileName, source));
+
+        public static Task<TempWorkspace> CreateAsync(params (string FileName, string Source)[] files) =>
+            CreateAsync("""
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net9.0</TargetFramework>
+                    <Nullable>enable</Nullable>
+                  </PropertyGroup>
+                </Project>
+                """, files);
+
+        public static async Task<TempWorkspace> CreateAsync(
+            string projectXml,
+            params (string FileName, string Source)[] files)
+        {
+            Skip.IfNot(ModuleInitializer.MsBuildAvailable, ModuleInitializer.MsBuildError ?? "MSBuild not available");
+
+            var directory = Path.Combine(Path.GetTempPath(), "RoslynMcpRenameNs_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(directory);
+
+            var projectPath = Path.Combine(directory, "TestApp.csproj");
+            await File.WriteAllTextAsync(projectPath, projectXml);
+
+            string? sourcePath = null;
+            string? secondary = null;
+            foreach (var (fileName, source) in files)
+            {
+                var path = Path.Combine(directory, fileName);
+                await File.WriteAllTextAsync(path, source);
+                if (sourcePath == null)
+                    sourcePath = path;
+                else
+                    secondary ??= path;
+            }
+
+            sourcePath ??= Path.Combine(directory, "Foo.cs");
+
+            try
+            {
+                var provider = new MSBuildWorkspaceProvider();
+                var context = await provider.CreateContextAsync(projectPath);
+                if (context.GetDocumentByPath(sourcePath) == null)
+                {
+                    context.Dispose();
+                    throw new InvalidOperationException($"Workspace loaded but did not include {sourcePath}.");
+                }
+
+                return new TempWorkspace
+                {
+                    DirectoryPath = directory,
+                    ProjectPath = projectPath,
+                    SourcePath = sourcePath,
+                    SecondarySourcePath = secondary ?? "",
+                    Context = context
+                };
+            }
+            catch (Exception ex) when (ex is not SkipException)
+            {
+                try
+                {
+                    Directory.Delete(directory, recursive: true);
+                }
+                catch
+                {
+                    // ignore cleanup failures
+                }
+
+                Skip.If(true, $"Workspace load failed: {ex.Message}");
+                throw;
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            Context.Dispose();
+            await Task.Run(() =>
+            {
+                try
+                {
+                    Directory.Delete(DirectoryPath, recursive: true);
+                }
+                catch
+                {
+                    // ignore locked temp files
+                }
+            });
+        }
+    }
+
+    #endregion
+}

--- a/tests/RoslynMcp.Server.Tests/Tools/RenameNamespaceToolTests.cs
+++ b/tests/RoslynMcp.Server.Tests/Tools/RenameNamespaceToolTests.cs
@@ -1,0 +1,137 @@
+using System.Text.Json;
+using RoslynMcp.Server.Tests.TestHelpers;
+using RoslynMcp.Server.Tools;
+using RoslynMcp.Server.Transport;
+using Xunit;
+
+namespace RoslynMcp.Server.Tests.Tools;
+
+/// <summary>
+/// Unit tests for RenameNamespaceTool.
+/// Tests tool definition and argument validation.
+/// </summary>
+public class RenameNamespaceToolTests
+{
+    private readonly RenameNamespaceTool _tool;
+
+    public RenameNamespaceToolTests()
+    {
+        // Fails loudly if workspace creation is attempted; argument validation is exercised via ExecuteAsync error paths.
+        _tool = new RenameNamespaceTool(new ThrowingWorkspaceProvider());
+    }
+
+    #region GetDefinition Tests
+
+    [Fact]
+    public void GetDefinition_ReturnsCorrectName()
+    {
+        Assert.Equal("rename_namespace", _tool.Name);
+    }
+
+    [Fact]
+    public void GetDefinition_ReturnsNonEmptyDescription()
+    {
+        Assert.NotNull(_tool.Description);
+        Assert.NotEmpty(_tool.Description);
+    }
+
+    [Fact]
+    public void GetDefinition_ReturnsCorrectSchema()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.Equal("object", root.GetProperty("type").GetString());
+        Assert.True(root.TryGetProperty("properties", out _));
+        Assert.True(root.TryGetProperty("required", out _));
+    }
+
+    [Fact]
+    public void GetDefinition_HasRequiredFields()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var required = doc.RootElement.GetProperty("required");
+
+        var requiredFields = new List<string>();
+        foreach (var item in required.EnumerateArray())
+        {
+            requiredFields.Add(item.GetString()!);
+        }
+
+        Assert.Contains("solutionPath", requiredFields);
+        Assert.Contains("sourceFile", requiredFields);
+        Assert.Contains("namespaceName", requiredFields);
+        Assert.Contains("newName", requiredFields);
+    }
+
+    [Fact]
+    public void GetDefinition_HasProperties_ForAllParameters()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var properties = doc.RootElement.GetProperty("properties");
+
+        Assert.True(properties.TryGetProperty("solutionPath", out _));
+        Assert.True(properties.TryGetProperty("sourceFile", out _));
+        Assert.True(properties.TryGetProperty("namespaceName", out _));
+        Assert.True(properties.TryGetProperty("newName", out _));
+        Assert.True(properties.TryGetProperty("line", out _));
+        Assert.True(properties.TryGetProperty("column", out _));
+        Assert.True(properties.TryGetProperty("updateFolders", out _));
+        Assert.True(properties.TryGetProperty("preview", out _));
+    }
+
+    #endregion
+
+    #region ExecuteAsync Argument Validation Tests
+
+    [Fact]
+    public async Task ExecuteAsync_NullArguments_ReturnsError()
+    {
+        var result = await _tool.ExecuteAsync(null);
+
+        Assert.True(result.IsError);
+        Assert.Contains("Arguments required", GetResultText(result));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EmptyArguments_ReturnsError()
+    {
+        var args = JsonDocument.Parse("{}").RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MissingRequiredField_ReturnsError()
+    {
+        var args = JsonDocument.Parse("""
+            {
+                "solutionPath": "C:/test/test.sln",
+                "sourceFile": "C:/test/Foo.cs"
+            }
+            """).RootElement;
+
+        var result = await _tool.ExecuteAsync(args);
+
+        Assert.True(result.IsError);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static string GetResultText(ToolResult result)
+    {
+        return result.Content.FirstOrDefault()?.Text ?? string.Empty;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `rename_namespace` / `RenameNamespaceOperation` so a namespace can be renamed across the solution without changing `rename_symbol`.

## What this does
- Rewrites matching namespace declarations plus `using` / qualified-name references to `newName`
- Uses Roslyn `Renamer` when only the last segment changes; rewrites the full path when the parent path changes
- Nested declarations keep a **relative** name given the enclosing namespace (`namespace A { namespace B { } }` → `namespace X { namespace Y { } }`, not `A.X.Y`)
- Dotted renames rewrite the **containing** qualified name so `A.B.Foo` becomes `X.Y.Foo` without stuffing a dotted name into a `SimpleNameSyntax` slot
- Collision checks walk descendant namespaces and namespace/type clashes (not only types directly in the source and target)
- Leaves folders alone by default; `updateFolders: true` is rejected because folder moves are not implemented
- Preview computes pending changes and writes nothing

## Parameters
`sourceFile`, `namespaceName`, `newName`, optional `line` / `column`, `updateFolders` (default false), `preview`

## Rejects
- Same name as current (`3004`)
- Invalid namespace name (`1004`)
- Namespace not found (`2003`)
- Name conflict, including descendant collisions (`3010`)
- Uneditable document (`3115`)
- Missing file (`2001`)
- `updateFolders: true` (`3136`, unused code)

## Tests
- Simple rename updates declaration and usings
- Preview writes nothing
- Nested declaration preserves relative name
- Qualified type name dotted rename does not throw and updates references
- Same-name reject
- Missing-namespace reject
- Immediate and descendant name-conflict reject
- MCP + CLI registration (61 → 62 tools, 48 → 49 refactoring)

Closes #74

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-419273a2-5873-44a7-aa5b-f82ba5ed9042?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-419273a2-5873-44a7-aa5b-f82ba5ed9042&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

