### PR TITLE
Honor rename_symbol renameImplementations

### DIFF
--- a/src/RoslynMcp.Core/Refactoring/Rename/RenameSymbolOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Rename/RenameSymbolOperation.cs
@@ -96,11 +96,14 @@ public sealed class RenameSymbolOperation : RefactoringOperationBase<RenameSymbo
         MemberIdentity? selectedImplementation = null;
         if (!@params.RenameImplementations)
         {
-            interfaceMembersToPreserve = CollectInterfaceMembers(symbol, @params.RenameOverloads);
+            interfaceMembersToPreserve = CollectInterfaceMembers(
+                symbol,
+                @params.RenameOverloads,
+                Context.Solution);
             if (interfaceMembersToPreserve.Count > 0
                 && symbol.ContainingType?.TypeKind != TypeKind.Interface)
             {
-                selectedImplementation = MemberIdentity.From(symbol);
+                selectedImplementation = MemberIdentity.From(symbol, Context.Solution);
             }
         }
 
@@ -118,7 +121,7 @@ public sealed class RenameSymbolOperation : RefactoringOperationBase<RenameSymbo
                 newSolution,
                 interfaceMembersToPreserve,
                 selectedImplementation,
-                symbol.Name,
+                GetRestoreName(symbol),
                 @params.NewName,
                 cancellationToken);
         }
@@ -494,18 +497,21 @@ public sealed class RenameSymbolOperation : RefactoringOperationBase<RenameSymbo
     /// Collects interface members whose implementations should keep the original
     /// name when <c>renameImplementations</c> is false.
     /// </summary>
-    private static List<MemberIdentity> CollectInterfaceMembers(ISymbol symbol, bool renameOverloads)
+    private static List<MemberIdentity> CollectInterfaceMembers(
+        ISymbol symbol,
+        bool renameOverloads,
+        Solution solution)
     {
         var result = new List<MemberIdentity>();
 
         if (symbol.ContainingType?.TypeKind == TypeKind.Interface)
         {
-            AddInterfaceMember(result, symbol, renameOverloads);
+            AddInterfaceMember(result, symbol, renameOverloads, solution);
             return result;
         }
 
         foreach (var implemented in GetImplementedInterfaceMembers(symbol))
-            AddInterfaceMember(result, implemented, renameOverloads);
+            AddInterfaceMember(result, implemented, renameOverloads, solution);
 
         return result;
     }
@@ -513,14 +519,15 @@ public sealed class RenameSymbolOperation : RefactoringOperationBase<RenameSymbo
     private static void AddInterfaceMember(
         List<MemberIdentity> result,
         ISymbol interfaceMember,
-        bool renameOverloads)
+        bool renameOverloads,
+        Solution solution)
     {
-        result.Add(MemberIdentity.From(interfaceMember));
+        result.Add(MemberIdentity.From(interfaceMember, solution));
         if (!renameOverloads || interfaceMember is not IMethodSymbol method)
             return;
 
         foreach (var overload in method.ContainingType.GetMembers(method.Name).OfType<IMethodSymbol>())
-            result.Add(MemberIdentity.From(overload));
+            result.Add(MemberIdentity.From(overload, solution));
     }
 
     private static IEnumerable<ISymbol> GetImplementedInterfaceMembers(ISymbol symbol)
@@ -607,21 +614,57 @@ public sealed class RenameSymbolOperation : RefactoringOperationBase<RenameSymbo
         string name,
         CancellationToken cancellationToken)
     {
-        foreach (var project in solution.Projects)
+        if (identity.DefiningProjectId is { } projectId)
         {
-            var compilation = await project.GetCompilationAsync(cancellationToken);
-            if (compilation == null)
-                continue;
-
-            var type = compilation.GetTypeByMetadataName(identity.ContainingTypeMetadataName);
-            if (type == null)
-                continue;
-
-            foreach (var member in type.GetMembers(name))
+            var project = solution.GetProject(projectId);
+            if (project != null)
             {
-                if (identity.Matches(member))
+                var member = await TryResolveInProjectAsync(project, identity, name, cancellationToken);
+                if (member != null)
                     return member;
             }
+        }
+
+        foreach (var project in solution.Projects)
+        {
+            if (identity.DefiningProjectId != null && project.Id == identity.DefiningProjectId)
+                continue;
+
+            var member = await TryResolveInProjectAsync(project, identity, name, cancellationToken);
+            if (member != null)
+                return member;
+        }
+
+        return null;
+    }
+
+    private static async Task<ISymbol?> TryResolveInProjectAsync(
+        Project project,
+        MemberIdentity identity,
+        string name,
+        CancellationToken cancellationToken)
+    {
+        var compilation = await project.GetCompilationAsync(cancellationToken);
+        if (compilation == null)
+            return null;
+
+        if (!string.IsNullOrEmpty(identity.AssemblyName)
+            && !string.Equals(compilation.AssemblyName, identity.AssemblyName, StringComparison.Ordinal)
+            && !string.Equals(compilation.Assembly.Name, identity.AssemblyName, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        // Look up on this project's assembly only so a referenced type with the
+        // same metadata name cannot steal the restore.
+        var type = compilation.Assembly.GetTypeByMetadataName(identity.ContainingTypeMetadataName);
+        if (type == null)
+            return null;
+
+        foreach (var member in type.GetMembers(name))
+        {
+            if (identity.Matches(member))
+                return member;
         }
 
         return null;
@@ -667,18 +710,52 @@ public sealed class RenameSymbolOperation : RefactoringOperationBase<RenameSymbo
         }
     }
 
-    private static TextSpan? TryGetDeclarationNameSpan(SyntaxNode node)
+    private static SyntaxToken? TryGetDeclarationIdentifier(SyntaxNode node)
     {
         return node switch
         {
-            MethodDeclarationSyntax method => method.Identifier.Span,
-            PropertyDeclarationSyntax property => property.Identifier.Span,
-            EventDeclarationSyntax @event => @event.Identifier.Span,
-            VariableDeclaratorSyntax variable => variable.Identifier.Span,
+            MethodDeclarationSyntax method => method.Identifier,
+            PropertyDeclarationSyntax property => property.Identifier,
+            EventDeclarationSyntax @event => @event.Identifier,
+            VariableDeclaratorSyntax variable => variable.Identifier,
             EventFieldDeclarationSyntax eventField =>
-                eventField.Declaration.Variables.FirstOrDefault()?.Identifier.Span,
+                eventField.Declaration.Variables.FirstOrDefault()?.Identifier,
             _ => null
         };
+    }
+
+    private static TextSpan? TryGetDeclarationNameSpan(SyntaxNode node) =>
+        TryGetDeclarationIdentifier(node)?.Span;
+
+    /// <summary>
+    /// Recovers the identifier text to write back when implementations are
+    /// preserved. <see cref="ISymbol.Name"/> drops the <c>@</c> on verbatim
+    /// keywords (<c>@class</c> becomes <c>class</c>), which would emit invalid C#.
+    /// </summary>
+    private static string GetRestoreName(ISymbol symbol)
+    {
+        foreach (var syntaxRef in symbol.DeclaringSyntaxReferences)
+        {
+            var identifier = TryGetDeclarationIdentifier(syntaxRef.GetSyntax());
+            if (identifier is { } token
+                && token.ValueText == symbol.Name
+                && !string.IsNullOrEmpty(token.Text))
+            {
+                return token.Text;
+            }
+        }
+
+        return EscapeIfReservedKeyword(symbol.Name);
+    }
+
+    private static string EscapeIfReservedKeyword(string name)
+    {
+        if (name.StartsWith('@'))
+            return name;
+
+        return SyntaxFacts.GetKeywordKind(name) != SyntaxKind.None
+            ? "@" + name
+            : name;
     }
 
     private static async Task<Solution> ApplyNameRestoresAsync(
@@ -757,6 +834,8 @@ public sealed class RenameSymbolOperation : RefactoringOperationBase<RenameSymbo
 
     private readonly record struct MemberIdentity(
         string ContainingTypeMetadataName,
+        string AssemblyName,
+        ProjectId? DefiningProjectId,
         Microsoft.CodeAnalysis.SymbolKind Kind,
         int Arity,
         string[] ParameterTypeKeys)
@@ -776,19 +855,38 @@ public sealed class RenameSymbolOperation : RefactoringOperationBase<RenameSymbo
         {
             return symbol.ContainingType != null
                 && ContainingTypeMetadataName == GetFullMetadataName(symbol.ContainingType)
+                && (string.IsNullOrEmpty(AssemblyName)
+                    || string.Equals(AssemblyName, symbol.ContainingAssembly?.Name, StringComparison.Ordinal))
                 && Matches(symbol);
         }
 
-        public static MemberIdentity From(ISymbol symbol)
+        public static MemberIdentity From(ISymbol symbol, Solution solution)
         {
             var type = symbol.ContainingType
                 ?? throw new ArgumentException("Symbol must be a type member.", nameof(symbol));
 
             return new MemberIdentity(
                 GetFullMetadataName(type),
+                symbol.ContainingAssembly?.Name ?? string.Empty,
+                GetDefiningProjectId(symbol, solution),
                 symbol.Kind,
                 symbol is IMethodSymbol method ? method.Arity : 0,
                 GetParameterTypeKeys(symbol));
+        }
+
+        private static ProjectId? GetDefiningProjectId(ISymbol symbol, Solution solution)
+        {
+            foreach (var location in symbol.Locations)
+            {
+                if (!location.IsInSource || location.SourceTree == null)
+                    continue;
+
+                var document = solution.GetDocument(location.SourceTree);
+                if (document != null)
+                    return document.Project.Id;
+            }
+
+            return null;
         }
     }
 }

--- a/src/RoslynMcp.Core/Refactoring/Rename/RenameSymbolOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Rename/RenameSymbolOperation.cs
@@ -2,7 +2,9 @@ using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Rename;
+using Microsoft.CodeAnalysis.Text;
 using RoslynMcp.Contracts.Enums;
 using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
@@ -81,13 +83,26 @@ public sealed class RenameSymbolOperation : RefactoringOperationBase<RenameSymbo
         // Find all references before rename
         var references = await ReferenceTracker.FindAllReferencesAsync(symbol, cancellationToken);
 
-        // Compute rename options
+        // Compute rename options. Roslyn's Renamer always updates interface
+        // implementations; renameImplementations: false is honored after the rename.
         var options = new SymbolRenameOptions(
             RenameOverloads: @params.RenameOverloads,
             RenameInStrings: false,
             RenameInComments: false,
             RenameFile: false // We handle file rename separately
         );
+
+        IReadOnlyList<MemberIdentity> interfaceMembersToPreserve = [];
+        MemberIdentity? selectedImplementation = null;
+        if (!@params.RenameImplementations)
+        {
+            interfaceMembersToPreserve = CollectInterfaceMembers(symbol, @params.RenameOverloads);
+            if (interfaceMembersToPreserve.Count > 0
+                && symbol.ContainingType?.TypeKind != TypeKind.Interface)
+            {
+                selectedImplementation = MemberIdentity.From(symbol);
+            }
+        }
 
         // Perform the rename
         var newSolution = await Renamer.RenameSymbolAsync(
@@ -96,6 +111,17 @@ public sealed class RenameSymbolOperation : RefactoringOperationBase<RenameSymbo
             options,
             @params.NewName,
             cancellationToken);
+
+        if (!@params.RenameImplementations && interfaceMembersToPreserve.Count > 0)
+        {
+            newSolution = await RestoreImplementationNamesAsync(
+                newSolution,
+                interfaceMembersToPreserve,
+                selectedImplementation,
+                symbol.Name,
+                @params.NewName,
+                cancellationToken);
+        }
 
         // Handle file rename for types
         string? renamedFile = null;
@@ -462,5 +488,307 @@ public sealed class RenameSymbolOperation : RefactoringOperationBase<RenameSymbo
         }
 
         return RefactoringResult.PreviewResult(operationId, pendingChanges);
+    }
+
+    /// <summary>
+    /// Collects interface members whose implementations should keep the original
+    /// name when <c>renameImplementations</c> is false.
+    /// </summary>
+    private static List<MemberIdentity> CollectInterfaceMembers(ISymbol symbol, bool renameOverloads)
+    {
+        var result = new List<MemberIdentity>();
+
+        if (symbol.ContainingType?.TypeKind == TypeKind.Interface)
+        {
+            AddInterfaceMember(result, symbol, renameOverloads);
+            return result;
+        }
+
+        foreach (var implemented in GetImplementedInterfaceMembers(symbol))
+            AddInterfaceMember(result, implemented, renameOverloads);
+
+        return result;
+    }
+
+    private static void AddInterfaceMember(
+        List<MemberIdentity> result,
+        ISymbol interfaceMember,
+        bool renameOverloads)
+    {
+        result.Add(MemberIdentity.From(interfaceMember));
+        if (!renameOverloads || interfaceMember is not IMethodSymbol method)
+            return;
+
+        foreach (var overload in method.ContainingType.GetMembers(method.Name).OfType<IMethodSymbol>())
+            result.Add(MemberIdentity.From(overload));
+    }
+
+    private static IEnumerable<ISymbol> GetImplementedInterfaceMembers(ISymbol symbol)
+    {
+        switch (symbol)
+        {
+            case IMethodSymbol method:
+                foreach (var implemented in method.ExplicitInterfaceImplementations)
+                    yield return implemented;
+                break;
+            case IPropertySymbol property:
+                foreach (var implemented in property.ExplicitInterfaceImplementations)
+                    yield return implemented;
+                break;
+            case IEventSymbol @event:
+                foreach (var implemented in @event.ExplicitInterfaceImplementations)
+                    yield return implemented;
+                break;
+        }
+
+        var containing = symbol.ContainingType;
+        if (containing == null)
+            yield break;
+
+        foreach (var iface in containing.AllInterfaces)
+        {
+            foreach (var member in iface.GetMembers(symbol.Name))
+            {
+                var implementation = containing.FindImplementationForInterfaceMember(member);
+                if (implementation != null && SymbolEqualityComparer.Default.Equals(implementation, symbol))
+                    yield return member;
+            }
+        }
+    }
+
+    private async Task<Solution> RestoreImplementationNamesAsync(
+        Solution solution,
+        IReadOnlyList<MemberIdentity> interfaceMembers,
+        MemberIdentity? selectedImplementation,
+        string originalName,
+        string newName,
+        CancellationToken cancellationToken)
+    {
+        var spansByDocument = new Dictionary<DocumentId, HashSet<TextSpan>>();
+
+        foreach (var identity in interfaceMembers)
+        {
+            var ifaceMember = await ResolveMemberAsync(solution, identity, newName, cancellationToken);
+            if (ifaceMember == null)
+                continue;
+
+            var implementations = await SymbolFinder.FindImplementationsAsync(
+                ifaceMember,
+                solution,
+                cancellationToken: cancellationToken);
+
+            foreach (var impl in implementations)
+            {
+                if (impl is INamedTypeSymbol)
+                    continue;
+
+                if (selectedImplementation is { } selected && selected.SameMemberIgnoringName(impl))
+                    continue;
+
+                await AddImplementationNameSpansAsync(
+                    solution,
+                    impl,
+                    spansByDocument,
+                    cancellationToken);
+            }
+        }
+
+        return await ApplyNameRestoresAsync(
+            solution,
+            spansByDocument,
+            newName,
+            originalName,
+            cancellationToken);
+    }
+
+    private static async Task<ISymbol?> ResolveMemberAsync(
+        Solution solution,
+        MemberIdentity identity,
+        string name,
+        CancellationToken cancellationToken)
+    {
+        foreach (var project in solution.Projects)
+        {
+            var compilation = await project.GetCompilationAsync(cancellationToken);
+            if (compilation == null)
+                continue;
+
+            var type = compilation.GetTypeByMetadataName(identity.ContainingTypeMetadataName);
+            if (type == null)
+                continue;
+
+            foreach (var member in type.GetMembers(name))
+            {
+                if (identity.Matches(member))
+                    return member;
+            }
+        }
+
+        return null;
+    }
+
+    private static async Task AddImplementationNameSpansAsync(
+        Solution solution,
+        ISymbol implementation,
+        Dictionary<DocumentId, HashSet<TextSpan>> spansByDocument,
+        CancellationToken cancellationToken)
+    {
+        foreach (var syntaxRef in implementation.DeclaringSyntaxReferences)
+        {
+            var node = await syntaxRef.GetSyntaxAsync(cancellationToken);
+            var document = solution.GetDocument(syntaxRef.SyntaxTree);
+            if (document == null)
+                continue;
+
+            var span = TryGetDeclarationNameSpan(node);
+            if (span is { } nameSpan)
+                AddSpan(spansByDocument, document.Id, nameSpan);
+        }
+
+        var references = await SymbolFinder.FindReferencesAsync(
+            implementation,
+            solution,
+            cancellationToken);
+
+        foreach (var referenced in references)
+        {
+            // Renamer cascades to the interface member; only revert the
+            // implementing symbol and its own references.
+            if (referenced.Definition.ContainingType?.TypeKind == TypeKind.Interface)
+                continue;
+
+            foreach (var location in referenced.Locations)
+            {
+                if (location.IsImplicit || !location.Location.IsInSource)
+                    continue;
+
+                AddSpan(spansByDocument, location.Document.Id, location.Location.SourceSpan);
+            }
+        }
+    }
+
+    private static TextSpan? TryGetDeclarationNameSpan(SyntaxNode node)
+    {
+        return node switch
+        {
+            MethodDeclarationSyntax method => method.Identifier.Span,
+            PropertyDeclarationSyntax property => property.Identifier.Span,
+            EventDeclarationSyntax @event => @event.Identifier.Span,
+            VariableDeclaratorSyntax variable => variable.Identifier.Span,
+            EventFieldDeclarationSyntax eventField =>
+                eventField.Declaration.Variables.FirstOrDefault()?.Identifier.Span,
+            _ => null
+        };
+    }
+
+    private static async Task<Solution> ApplyNameRestoresAsync(
+        Solution solution,
+        Dictionary<DocumentId, HashSet<TextSpan>> spansByDocument,
+        string currentName,
+        string originalName,
+        CancellationToken cancellationToken)
+    {
+        foreach (var (documentId, spans) in spansByDocument)
+        {
+            var document = solution.GetDocument(documentId);
+            if (document == null)
+                continue;
+
+            var text = await document.GetTextAsync(cancellationToken);
+            var changes = spans
+                .Where(span => span.End <= text.Length
+                    && string.Equals(text.ToString(span), currentName, StringComparison.Ordinal))
+                .OrderBy(span => span.Start)
+                .Select(span => new TextChange(span, originalName))
+                .ToList();
+
+            if (changes.Count == 0)
+                continue;
+
+            solution = document.WithText(text.WithChanges(changes)).Project.Solution;
+        }
+
+        return solution;
+    }
+
+    private static void AddSpan(
+        Dictionary<DocumentId, HashSet<TextSpan>> spansByDocument,
+        DocumentId documentId,
+        TextSpan span)
+    {
+        if (!spansByDocument.TryGetValue(documentId, out var spans))
+        {
+            spans = [];
+            spansByDocument[documentId] = spans;
+        }
+
+        spans.Add(span);
+    }
+
+    private static string GetFullMetadataName(INamedTypeSymbol type)
+    {
+        var parts = new List<string>();
+        for (var current = type; current != null; current = current.ContainingType)
+            parts.Add(current.MetadataName);
+
+        parts.Reverse();
+        var typeName = string.Join("+", parts);
+        return type.ContainingNamespace.IsGlobalNamespace
+            ? typeName
+            : type.ContainingNamespace.ToDisplayString() + "." + typeName;
+    }
+
+    private static string[] GetParameterTypeKeys(ISymbol symbol)
+    {
+        var parameters = symbol switch
+        {
+            IMethodSymbol method => method.Parameters,
+            IPropertySymbol property => property.Parameters,
+            _ => default
+        };
+
+        if (parameters.IsDefaultOrEmpty)
+            return [];
+
+        return parameters
+            .Select(p => $"{p.RefKind}:{p.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}")
+            .ToArray();
+    }
+
+    private readonly record struct MemberIdentity(
+        string ContainingTypeMetadataName,
+        Microsoft.CodeAnalysis.SymbolKind Kind,
+        int Arity,
+        string[] ParameterTypeKeys)
+    {
+        public bool Matches(ISymbol symbol)
+        {
+            if (symbol.Kind != Kind)
+                return false;
+
+            if (symbol is IMethodSymbol method && method.Arity != Arity)
+                return false;
+
+            return GetParameterTypeKeys(symbol).SequenceEqual(ParameterTypeKeys, StringComparer.Ordinal);
+        }
+
+        public bool SameMemberIgnoringName(ISymbol symbol)
+        {
+            return symbol.ContainingType != null
+                && ContainingTypeMetadataName == GetFullMetadataName(symbol.ContainingType)
+                && Matches(symbol);
+        }
+
+        public static MemberIdentity From(ISymbol symbol)
+        {
+            var type = symbol.ContainingType
+                ?? throw new ArgumentException("Symbol must be a type member.", nameof(symbol));
+
+            return new MemberIdentity(
+                GetFullMetadataName(type),
+                symbol.Kind,
+                symbol is IMethodSymbol method ? method.Arity : 0,
+                GetParameterTypeKeys(symbol));
+        }
     }
 }

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Rename/RenameSymbolImplementationsTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Rename/RenameSymbolImplementationsTests.cs
@@ -232,6 +232,158 @@ public class RenameSymbolImplementationsTests
         Assert.DoesNotContain("public int Amount { get; set; }", await File.ReadAllTextAsync(workspace.SecondarySourcePath));
     }
 
+    [SkippableFact]
+    public async Task RenameSymbol_RenameImplementationsFalse_DoesNotRestoreOtherProjectWithSameInterfaceName()
+    {
+        const string earlierInterface = """
+            namespace TestApp;
+
+            public interface IWorker
+            {
+                void Execute();
+            }
+            """;
+        const string earlierImplementation = """
+            namespace TestApp;
+
+            public class Worker : IWorker
+            {
+                public void Execute()
+                {
+                }
+            }
+            """;
+        const string laterInterface = """
+            namespace TestApp;
+
+            public interface IWorker
+            {
+                void Process();
+            }
+            """;
+        const string laterImplementation = """
+            namespace TestApp;
+
+            public class Worker : IWorker
+            {
+                public void Process()
+                {
+                }
+            }
+
+            public class ExplicitWorker : IWorker
+            {
+                void IWorker.Process()
+                {
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateTwoProjectSolutionAsync(
+            "Other",
+            [("IWorker.cs", earlierInterface), ("Worker.cs", earlierImplementation)],
+            "App",
+            [("IWorker.cs", laterInterface), ("Worker.cs", laterImplementation)]);
+        var operation = new RenameSymbolOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new RenameSymbolParams
+        {
+            SourceFile = workspace.SourcePath,
+            SymbolName = "Process",
+            NewName = "Execute",
+            RenameImplementations = false
+        });
+
+        Assert.True(result.Success);
+
+        var appInterface = await File.ReadAllTextAsync(workspace.SourcePath);
+        var appImpl = await File.ReadAllTextAsync(workspace.SecondarySourcePath);
+        var otherInterface = await File.ReadAllTextAsync(workspace.EarlierSourcePath);
+        var otherImpl = await File.ReadAllTextAsync(workspace.EarlierSecondaryPath);
+
+        Assert.Contains("void Execute();", appInterface);
+        Assert.DoesNotContain("void Process();", appInterface);
+        Assert.Contains("public void Process()", appImpl);
+        Assert.DoesNotContain("public void Execute()", appImpl);
+        Assert.Contains("void IWorker.Process()", appImpl);
+        Assert.DoesNotContain("void IWorker.Execute()", appImpl);
+
+        Assert.Contains("void Execute();", otherInterface);
+        Assert.DoesNotContain("void Process();", otherInterface);
+        Assert.Contains("public void Execute()", otherImpl);
+        Assert.DoesNotContain("public void Process()", otherImpl);
+    }
+
+    [SkippableFact]
+    public async Task RenameSymbol_VerbatimKeyword_RenameImplementationsFalse_RestoresEscapedName()
+    {
+        const string iface = """
+            namespace TestApp;
+
+            public interface IWorker
+            {
+                void @class();
+            }
+            """;
+        const string impl = """
+            namespace TestApp;
+
+            public class Worker : IWorker
+            {
+                public void @class()
+                {
+                }
+            }
+
+            public class ExplicitWorker : IWorker
+            {
+                void IWorker.@class()
+                {
+                }
+            }
+
+            public class Consumer
+            {
+                public void Use(IWorker contract, Worker impl)
+                {
+                    contract.@class();
+                    impl.@class();
+                }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(
+            ("IWorker.cs", iface),
+            ("Worker.cs", impl));
+        var operation = new RenameSymbolOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new RenameSymbolParams
+        {
+            SourceFile = workspace.SourcePath,
+            SymbolName = "class",
+            NewName = "Execute",
+            RenameImplementations = false
+        });
+
+        Assert.True(result.Success);
+
+        var interfaceText = await File.ReadAllTextAsync(workspace.SourcePath);
+        var implementationText = await File.ReadAllTextAsync(workspace.SecondarySourcePath);
+
+        Assert.Contains("void Execute();", interfaceText);
+        Assert.DoesNotContain("void @class();", interfaceText);
+        Assert.Contains("public void @class()", implementationText);
+        Assert.DoesNotContain("public void class()", implementationText);
+        Assert.DoesNotContain("public void Execute()", implementationText);
+        Assert.Contains("void IWorker.@class()", implementationText);
+        Assert.DoesNotContain("void IWorker.class()", implementationText);
+        Assert.DoesNotContain("void IWorker.Execute()", implementationText);
+        Assert.Contains("contract.Execute();", implementationText);
+        Assert.Contains("impl.@class();", implementationText);
+        Assert.DoesNotContain("impl.class();", implementationText);
+        Assert.DoesNotContain("impl.Execute();", implementationText);
+    }
+
     private sealed class TempWorkspace : IAsyncDisposable
     {
         public required string DirectoryPath { get; init; }
@@ -239,6 +391,8 @@ public class RenameSymbolImplementationsTests
         public required string SourcePath { get; init; }
         public required WorkspaceContext Context { get; init; }
         public string SecondarySourcePath { get; init; } = "";
+        public string EarlierSourcePath { get; init; } = "";
+        public string EarlierSecondaryPath { get; init; } = "";
 
         public static Task<TempWorkspace> CreateAsync(string source, string fileName = "Foo.cs") =>
             CreateAsync((fileName, source));
@@ -278,7 +432,105 @@ public class RenameSymbolImplementationsTests
             }
 
             sourcePath ??= Path.Combine(directory, "Foo.cs");
+            return await LoadAsync(directory, projectPath, sourcePath, secondary ?? "");
+        }
 
+        /// <summary>
+        /// Two independent projects in one solution. The earlier project is listed
+        /// first so a metadata-name-only lookup would see it before the target.
+        /// SourcePath is the first file of the later project.
+        /// </summary>
+        public static async Task<TempWorkspace> CreateTwoProjectSolutionAsync(
+            string earlierProjectName,
+            (string FileName, string Source)[] earlierFiles,
+            string laterProjectName,
+            (string FileName, string Source)[] laterFiles)
+        {
+            Skip.IfNot(ModuleInitializer.MsBuildAvailable, ModuleInitializer.MsBuildError ?? "MSBuild not available");
+
+            var directory = Path.Combine(Path.GetTempPath(), "RoslynMcpRenameImplXP_" + Guid.NewGuid().ToString("N"));
+            var earlierDir = Path.Combine(directory, earlierProjectName);
+            var laterDir = Path.Combine(directory, laterProjectName);
+            Directory.CreateDirectory(earlierDir);
+            Directory.CreateDirectory(laterDir);
+
+            const string csproj = """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net9.0</TargetFramework>
+                    <Nullable>enable</Nullable>
+                  </PropertyGroup>
+                </Project>
+                """;
+            await File.WriteAllTextAsync(Path.Combine(earlierDir, earlierProjectName + ".csproj"), csproj);
+            await File.WriteAllTextAsync(Path.Combine(laterDir, laterProjectName + ".csproj"), csproj);
+
+            string? earlierSource = null;
+            string? earlierSecondary = null;
+            foreach (var (fileName, source) in earlierFiles)
+            {
+                var path = Path.Combine(earlierDir, fileName);
+                await File.WriteAllTextAsync(path, source);
+                if (earlierSource == null)
+                    earlierSource = path;
+                else
+                    earlierSecondary ??= path;
+            }
+
+            string? laterSource = null;
+            string? laterSecondary = null;
+            foreach (var (fileName, source) in laterFiles)
+            {
+                var path = Path.Combine(laterDir, fileName);
+                await File.WriteAllTextAsync(path, source);
+                if (laterSource == null)
+                    laterSource = path;
+                else
+                    laterSecondary ??= path;
+            }
+
+            laterSource ??= Path.Combine(laterDir, "IWorker.cs");
+            earlierSource ??= Path.Combine(earlierDir, "IWorker.cs");
+
+            var solutionPath = Path.Combine(directory, "TestApp.sln");
+            await File.WriteAllTextAsync(solutionPath, $$"""
+                Microsoft Visual Studio Solution File, Format Version 12.00
+                # Visual Studio Version 17
+                Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "{{earlierProjectName}}", "{{earlierProjectName}}\{{earlierProjectName}}.csproj", "{11111111-1111-1111-1111-111111111111}"
+                EndProject
+                Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "{{laterProjectName}}", "{{laterProjectName}}\{{laterProjectName}}.csproj", "{22222222-2222-2222-2222-222222222222}"
+                EndProject
+                Global
+                	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                		Debug|Any CPU = Debug|Any CPU
+                	EndGlobalSection
+                	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                		{11111111-1111-1111-1111-111111111111}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                		{11111111-1111-1111-1111-111111111111}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                		{22222222-2222-2222-2222-222222222222}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                		{22222222-2222-2222-2222-222222222222}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                	EndGlobalSection
+                EndGlobal
+                """);
+
+            var workspace = await LoadAsync(
+                directory,
+                solutionPath,
+                laterSource,
+                laterSecondary ?? "",
+                earlierSource,
+                earlierSecondary ?? "");
+            return workspace;
+        }
+
+        private static async Task<TempWorkspace> LoadAsync(
+            string directory,
+            string projectPath,
+            string sourcePath,
+            string secondarySourcePath,
+            string earlierSourcePath = "",
+            string earlierSecondaryPath = "")
+        {
             try
             {
                 var provider = new MSBuildWorkspaceProvider();
@@ -294,7 +546,9 @@ public class RenameSymbolImplementationsTests
                     DirectoryPath = directory,
                     ProjectPath = projectPath,
                     SourcePath = sourcePath,
-                    SecondarySourcePath = secondary ?? "",
+                    SecondarySourcePath = secondarySourcePath,
+                    EarlierSourcePath = earlierSourcePath,
+                    EarlierSecondaryPath = earlierSecondaryPath,
                     Context = context
                 };
             }

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Rename/RenameSymbolImplementationsTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Rename/RenameSymbolImplementationsTests.cs
@@ -1,0 +1,333 @@
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.Refactoring.Rename;
+using RoslynMcp.Core.Workspace;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Refactoring.Rename;
+
+/// <summary>
+/// Operation-level tests for <see cref="RenameSymbolOperation"/>
+/// <c>renameImplementations</c> (UC-R1 BR-R1.4).
+/// </summary>
+public class RenameSymbolImplementationsTests
+{
+    private const string InterfaceSource = """
+        namespace TestApp;
+
+        public interface IWorker
+        {
+            void Process();
+        }
+        """;
+
+    private const string ImplementationSource = """
+        namespace TestApp;
+
+        public class Worker : IWorker
+        {
+            public void Process()
+            {
+            }
+        }
+
+        public class ExplicitWorker : IWorker
+        {
+            void IWorker.Process()
+            {
+            }
+        }
+
+        public class Consumer
+        {
+            public void Use(IWorker contract, Worker impl)
+            {
+                contract.Process();
+                impl.Process();
+            }
+        }
+        """;
+
+    [SkippableFact]
+    public async Task RenameSymbol_Default_RenamesImplicitAndExplicitImplementations()
+    {
+        await using var workspace = await TempWorkspace.CreateAsync(
+            ("IWorker.cs", InterfaceSource),
+            ("Worker.cs", ImplementationSource));
+        var operation = new RenameSymbolOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new RenameSymbolParams
+        {
+            SourceFile = workspace.SourcePath,
+            SymbolName = "Process",
+            NewName = "Execute"
+        });
+
+        Assert.True(result.Success);
+        Assert.False(result.Preview);
+
+        var iface = await File.ReadAllTextAsync(workspace.SourcePath);
+        var impl = await File.ReadAllTextAsync(workspace.SecondarySourcePath);
+
+        Assert.Contains("void Execute();", iface);
+        Assert.DoesNotContain("void Process();", iface);
+        Assert.Contains("public void Execute()", impl);
+        Assert.DoesNotContain("public void Process()", impl);
+        Assert.Contains("void IWorker.Execute()", impl);
+        Assert.DoesNotContain("void IWorker.Process()", impl);
+        Assert.Contains("contract.Execute();", impl);
+        Assert.Contains("impl.Execute();", impl);
+        Assert.DoesNotContain("contract.Process();", impl);
+        Assert.DoesNotContain("impl.Process();", impl);
+    }
+
+    [SkippableFact]
+    public async Task RenameSymbol_RenameImplementationsTrue_RenamesImplementations()
+    {
+        await using var workspace = await TempWorkspace.CreateAsync(
+            ("IWorker.cs", InterfaceSource),
+            ("Worker.cs", ImplementationSource));
+        var operation = new RenameSymbolOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new RenameSymbolParams
+        {
+            SourceFile = workspace.SourcePath,
+            SymbolName = "Process",
+            NewName = "Execute",
+            RenameImplementations = true
+        });
+
+        Assert.True(result.Success);
+
+        var impl = await File.ReadAllTextAsync(workspace.SecondarySourcePath);
+        Assert.Contains("public void Execute()", impl);
+        Assert.Contains("void IWorker.Execute()", impl);
+        Assert.Contains("impl.Execute();", impl);
+    }
+
+    [SkippableFact]
+    public async Task RenameSymbol_RenameImplementationsFalse_LeavesImplementingMembers()
+    {
+        await using var workspace = await TempWorkspace.CreateAsync(
+            ("IWorker.cs", InterfaceSource),
+            ("Worker.cs", ImplementationSource));
+        var operation = new RenameSymbolOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new RenameSymbolParams
+        {
+            SourceFile = workspace.SourcePath,
+            SymbolName = "Process",
+            NewName = "Execute",
+            RenameImplementations = false
+        });
+
+        Assert.True(result.Success);
+        Assert.False(result.Preview);
+
+        var iface = await File.ReadAllTextAsync(workspace.SourcePath);
+        var impl = await File.ReadAllTextAsync(workspace.SecondarySourcePath);
+
+        Assert.Contains("void Execute();", iface);
+        Assert.DoesNotContain("void Process();", iface);
+        Assert.Contains("public void Process()", impl);
+        Assert.DoesNotContain("public void Execute()", impl);
+        Assert.Contains("void IWorker.Process()", impl);
+        Assert.DoesNotContain("void IWorker.Execute()", impl);
+        Assert.Contains("contract.Execute();", impl);
+        Assert.Contains("impl.Process();", impl);
+        Assert.DoesNotContain("contract.Process();", impl);
+        Assert.DoesNotContain("impl.Execute();", impl);
+    }
+
+    [SkippableFact]
+    public async Task RenameSymbol_RenameImplementationsFalse_PreviewWritesNothing()
+    {
+        await using var workspace = await TempWorkspace.CreateAsync(
+            ("IWorker.cs", InterfaceSource),
+            ("Worker.cs", ImplementationSource));
+        var originalInterface = await File.ReadAllTextAsync(workspace.SourcePath);
+        var originalImplementation = await File.ReadAllTextAsync(workspace.SecondarySourcePath);
+        var operation = new RenameSymbolOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new RenameSymbolParams
+        {
+            SourceFile = workspace.SourcePath,
+            SymbolName = "Process",
+            NewName = "Execute",
+            RenameImplementations = false,
+            Preview = true
+        });
+
+        Assert.True(result.Success);
+        Assert.True(result.Preview);
+        Assert.NotNull(result.PendingChanges);
+        Assert.NotEmpty(result.PendingChanges);
+        Assert.Equal(originalInterface, await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Equal(originalImplementation, await File.ReadAllTextAsync(workspace.SecondarySourcePath));
+        Assert.Contains("void Process();", await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("public void Process()", await File.ReadAllTextAsync(workspace.SecondarySourcePath));
+        Assert.Contains("void IWorker.Process()", await File.ReadAllTextAsync(workspace.SecondarySourcePath));
+    }
+
+    [SkippableFact]
+    public async Task RenameSymbol_RenameImplementationsTrue_PreviewWritesNothing()
+    {
+        await using var workspace = await TempWorkspace.CreateAsync(
+            ("IWorker.cs", InterfaceSource),
+            ("Worker.cs", ImplementationSource));
+        var originalInterface = await File.ReadAllTextAsync(workspace.SourcePath);
+        var originalImplementation = await File.ReadAllTextAsync(workspace.SecondarySourcePath);
+        var operation = new RenameSymbolOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new RenameSymbolParams
+        {
+            SourceFile = workspace.SourcePath,
+            SymbolName = "Process",
+            NewName = "Execute",
+            RenameImplementations = true,
+            Preview = true
+        });
+
+        Assert.True(result.Success);
+        Assert.True(result.Preview);
+        Assert.Equal(originalInterface, await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Equal(originalImplementation, await File.ReadAllTextAsync(workspace.SecondarySourcePath));
+    }
+
+    [SkippableFact]
+    public async Task RenameSymbol_Property_RenameImplementationsFalse_LeavesImplementingProperty()
+    {
+        const string iface = """
+            namespace TestApp;
+
+            public interface IWidget
+            {
+                int Value { get; set; }
+            }
+            """;
+        const string impl = """
+            namespace TestApp;
+
+            public class Widget : IWidget
+            {
+                public int Value { get; set; }
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(
+            ("IWidget.cs", iface),
+            ("Widget.cs", impl));
+        var operation = new RenameSymbolOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new RenameSymbolParams
+        {
+            SourceFile = workspace.SourcePath,
+            SymbolName = "Value",
+            NewName = "Amount",
+            RenameImplementations = false
+        });
+
+        Assert.True(result.Success);
+        Assert.Contains("int Amount { get; set; }", await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("public int Value { get; set; }", await File.ReadAllTextAsync(workspace.SecondarySourcePath));
+        Assert.DoesNotContain("public int Amount { get; set; }", await File.ReadAllTextAsync(workspace.SecondarySourcePath));
+    }
+
+    private sealed class TempWorkspace : IAsyncDisposable
+    {
+        public required string DirectoryPath { get; init; }
+        public required string ProjectPath { get; init; }
+        public required string SourcePath { get; init; }
+        public required WorkspaceContext Context { get; init; }
+        public string SecondarySourcePath { get; init; } = "";
+
+        public static Task<TempWorkspace> CreateAsync(string source, string fileName = "Foo.cs") =>
+            CreateAsync((fileName, source));
+
+        public static Task<TempWorkspace> CreateAsync(params (string FileName, string Source)[] files) =>
+            CreateAsync("""
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net9.0</TargetFramework>
+                    <Nullable>enable</Nullable>
+                  </PropertyGroup>
+                </Project>
+                """, files);
+
+        public static async Task<TempWorkspace> CreateAsync(
+            string projectXml,
+            params (string FileName, string Source)[] files)
+        {
+            Skip.IfNot(ModuleInitializer.MsBuildAvailable, ModuleInitializer.MsBuildError ?? "MSBuild not available");
+
+            var directory = Path.Combine(Path.GetTempPath(), "RoslynMcpRenameImpl_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(directory);
+
+            var projectPath = Path.Combine(directory, "TestApp.csproj");
+            await File.WriteAllTextAsync(projectPath, projectXml);
+
+            string? sourcePath = null;
+            string? secondary = null;
+            foreach (var (fileName, source) in files)
+            {
+                var path = Path.Combine(directory, fileName);
+                await File.WriteAllTextAsync(path, source);
+                if (sourcePath == null)
+                    sourcePath = path;
+                else
+                    secondary ??= path;
+            }
+
+            sourcePath ??= Path.Combine(directory, "Foo.cs");
+
+            try
+            {
+                var provider = new MSBuildWorkspaceProvider();
+                var context = await provider.CreateContextAsync(projectPath);
+                if (context.GetDocumentByPath(sourcePath) == null)
+                {
+                    context.Dispose();
+                    throw new InvalidOperationException($"Workspace loaded but did not include {sourcePath}.");
+                }
+
+                return new TempWorkspace
+                {
+                    DirectoryPath = directory,
+                    ProjectPath = projectPath,
+                    SourcePath = sourcePath,
+                    SecondarySourcePath = secondary ?? "",
+                    Context = context
+                };
+            }
+            catch (Exception ex) when (ex is not SkipException)
+            {
+                try
+                {
+                    Directory.Delete(directory, recursive: true);
+                }
+                catch
+                {
+                    // ignore cleanup failures
+                }
+
+                Skip.If(true, $"Workspace load failed: {ex.Message}");
+                throw;
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            Context.Dispose();
+            await Task.Run(() =>
+            {
+                try
+                {
+                    Directory.Delete(DirectoryPath, recursive: true);
+                }
+                catch
+                {
+                    // ignore locked temp files
+                }
+            });
+        }
+    }
+}

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Rename/RenameSymbolOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Rename/RenameSymbolOperationTests.cs
@@ -286,6 +286,37 @@ public class RenameSymbolOperationTests
 
     #endregion
 
+    #region Rename Implementations Flag Tests
+
+    [Fact]
+    public void RenameSymbol_RenameImplementations_DefaultsTrue()
+    {
+        var @params = new RenameSymbolParams
+        {
+            SourceFile = "C:\\test\\file.cs",
+            SymbolName = "Process",
+            NewName = "Execute"
+        };
+
+        Assert.True(@params.RenameImplementations);
+    }
+
+    [Fact]
+    public void RenameSymbol_RenameImplementations_CanBeDisabled()
+    {
+        var @params = new RenameSymbolParams
+        {
+            SourceFile = "C:\\test\\file.cs",
+            SymbolName = "Process",
+            NewName = "Execute",
+            RenameImplementations = false
+        };
+
+        Assert.False(@params.RenameImplementations);
+    }
+
+    #endregion
+
     #region Helper Methods
 
     /// <summary>

--- a/tests/RoslynMcp.Server.Tests/Tools/RenameSymbolToolTests.cs
+++ b/tests/RoslynMcp.Server.Tests/Tools/RenameSymbolToolTests.cs
@@ -93,9 +93,10 @@ public class RenameSymbolToolTests
         Assert.True(properties.TryGetProperty("line", out _));
         Assert.True(properties.TryGetProperty("column", out _));
         Assert.True(properties.TryGetProperty("renameOverloads", out _));
-        Assert.True(properties.TryGetProperty("renameImplementations", out _));
+        Assert.True(properties.TryGetProperty("renameImplementations", out var renameImplementations));
         Assert.True(properties.TryGetProperty("renameFile", out _));
         Assert.True(properties.TryGetProperty("preview", out _));
+        Assert.True(renameImplementations.GetProperty("default").GetBoolean());
     }
 
     #endregion


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

`rename_symbol` already exposed `renameImplementations` (default `true`) on the MCP tool and `RenameSymbolParams`, but `RenameSymbolOperation` never read it. Roslyn's `SymbolRenameOptions` has no implementations flag, so `Renamer.RenameSymbolAsync` always updates interface implementations.

This change honors the existing flag in `RenameSymbolOperation`:

- **`renameImplementations: true` (default):** today's behavior — implementing members rename with the interface member.
- **`renameImplementations: false`:** rename the selected symbol and its non-implementation references; implicit and explicit implementations keep the original name (may break compilation, as specified in UC-R1 AF-R1.2).
- **Preview:** still writes nothing.

No new MCP tool. No new error codes.

Review follow-ups on this PR:
- Scope `MemberIdentity` / `ResolveMemberAsync` to the defining project and assembly so a same-named interface in another project cannot steal restore.
- Recover verbatim identifier spelling (`@class`) when restoring names so reserved keywords stay valid C#.

## Related Issues

Closes #78

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Test additions or updates

## Testing

- Default / explicit `true` still renames implicit and explicit implementations and their references.
- `false` leaves implementing members (methods and properties) and implementation-typed call sites; interface declarations and interface-typed call sites are updated.
- Preview with either value writes nothing.
- Cross-project collision: an earlier project that already has the new name is left alone.
- Verbatim keyword (`@class`) is restored with the `@` prefix.

**Test Configuration**:
- OS: Linux
- .NET Version: 9.0.317

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a86ad404-b859-4b4b-92a0-d896f3e1228e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a86ad404-b859-4b4b-92a0-d896f3e1228e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

