### PR TITLE
Honor move_type_to_namespace updateFileLocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Changed
+- `move_type_to_namespace` now honors `updateFileLocation`: when true, moves the source file to a folder matching the target namespace (e.g. `MyApp.Services` → `MyApp/Services/`), creating missing directories and updating project document paths / explicit compile items; preview writes nothing (including folders); rejects destination-exists, file-name collision, uneditable project, and missing file. Default `false` keeps today's namespace-only rewrite.
+
 ### Added
 - `pull_members_up` — move selected members from a derived type onto an existing base class or interface, with preview mode and rejects for missing bases, interface-incompatible members, and name/signature conflicts
 - `push_members_down` — move selected members from a base type down onto derived types, with optional named targets, preview mode, and rejects for missing derived types, conflicts, interface-incompatible members, and uneditable targets

--- a/src/RoslynMcp.Core/Refactoring/MoveTypeToNamespaceOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/MoveTypeToNamespaceOperation.cs
@@ -8,6 +8,7 @@ using RoslynMcp.Contracts.Enums;
 using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
+using RoslynMcp.Core.Refactoring.Rename;
 using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 
@@ -77,13 +78,17 @@ public sealed class MoveTypeToNamespaceOperation
                 references,
                 cancellationToken);
 
-            // If preview mode, return without applying
+            FileLocationPlan? filePlan = null;
+            if (@params.UpdateFileLocation)
+                filePlan = PlanFileLocationUpdate(resolution, @params.TargetNamespace);
+
+            // If preview mode, return without applying (including folders)
             if (@params.Preview)
             {
-                return CreatePreviewResult(operationId, @params, resolution, changeStats);
+                return CreatePreviewResult(operationId, @params, resolution, changeStats, filePlan);
             }
 
-            // Commit changes
+            // Commit text changes at the current document path first
             var commitResult = await _context.CommitChangesAsync(newSolution, cancellationToken);
 
             if (!commitResult.Success)
@@ -91,6 +96,22 @@ public sealed class MoveTypeToNamespaceOperation
                 throw new RefactoringException(
                     ErrorCodes.FilesystemError,
                     $"Failed to write files: {commitResult.Error}");
+            }
+
+            var filesModified = commitResult.FilesModified.ToList();
+            var filesCreated = commitResult.FilesCreated.ToList();
+            var filesDeleted = commitResult.FilesDeleted.ToList();
+
+            if (filePlan != null)
+            {
+                ApplyFileLocationUpdate(filePlan);
+                filesModified = filesModified
+                    .Select(path => RemapCommittedPath(path, filePlan))
+                    .ToList();
+                if (filePlan.ProjectText != null && filePlan.ProjectPath != null)
+                    filesModified.Add(filePlan.ProjectPath);
+                filesCreated.Add(filePlan.DestinationFile);
+                filesDeleted.Add(filePlan.SourceFile);
             }
 
             stopwatch.Stop();
@@ -101,11 +122,11 @@ public sealed class MoveTypeToNamespaceOperation
                 OperationId = operationId,
                 Changes = new FileChanges
                 {
-                    FilesModified = commitResult.FilesModified,
-                    FilesCreated = commitResult.FilesCreated,
-                    FilesDeleted = commitResult.FilesDeleted
+                    FilesModified = filesModified,
+                    FilesCreated = filesCreated,
+                    FilesDeleted = filesDeleted
                 },
-                Symbol = CreateSymbolInfo(resolution, @params.TargetNamespace),
+                Symbol = CreateSymbolInfo(resolution, @params.TargetNamespace, filePlan?.DestinationFile),
                 ReferencesUpdated = references.TotalReferenceCount,
                 UsingDirectivesAdded = changeStats.UsingsAdded,
                 UsingDirectivesRemoved = changeStats.UsingsRemoved,
@@ -125,7 +146,13 @@ public sealed class MoveTypeToNamespaceOperation
         }
     }
 
-    private void ValidateInputs(MoveTypeToNamespaceParams @params)
+    private void ValidateInputs(MoveTypeToNamespaceParams @params) => Validate(@params);
+
+    /// <summary>
+    /// Validates move-type-to-namespace inputs. Internal so tests can exercise
+    /// rules without loading a workspace.
+    /// </summary>
+    internal static void Validate(MoveTypeToNamespaceParams @params)
     {
         if (string.IsNullOrWhiteSpace(@params.SourceFile))
             throw new RefactoringException(ErrorCodes.MissingRequiredParam, "sourceFile is required.");
@@ -324,10 +351,209 @@ public sealed class MoveTypeToNamespaceOperation
         return (newDoc, added, removed);
     }
 
-    private Contracts.Models.SymbolInfo CreateSymbolInfo(SymbolResolutionResult resolution, string newNamespace)
+    /// <summary>
+    /// Builds the destination path for <paramref name="sourceFile"/> so it
+    /// matches <paramref name="newNamespace"/> (e.g. <c>MyApp.Services</c> →
+    /// <c>MyApp/Services/</c>). When the current folder already matches
+    /// <paramref name="oldNamespace"/>, that folder is remapped (preserving a
+    /// prefix such as <c>src/</c>); otherwise the namespace path is created
+    /// under <paramref name="projectDirectory"/>.
+    /// </summary>
+    internal static string ComputeDestinationFile(
+        string sourceFile,
+        string oldNamespace,
+        string newNamespace,
+        string projectDirectory)
+    {
+        var fileName = Path.GetFileName(sourceFile);
+        var matchingFolder = RenameNamespaceOperation.TryFindMatchingFolder(
+            sourceFile,
+            oldNamespace,
+            projectDirectory);
+
+        string destFolder;
+        if (matchingFolder != null)
+        {
+            destFolder = RenameNamespaceOperation.GetDestinationFolder(
+                matchingFolder,
+                oldNamespace,
+                newNamespace);
+        }
+        else
+        {
+            var parts = RenameNamespaceOperation.SplitNamespace(newNamespace);
+            destFolder = PathResolver.NormalizePath(
+                Path.Combine(new[] { projectDirectory }.Concat(parts).ToArray()));
+        }
+
+        return PathResolver.NormalizePath(Path.Combine(destFolder, fileName));
+    }
+
+    private FileLocationPlan? PlanFileLocationUpdate(
+        SymbolResolutionResult resolution,
+        string newNamespace)
+    {
+        var document = resolution.Document;
+        if (string.IsNullOrWhiteSpace(document.FilePath) || !File.Exists(document.FilePath))
+        {
+            throw new RefactoringException(
+                ErrorCodes.SourceFileNotFound,
+                $"Source file not found: {document.FilePath}");
+        }
+
+        RenameFileToMatchTypeOperation.ValidateDocumentIsEditable(document, _context.Workspace);
+
+        if (string.IsNullOrWhiteSpace(document.Project.FilePath))
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Project '{document.Project.Name}' is not editable.");
+        }
+
+        var projectDirectory = Path.GetDirectoryName(document.Project.FilePath);
+        if (string.IsNullOrEmpty(projectDirectory))
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Project '{document.Project.Name}' is not editable.");
+        }
+
+        var sourceFile = PathResolver.NormalizePath(document.FilePath);
+        var oldNamespace = resolution.Symbol.ContainingNamespace.ToDisplayString();
+        var destFile = ComputeDestinationFile(sourceFile, oldNamespace, newNamespace, projectDirectory);
+
+        if (RenameFileToMatchTypeOperation.ReferToSameFile(sourceFile, destFile)
+            || string.Equals(sourceFile, destFile, StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        if (RenameFileToMatchTypeOperation.IsDestinationOccupiedByDifferentFile(sourceFile, destFile))
+        {
+            throw new RefactoringException(
+                ErrorCodes.TargetFileExists,
+                $"Destination file already exists: {destFile}");
+        }
+
+        foreach (var other in _context.Solution.Projects.SelectMany(p => p.Documents))
+        {
+            if (other.Id == document.Id || string.IsNullOrWhiteSpace(other.FilePath))
+                continue;
+
+            var otherNorm = PathResolver.NormalizePath(other.FilePath);
+            if (string.Equals(otherNorm, destFile, StringComparison.OrdinalIgnoreCase)
+                || RenameFileToMatchTypeOperation.ReferToSameFile(otherNorm, destFile))
+            {
+                throw new RefactoringException(
+                    ErrorCodes.TargetFileExists,
+                    $"File name collision after move: {destFile}");
+            }
+        }
+
+        var updatedProjectText = TryGetUpdatedProjectText(
+            document.Project.FilePath,
+            projectDirectory,
+            sourceFile,
+            destFile);
+
+        if (updatedProjectText != null && new FileInfo(document.Project.FilePath).IsReadOnly)
+        {
+            throw new RefactoringException(
+                ErrorCodes.DocumentNotEditable,
+                $"Project '{document.Project.Name}' is not editable.");
+        }
+
+        return new FileLocationPlan
+        {
+            DocumentId = document.Id,
+            SourceFile = sourceFile,
+            DestinationFile = destFile,
+            ProjectPath = updatedProjectText != null ? document.Project.FilePath : null,
+            ProjectText = updatedProjectText
+        };
+    }
+
+    private void ApplyFileLocationUpdate(FileLocationPlan plan)
+    {
+        var destDirectory = Path.GetDirectoryName(plan.DestinationFile);
+        if (string.IsNullOrEmpty(destDirectory))
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidTargetPath,
+                $"Destination file has no directory: {plan.DestinationFile}");
+        }
+
+        try
+        {
+            Directory.CreateDirectory(destDirectory);
+            RenameFileToMatchTypeOperation.MoveSourceFile(plan.SourceFile, plan.DestinationFile);
+        }
+        catch (IOException ex)
+        {
+            throw new RefactoringException(
+                ErrorCodes.FilesystemError,
+                $"Failed to move file: {ex.Message}",
+                ex);
+        }
+
+        if (plan.ProjectText != null && !string.IsNullOrWhiteSpace(plan.ProjectPath))
+        {
+            try
+            {
+                File.WriteAllText(plan.ProjectPath, plan.ProjectText);
+            }
+            catch (IOException ex)
+            {
+                throw new RefactoringException(
+                    ErrorCodes.FilesystemError,
+                    $"Failed to update project file: {ex.Message}",
+                    ex);
+            }
+        }
+
+        var updated = _context.Solution.WithDocumentFilePath(plan.DocumentId, plan.DestinationFile);
+        _context.UpdateSolution(updated);
+    }
+
+    private static string RemapCommittedPath(string path, FileLocationPlan plan)
+    {
+        var normalized = PathResolver.NormalizePath(path);
+        if (string.Equals(normalized, plan.SourceFile, StringComparison.OrdinalIgnoreCase)
+            || RenameFileToMatchTypeOperation.ReferToSameFile(normalized, plan.SourceFile))
+        {
+            return plan.DestinationFile;
+        }
+
+        return path;
+    }
+
+    private static string? TryGetUpdatedProjectText(
+        string? projectPath,
+        string projectDirectory,
+        string sourceFile,
+        string destFile)
+    {
+        if (string.IsNullOrWhiteSpace(projectPath) || !File.Exists(projectPath))
+            return null;
+
+        var original = File.ReadAllText(projectPath);
+        var updated = RenameNamespaceOperation.UpdateExplicitCompileItemsForMoves(
+            original,
+            projectDirectory,
+            [(sourceFile, destFile)]);
+        return string.Equals(original, updated, StringComparison.Ordinal) ? null : updated;
+    }
+
+    private Contracts.Models.SymbolInfo CreateSymbolInfo(
+        SymbolResolutionResult resolution,
+        string newNamespace,
+        string? newFilePath = null)
     {
         var oldNamespace = resolution.Symbol.ContainingNamespace.ToDisplayString();
         var location = resolution.Declaration.GetLocation().GetLineSpan();
+        var previousFile = resolution.Document.FilePath!;
+        var line = location.StartLinePosition.Line + 1;
+        var column = location.StartLinePosition.Character + 1;
 
         return new Contracts.Models.SymbolInfo
         {
@@ -338,9 +564,15 @@ public sealed class MoveTypeToNamespaceOperation
             NewNamespace = newNamespace,
             PreviousLocation = new SymbolLocation
             {
-                File = resolution.Document.FilePath!,
-                Line = location.StartLinePosition.Line + 1,
-                Column = location.StartLinePosition.Character + 1
+                File = previousFile,
+                Line = line,
+                Column = column
+            },
+            NewLocation = new SymbolLocation
+            {
+                File = newFilePath ?? previousFile,
+                Line = line,
+                Column = column
             }
         };
     }
@@ -363,7 +595,8 @@ public sealed class MoveTypeToNamespaceOperation
         Guid operationId,
         MoveTypeToNamespaceParams @params,
         SymbolResolutionResult resolution,
-        ChangeStats stats)
+        ChangeStats stats,
+        FileLocationPlan? filePlan)
     {
         var pendingChanges = new List<PendingChange>
         {
@@ -385,6 +618,32 @@ public sealed class MoveTypeToNamespaceOperation
             });
         }
 
+        if (filePlan != null)
+        {
+            pendingChanges.Add(new PendingChange
+            {
+                File = filePlan.SourceFile,
+                ChangeType = ChangeKind.Delete,
+                Description = $"Move file to match namespace '{@params.TargetNamespace}'"
+            });
+            pendingChanges.Add(new PendingChange
+            {
+                File = filePlan.DestinationFile,
+                ChangeType = ChangeKind.Create,
+                Description = $"Move '{filePlan.SourceFile}' to '{filePlan.DestinationFile}'"
+            });
+
+            if (filePlan.ProjectPath != null)
+            {
+                pendingChanges.Add(new PendingChange
+                {
+                    File = filePlan.ProjectPath,
+                    ChangeType = ChangeKind.Modify,
+                    Description = "Update explicit Compile item to the moved file"
+                });
+            }
+        }
+
         return RefactoringResult.PreviewResult(operationId, pendingChanges);
     }
 
@@ -392,5 +651,14 @@ public sealed class MoveTypeToNamespaceOperation
     {
         public int UsingsAdded { get; set; }
         public int UsingsRemoved { get; set; }
+    }
+
+    private sealed class FileLocationPlan
+    {
+        public required DocumentId DocumentId { get; init; }
+        public required string SourceFile { get; init; }
+        public required string DestinationFile { get; init; }
+        public string? ProjectPath { get; init; }
+        public string? ProjectText { get; init; }
     }
 }

--- a/src/RoslynMcp.Core/Refactoring/MoveTypeToNamespaceOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/MoveTypeToNamespaceOperation.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Text.RegularExpressions;
+using System.Xml.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -108,8 +109,7 @@ public sealed class MoveTypeToNamespaceOperation
                 filesModified = filesModified
                     .Select(path => RemapCommittedPath(path, filePlan))
                     .ToList();
-                if (filePlan.ProjectText != null && filePlan.ProjectPath != null)
-                    filesModified.Add(filePlan.ProjectPath);
+                filesModified.AddRange(filePlan.ProjectTexts.Keys);
                 filesCreated.Add(filePlan.DestinationFile);
                 filesDeleted.Add(filePlan.SourceFile);
             }
@@ -422,11 +422,8 @@ public sealed class MoveTypeToNamespaceOperation
         var oldNamespace = resolution.Symbol.ContainingNamespace.ToDisplayString();
         var destFile = ComputeDestinationFile(sourceFile, oldNamespace, newNamespace, projectDirectory);
 
-        if (RenameFileToMatchTypeOperation.ReferToSameFile(sourceFile, destFile)
-            || string.Equals(sourceFile, destFile, StringComparison.OrdinalIgnoreCase))
-        {
+        if (IsUnchangedFileLocation(sourceFile, destFile))
             return null;
-        }
 
         if (RenameFileToMatchTypeOperation.IsDestinationOccupiedByDifferentFile(sourceFile, destFile))
         {
@@ -435,14 +432,20 @@ public sealed class MoveTypeToNamespaceOperation
                 $"Destination file already exists: {destFile}");
         }
 
+        var linkedDocuments = FindDocumentsAtPath(_context.Solution, sourceFile);
+        foreach (var linked in linkedDocuments)
+            RenameFileToMatchTypeOperation.ValidateDocumentIsEditable(linked, _context.Workspace);
+
         foreach (var other in _context.Solution.Projects.SelectMany(p => p.Documents))
         {
-            if (other.Id == document.Id || string.IsNullOrWhiteSpace(other.FilePath))
+            if (string.IsNullOrWhiteSpace(other.FilePath))
                 continue;
 
             var otherNorm = PathResolver.NormalizePath(other.FilePath);
-            if (string.Equals(otherNorm, destFile, StringComparison.OrdinalIgnoreCase)
-                || RenameFileToMatchTypeOperation.ReferToSameFile(otherNorm, destFile))
+            if (IsSameDocumentPath(otherNorm, sourceFile))
+                continue;
+
+            if (IsSameDocumentPath(otherNorm, destFile))
             {
                 throw new RefactoringException(
                     ErrorCodes.TargetFileExists,
@@ -450,26 +453,51 @@ public sealed class MoveTypeToNamespaceOperation
             }
         }
 
-        var updatedProjectText = TryGetUpdatedProjectText(
-            document.Project.FilePath,
-            projectDirectory,
-            sourceFile,
-            destFile);
-
-        if (updatedProjectText != null && new FileInfo(document.Project.FilePath).IsReadOnly)
+        var projectTexts = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var linked in linkedDocuments)
         {
-            throw new RefactoringException(
-                ErrorCodes.DocumentNotEditable,
-                $"Project '{document.Project.Name}' is not editable.");
+            if (string.IsNullOrWhiteSpace(linked.Project.FilePath))
+            {
+                throw new RefactoringException(
+                    ErrorCodes.DocumentNotEditable,
+                    $"Project '{linked.Project.Name}' is not editable.");
+            }
+
+            if (projectTexts.ContainsKey(linked.Project.FilePath))
+                continue;
+
+            var linkedProjectDirectory = Path.GetDirectoryName(linked.Project.FilePath);
+            if (string.IsNullOrEmpty(linkedProjectDirectory))
+            {
+                throw new RefactoringException(
+                    ErrorCodes.DocumentNotEditable,
+                    $"Project '{linked.Project.Name}' is not editable.");
+            }
+
+            var updatedProjectText = TryGetUpdatedProjectText(
+                linked.Project.FilePath,
+                linkedProjectDirectory,
+                sourceFile,
+                destFile);
+            if (updatedProjectText == null)
+                continue;
+
+            if (new FileInfo(linked.Project.FilePath).IsReadOnly)
+            {
+                throw new RefactoringException(
+                    ErrorCodes.DocumentNotEditable,
+                    $"Project '{linked.Project.Name}' is not editable.");
+            }
+
+            projectTexts[linked.Project.FilePath] = updatedProjectText;
         }
 
         return new FileLocationPlan
         {
-            DocumentId = document.Id,
+            DocumentIds = linkedDocuments.Select(d => d.Id).ToList(),
             SourceFile = sourceFile,
             DestinationFile = destFile,
-            ProjectPath = updatedProjectText != null ? document.Project.FilePath : null,
-            ProjectText = updatedProjectText
+            ProjectTexts = projectTexts
         };
     }
 
@@ -496,11 +524,11 @@ public sealed class MoveTypeToNamespaceOperation
                 ex);
         }
 
-        if (plan.ProjectText != null && !string.IsNullOrWhiteSpace(plan.ProjectPath))
+        foreach (var (projectPath, projectText) in plan.ProjectTexts)
         {
             try
             {
-                File.WriteAllText(plan.ProjectPath, plan.ProjectText);
+                File.WriteAllText(projectPath, projectText);
             }
             catch (IOException ex)
             {
@@ -511,18 +539,68 @@ public sealed class MoveTypeToNamespaceOperation
             }
         }
 
-        var updated = _context.Solution.WithDocumentFilePath(plan.DocumentId, plan.DestinationFile);
+        var updated = _context.Solution;
+        foreach (var documentId in plan.DocumentIds)
+            updated = updated.WithDocumentFilePath(documentId, plan.DestinationFile);
         _context.UpdateSolution(updated);
+    }
+
+    /// <summary>
+    /// True when <paramref name="sourceFile"/> and <paramref name="destFile"/>
+    /// identify the same filesystem entry. Case-only path differences on a
+    /// case-sensitive volume are a real move and must not be skipped.
+    /// </summary>
+    internal static bool IsUnchangedFileLocation(string sourceFile, string destFile) =>
+        RenameFileToMatchTypeOperation.ReferToSameFile(sourceFile, destFile);
+
+    /// <summary>
+    /// True when an explicit Compile spec (literal, glob, or semicolon list)
+    /// includes <paramref name="filePath"/>.
+    /// </summary>
+    internal static bool CompileSpecCoversFile(string spec, string projectDirectory, string filePath)
+    {
+        foreach (var part in spec.Split(';'))
+        {
+            var trimmed = part.Trim();
+            if (trimmed.Length == 0)
+                continue;
+
+            if (RenameNamespaceOperation.ContainsMsBuildGlob(trimmed))
+            {
+                if (GlobSpecCoversFile(trimmed, projectDirectory, filePath))
+                    return true;
+                continue;
+            }
+
+            if (RenameFileToMatchTypeOperation.ProjectItemRefersToFile(projectDirectory, trimmed, filePath))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Rewrites literal Compile items and supplements globs / semicolon lists
+    /// so a file-only move stays in the project when default items are disabled.
+    /// </summary>
+    internal static string UpdateProjectTextForFileMove(
+        string projectXml,
+        string projectDirectory,
+        string sourceFile,
+        string destFile)
+    {
+        var afterLiterals = RenameNamespaceOperation.UpdateExplicitCompileItemsForMoves(
+            projectXml,
+            projectDirectory,
+            [(sourceFile, destFile)]);
+        return UpdateGlobAndListCompileItems(afterLiterals, projectDirectory, sourceFile, destFile);
     }
 
     private static string RemapCommittedPath(string path, FileLocationPlan plan)
     {
         var normalized = PathResolver.NormalizePath(path);
-        if (string.Equals(normalized, plan.SourceFile, StringComparison.OrdinalIgnoreCase)
-            || RenameFileToMatchTypeOperation.ReferToSameFile(normalized, plan.SourceFile))
-        {
+        if (IsSameDocumentPath(normalized, plan.SourceFile))
             return plan.DestinationFile;
-        }
 
         return path;
     }
@@ -537,11 +615,207 @@ public sealed class MoveTypeToNamespaceOperation
             return null;
 
         var original = File.ReadAllText(projectPath);
-        var updated = RenameNamespaceOperation.UpdateExplicitCompileItemsForMoves(
-            original,
-            projectDirectory,
-            [(sourceFile, destFile)]);
+        var updated = UpdateProjectTextForFileMove(original, projectDirectory, sourceFile, destFile);
         return string.Equals(original, updated, StringComparison.Ordinal) ? null : updated;
+    }
+
+    private static IReadOnlyList<Document> FindDocumentsAtPath(Solution solution, string filePath)
+    {
+        return solution.Projects
+            .SelectMany(project => project.Documents)
+            .Where(document =>
+                !string.IsNullOrWhiteSpace(document.FilePath)
+                && IsSameDocumentPath(PathResolver.NormalizePath(document.FilePath), filePath))
+            .ToList();
+    }
+
+    private static bool IsSameDocumentPath(string left, string right) =>
+        string.Equals(left, right, StringComparison.Ordinal)
+        || RenameFileToMatchTypeOperation.ReferToSameFile(left, right);
+
+    private static string UpdateGlobAndListCompileItems(
+        string projectXml,
+        string projectDirectory,
+        string sourceFile,
+        string destFile)
+    {
+        XDocument document;
+        try
+        {
+            document = XDocument.Parse(projectXml, LoadOptions.PreserveWhitespace | LoadOptions.SetLineInfo);
+        }
+        catch (System.Xml.XmlException)
+        {
+            return projectXml;
+        }
+
+        var ns = document.Root?.Name.Namespace ?? XNamespace.None;
+        var changed = false;
+
+        foreach (var compile in document.Descendants(ns + "Compile").ToList())
+        {
+            changed |= TryUpdateGlobOrListAttribute(compile, "Include", projectDirectory, sourceFile, destFile);
+            changed |= TryUpdateGlobOrListAttribute(compile, "Update", projectDirectory, sourceFile, destFile);
+        }
+
+        if (!changed)
+            return projectXml;
+
+        return SerializeProjectXml(document, projectXml);
+    }
+
+    private static bool TryUpdateGlobOrListAttribute(
+        XElement compile,
+        string attributeName,
+        string projectDirectory,
+        string sourceFile,
+        string destFile)
+    {
+        var attribute = compile.Attribute(attributeName);
+        if (attribute == null)
+            return false;
+
+        var spec = attribute.Value;
+        if (!spec.Contains(';') && !RenameNamespaceOperation.ContainsMsBuildGlob(spec))
+            return false;
+
+        var parts = spec.Split(';');
+        var rewritten = false;
+        for (var i = 0; i < parts.Length; i++)
+        {
+            var trimmed = parts[i].Trim();
+            if (trimmed.Length == 0 || RenameNamespaceOperation.ContainsMsBuildGlob(trimmed))
+                continue;
+            if (!RenameFileToMatchTypeOperation.ProjectItemRefersToFile(projectDirectory, trimmed, sourceFile))
+                continue;
+
+            var replacement = RenameNamespaceOperation.RewriteProjectItemToTarget(
+                trimmed,
+                projectDirectory,
+                destFile);
+            if (string.Equals(parts[i], replacement, StringComparison.Ordinal))
+                continue;
+
+            parts[i] = replacement;
+            rewritten = true;
+        }
+
+        var joined = string.Join(';', parts);
+        if (!CompileSpecCoversFile(joined, projectDirectory, destFile)
+            && CompileSpecCoversFile(joined, projectDirectory, sourceFile))
+        {
+            var destSpec = RenameNamespaceOperation.RewriteProjectItemToTarget(
+                parts[0],
+                projectDirectory,
+                destFile);
+            joined = joined + ";" + destSpec;
+            rewritten = true;
+        }
+
+        if (!rewritten || string.Equals(attribute.Value, joined, StringComparison.Ordinal))
+            return false;
+
+        attribute.Value = joined;
+        return true;
+    }
+
+    private static bool GlobSpecCoversFile(string spec, string projectDirectory, string filePath)
+    {
+        string candidate;
+        string pattern;
+        try
+        {
+            var specNative = spec.Trim()
+                .Replace('\\', Path.DirectorySeparatorChar)
+                .Replace('/', Path.DirectorySeparatorChar);
+            pattern = spec.Trim().Replace('\\', '/');
+            if (Path.IsPathRooted(specNative))
+            {
+                candidate = PathResolver.NormalizePath(filePath).Replace('\\', '/');
+                var specDir = RenameNamespaceOperation.GetGlobDirectoryPrefix(spec);
+                if (!string.IsNullOrEmpty(specDir))
+                {
+                    var specDirNative = specDir
+                        .Replace('\\', Path.DirectorySeparatorChar)
+                        .Replace('/', Path.DirectorySeparatorChar);
+                    var resolvedDir = PathResolver.NormalizePath(specDirNative).Replace('\\', '/');
+                    var specDirNormalized = specDir.Replace('\\', '/');
+                    if (pattern.StartsWith(specDirNormalized, StringComparison.OrdinalIgnoreCase))
+                        pattern = resolvedDir + pattern[specDirNormalized.Length..];
+                }
+            }
+            else
+            {
+                candidate = Path.GetRelativePath(
+                        projectDirectory,
+                        PathResolver.NormalizePath(filePath))
+                    .Replace('\\', '/');
+            }
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            return false;
+        }
+
+        var options = OperatingSystem.IsWindows()
+            ? RegexOptions.IgnoreCase | RegexOptions.CultureInvariant
+            : RegexOptions.CultureInvariant;
+        return Regex.IsMatch(candidate, GlobToRegex(pattern), options);
+    }
+
+    private static string GlobToRegex(string glob)
+    {
+        var sb = new System.Text.StringBuilder("^");
+        for (var i = 0; i < glob.Length; i++)
+        {
+            if (glob[i] == '*' && i + 1 < glob.Length && glob[i + 1] == '*')
+            {
+                i++;
+                if (i + 1 < glob.Length && glob[i + 1] == '/')
+                {
+                    i++;
+                    sb.Append("(?:.*/)?");
+                }
+                else
+                {
+                    sb.Append(".*");
+                }
+
+                continue;
+            }
+
+            sb.Append(glob[i] switch
+            {
+                '*' => "[^/]*",
+                '?' => "[^/]",
+                _ => Regex.Escape(glob[i].ToString())
+            });
+        }
+
+        sb.Append('$');
+        return sb.ToString();
+    }
+
+    private static string SerializeProjectXml(XDocument document, string originalXml)
+    {
+        var writerSettings = new System.Xml.XmlWriterSettings
+        {
+            OmitXmlDeclaration = !originalXml.Contains("<?xml", StringComparison.OrdinalIgnoreCase),
+            NewLineHandling = System.Xml.NewLineHandling.Replace,
+            NewLineChars = originalXml.Contains("\r\n", StringComparison.Ordinal) ? "\r\n" : "\n",
+            Indent = false
+        };
+
+        using var writer = new StringWriter();
+        using (var xmlWriter = System.Xml.XmlWriter.Create(writer, writerSettings))
+        {
+            document.Save(xmlWriter);
+        }
+
+        var serialized = writer.ToString();
+        if (originalXml.EndsWith('\n') && !serialized.EndsWith('\n'))
+            serialized += writerSettings.NewLineChars;
+        return serialized;
     }
 
     private Contracts.Models.SymbolInfo CreateSymbolInfo(
@@ -633,11 +907,11 @@ public sealed class MoveTypeToNamespaceOperation
                 Description = $"Move '{filePlan.SourceFile}' to '{filePlan.DestinationFile}'"
             });
 
-            if (filePlan.ProjectPath != null)
+            foreach (var projectPath in filePlan.ProjectTexts.Keys)
             {
                 pendingChanges.Add(new PendingChange
                 {
-                    File = filePlan.ProjectPath,
+                    File = projectPath,
                     ChangeType = ChangeKind.Modify,
                     Description = "Update explicit Compile item to the moved file"
                 });
@@ -655,10 +929,9 @@ public sealed class MoveTypeToNamespaceOperation
 
     private sealed class FileLocationPlan
     {
-        public required DocumentId DocumentId { get; init; }
+        public required IReadOnlyList<DocumentId> DocumentIds { get; init; }
         public required string SourceFile { get; init; }
         public required string DestinationFile { get; init; }
-        public string? ProjectPath { get; init; }
-        public string? ProjectText { get; init; }
+        public required IReadOnlyDictionary<string, string> ProjectTexts { get; init; }
     }
 }

--- a/src/RoslynMcp.Server/Tools/MoveTypeToNamespaceTool.cs
+++ b/src/RoslynMcp.Server/Tools/MoveTypeToNamespaceTool.cs
@@ -31,7 +31,7 @@ public sealed class MoveTypeToNamespaceTool : IToolHandler
     public string Name => "move_type_to_namespace";
 
     /// <inheritdoc />
-    public string Description => "Change the namespace of a C# type. Updates all using directives and qualified references.";
+    public string Description => "Change the namespace of a C# type. Updates all using directives and qualified references. When updateFileLocation is true, also moves the source file to a folder matching the target namespace.";
 
     /// <inheritdoc />
     public object InputSchema => new

--- a/tests/RoslynMcp.Core.Tests/Refactoring/MoveTypeToNamespaceOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/MoveTypeToNamespaceOperationTests.cs
@@ -1,0 +1,576 @@
+using RoslynMcp.Contracts.Enums;
+using RoslynMcp.Contracts.Errors;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.FileSystem;
+using RoslynMcp.Core.Refactoring;
+using RoslynMcp.Core.Workspace;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Refactoring;
+
+/// <summary>
+/// Operation-level tests for <see cref="MoveTypeToNamespaceOperation"/>,
+/// including <c>updateFileLocation</c>.
+/// </summary>
+public class MoveTypeToNamespaceOperationTests
+{
+    #region Input Validation
+
+    [Fact]
+    public void Validate_MissingSourceFile_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            MoveTypeToNamespaceOperation.Validate(ValidParams(sourceFile: "")));
+
+        Assert.Equal(ErrorCodes.MissingRequiredParam, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_MissingFile_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            MoveTypeToNamespaceOperation.Validate(ValidParams()));
+
+        Assert.Equal(ErrorCodes.SourceFileNotFound, ex.ErrorCode);
+    }
+
+    #endregion
+
+    #region Destination Path
+
+    [Fact]
+    public void ComputeDestinationFile_RemapsMatchingNamespaceFolder()
+    {
+        var projectDir = Path.Combine(Path.GetTempPath(), "RoslynMcpMoveNsProj");
+        var source = Path.Combine(projectDir, "Old", "Ns", "Foo.cs");
+
+        var dest = MoveTypeToNamespaceOperation.ComputeDestinationFile(
+            source,
+            "Old.Ns",
+            "New.Ns",
+            projectDir);
+
+        Assert.Equal(
+            PathResolver.NormalizePath(Path.Combine(projectDir, "New", "Ns", "Foo.cs")),
+            dest);
+    }
+
+    [Fact]
+    public void ComputeDestinationFile_UsesNamespacePathUnderProjectWhenUnmatched()
+    {
+        var projectDir = Path.Combine(Path.GetTempPath(), "RoslynMcpMoveNsRoot");
+        var source = Path.Combine(projectDir, "Foo.cs");
+
+        var dest = MoveTypeToNamespaceOperation.ComputeDestinationFile(
+            source,
+            "MyApp",
+            "MyApp.Services",
+            projectDir);
+
+        Assert.Equal(
+            PathResolver.NormalizePath(Path.Combine(projectDir, "MyApp", "Services", "Foo.cs")),
+            dest);
+    }
+
+    #endregion
+
+    #region updateFileLocation
+
+    [SkippableFact]
+    public async Task UpdateFileLocationFalse_LeavesFileAndRewritesNamespace()
+    {
+        const string source = """
+            namespace Old.Ns;
+
+            public class Foo
+            {
+            }
+            """;
+        const string consumer = """
+            using Old.Ns;
+
+            namespace Other;
+
+            public class Consumer
+            {
+                public Foo Create() => new Foo();
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(
+            ("Old/Ns/Foo.cs", source),
+            ("Consumer.cs", consumer));
+        var oldFile = workspace.GetPath("Old/Ns/Foo.cs");
+        var newFile = workspace.GetPath("New/Ns/Foo.cs");
+        var operation = new MoveTypeToNamespaceOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new MoveTypeToNamespaceParams
+        {
+            SourceFile = workspace.SourcePath,
+            SymbolName = "Foo",
+            TargetNamespace = "New.Ns",
+            UpdateFileLocation = false
+        });
+
+        Assert.True(result.Success);
+        Assert.True(File.Exists(oldFile));
+        Assert.False(File.Exists(newFile));
+        Assert.False(Directory.Exists(workspace.GetPath("New/Ns")));
+        Assert.Contains("namespace New.Ns;", await File.ReadAllTextAsync(oldFile));
+        Assert.DoesNotContain("namespace Old.Ns;", await File.ReadAllTextAsync(oldFile));
+        Assert.Contains("using New.Ns;", await File.ReadAllTextAsync(workspace.SecondarySourcePath));
+        Assert.NotNull(workspace.Context.GetDocumentByPath(oldFile));
+        Assert.Null(workspace.Context.GetDocumentByPath(newFile));
+        Assert.DoesNotContain(newFile, result.Changes!.FilesCreated);
+        Assert.DoesNotContain(oldFile, result.Changes.FilesDeleted);
+    }
+
+    [SkippableFact]
+    public async Task UpdateFileLocationTrue_MovesFileAndUpdatesNamespace()
+    {
+        const string source = """
+            namespace Old.Ns;
+
+            public class Foo
+            {
+            }
+            """;
+        const string consumer = """
+            using Old.Ns;
+
+            namespace Other;
+
+            public class Consumer
+            {
+                public Foo Create() => new Foo();
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(
+            ("Old/Ns/Foo.cs", source),
+            ("Consumer.cs", consumer));
+        var oldFile = workspace.GetPath("Old/Ns/Foo.cs");
+        var newFile = workspace.GetPath("New/Ns/Foo.cs");
+        var operation = new MoveTypeToNamespaceOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new MoveTypeToNamespaceParams
+        {
+            SourceFile = workspace.SourcePath,
+            SymbolName = "Foo",
+            TargetNamespace = "New.Ns",
+            UpdateFileLocation = true
+        });
+
+        Assert.True(result.Success);
+        Assert.False(File.Exists(oldFile));
+        Assert.True(File.Exists(newFile));
+        Assert.True(Directory.Exists(workspace.GetPath("New/Ns")));
+
+        var declaration = await File.ReadAllTextAsync(newFile);
+        Assert.Contains("namespace New.Ns;", declaration);
+        Assert.DoesNotContain("namespace Old.Ns;", declaration);
+
+        var usages = await File.ReadAllTextAsync(workspace.SecondarySourcePath);
+        Assert.Contains("using New.Ns;", usages);
+        Assert.Contains(newFile, result.Changes!.FilesCreated);
+        Assert.Contains(oldFile, result.Changes.FilesDeleted);
+        Assert.NotNull(workspace.Context.GetDocumentByPath(newFile));
+        Assert.Null(workspace.Context.GetDocumentByPath(oldFile));
+        Assert.Equal(newFile, result.Symbol!.NewLocation!.File);
+    }
+
+    [SkippableFact]
+    public async Task UpdateFileLocationTrue_Preview_WritesNothing()
+    {
+        const string source = """
+            namespace Old.Ns;
+
+            public class Foo
+            {
+            }
+            """;
+        const string consumer = """
+            using Old.Ns;
+
+            namespace Other;
+
+            public class Consumer
+            {
+                public Foo Create() => new Foo();
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(
+            ("Old/Ns/Foo.cs", source),
+            ("Consumer.cs", consumer));
+        var originalSource = await File.ReadAllTextAsync(workspace.SourcePath);
+        var originalConsumer = await File.ReadAllTextAsync(workspace.SecondarySourcePath);
+        var oldFile = workspace.GetPath("Old/Ns/Foo.cs");
+        var newFile = workspace.GetPath("New/Ns/Foo.cs");
+        var operation = new MoveTypeToNamespaceOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new MoveTypeToNamespaceParams
+        {
+            SourceFile = workspace.SourcePath,
+            SymbolName = "Foo",
+            TargetNamespace = "New.Ns",
+            UpdateFileLocation = true,
+            Preview = true
+        });
+
+        Assert.True(result.Success);
+        Assert.True(result.Preview);
+        Assert.NotNull(result.PendingChanges);
+        Assert.Contains(result.PendingChanges, c =>
+            c.ChangeType == ChangeKind.Create &&
+            string.Equals(
+                Path.GetFullPath(c.File),
+                Path.GetFullPath(newFile),
+                StringComparison.OrdinalIgnoreCase));
+
+        Assert.True(File.Exists(oldFile));
+        Assert.False(File.Exists(newFile));
+        Assert.True(Directory.Exists(workspace.GetPath("Old/Ns")));
+        Assert.False(Directory.Exists(workspace.GetPath("New/Ns")));
+        Assert.Equal(originalSource, await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Equal(originalConsumer, await File.ReadAllTextAsync(workspace.SecondarySourcePath));
+        Assert.Contains("namespace Old.Ns;", await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("using Old.Ns;", await File.ReadAllTextAsync(workspace.SecondarySourcePath));
+    }
+
+    [SkippableFact]
+    public async Task UpdateFileLocationTrue_DestinationExists_ThrowsTargetFileExists()
+    {
+        const string source = """
+            namespace Old.Ns;
+
+            public class Foo
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source, "Old/Ns/Foo.cs");
+        var destFile = workspace.GetPath("New/Ns/Foo.cs");
+        Directory.CreateDirectory(Path.GetDirectoryName(destFile)!);
+        await File.WriteAllTextAsync(destFile, "// occupied");
+        var original = await File.ReadAllTextAsync(workspace.SourcePath);
+        var operation = new MoveTypeToNamespaceOperation(workspace.Context);
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new MoveTypeToNamespaceParams
+            {
+                SourceFile = workspace.SourcePath,
+                SymbolName = "Foo",
+                TargetNamespace = "New.Ns",
+                UpdateFileLocation = true
+            }));
+
+        Assert.Equal(ErrorCodes.TargetFileExists, ex.ErrorCode);
+        Assert.Equal("3019", ex.ErrorCode);
+        Assert.True(File.Exists(workspace.SourcePath));
+        Assert.True(Directory.Exists(workspace.GetPath("Old/Ns")));
+        Assert.Equal(original, await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Contains("namespace Old.Ns;", await File.ReadAllTextAsync(workspace.SourcePath));
+        Assert.Equal("// occupied", await File.ReadAllTextAsync(destFile));
+    }
+
+    [SkippableFact]
+    public async Task UpdateFileLocationTrue_ExistingDestinationFolder_MovesIntoIt()
+    {
+        const string source = """
+            namespace Old.Ns;
+
+            public class Foo
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source, "Old/Ns/Foo.cs");
+        var destFolder = workspace.GetPath("New/Ns");
+        Directory.CreateDirectory(destFolder);
+        var destFile = workspace.GetPath("New/Ns/Foo.cs");
+        var operation = new MoveTypeToNamespaceOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new MoveTypeToNamespaceParams
+        {
+            SourceFile = workspace.SourcePath,
+            SymbolName = "Foo",
+            TargetNamespace = "New.Ns",
+            UpdateFileLocation = true
+        });
+
+        Assert.True(result.Success);
+        Assert.True(File.Exists(destFile));
+        Assert.False(File.Exists(workspace.GetPath("Old/Ns/Foo.cs")));
+        Assert.Contains("namespace New.Ns;", await File.ReadAllTextAsync(destFile));
+    }
+
+    [SkippableFact]
+    public async Task UpdateFileLocationTrue_UnmatchedFolder_CreatesNamespacePathUnderProject()
+    {
+        const string source = """
+            namespace MyApp;
+
+            public class Foo
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source, "Foo.cs");
+        var destFile = workspace.GetPath("MyApp/Services/Foo.cs");
+        var operation = new MoveTypeToNamespaceOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new MoveTypeToNamespaceParams
+        {
+            SourceFile = workspace.SourcePath,
+            SymbolName = "Foo",
+            TargetNamespace = "MyApp.Services",
+            UpdateFileLocation = true
+        });
+
+        Assert.True(result.Success);
+        Assert.True(File.Exists(destFile));
+        Assert.False(File.Exists(workspace.GetPath("Foo.cs")));
+        Assert.Contains("namespace MyApp.Services;", await File.ReadAllTextAsync(destFile));
+        Assert.NotNull(workspace.Context.GetDocumentByPath(destFile));
+    }
+
+    [SkippableFact]
+    public async Task UpdateFileLocationTrue_ExplicitCompileItem_UpdatesProjectFile()
+    {
+        const string source = """
+            namespace Old.Ns;
+
+            public class Foo
+            {
+            }
+            """;
+        const string consumer = """
+            using Old.Ns;
+
+            namespace Other;
+
+            public class Consumer
+            {
+                public Foo Create() => new Foo();
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateWithExplicitCompileItemsAsync(
+            ("Old/Ns/Foo.cs", source),
+            ("Consumer.cs", consumer));
+        var newFile = workspace.GetPath("New/Ns/Foo.cs");
+        var operation = new MoveTypeToNamespaceOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new MoveTypeToNamespaceParams
+        {
+            SourceFile = workspace.SourcePath,
+            SymbolName = "Foo",
+            TargetNamespace = "New.Ns",
+            UpdateFileLocation = true
+        });
+
+        Assert.True(result.Success);
+        Assert.True(File.Exists(newFile));
+        Assert.False(File.Exists(workspace.GetPath("Old/Ns/Foo.cs")));
+
+        var csproj = await File.ReadAllTextAsync(workspace.ProjectPath);
+        Assert.Contains("New/Ns/Foo.cs", csproj);
+        Assert.DoesNotContain("Old/Ns/Foo.cs", csproj);
+        Assert.Contains("Consumer.cs", csproj);
+        Assert.Contains(workspace.ProjectPath, result.Changes!.FilesModified);
+
+        workspace.Context.Dispose();
+        var provider = new MSBuildWorkspaceProvider();
+        using var reloaded = await provider.CreateContextAsync(workspace.ProjectPath);
+        Assert.NotNull(reloaded.GetDocumentByPath(newFile));
+        Assert.Null(reloaded.GetDocumentByPath(workspace.GetPath("Old/Ns/Foo.cs")));
+    }
+
+    [SkippableFact]
+    public async Task UpdateFileLocationTrue_ReadOnlyProjectWithCompileItems_ThrowsDocumentNotEditable()
+    {
+        const string source = """
+            namespace Old.Ns;
+
+            public class Foo
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateWithExplicitCompileItemsAsync(
+            ("Old/Ns/Foo.cs", source));
+        var original = await File.ReadAllTextAsync(workspace.SourcePath);
+        var destFile = workspace.GetPath("New/Ns/Foo.cs");
+        var projectInfo = new FileInfo(workspace.ProjectPath);
+        var wasReadOnly = projectInfo.IsReadOnly;
+        projectInfo.IsReadOnly = true;
+        try
+        {
+            var operation = new MoveTypeToNamespaceOperation(workspace.Context);
+            var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+                operation.ExecuteAsync(new MoveTypeToNamespaceParams
+                {
+                    SourceFile = workspace.SourcePath,
+                    SymbolName = "Foo",
+                    TargetNamespace = "New.Ns",
+                    UpdateFileLocation = true
+                }));
+
+            Assert.Equal(ErrorCodes.DocumentNotEditable, ex.ErrorCode);
+            Assert.Equal(original, await File.ReadAllTextAsync(workspace.SourcePath));
+            Assert.False(File.Exists(destFile));
+            Assert.False(Directory.Exists(workspace.GetPath("New/Ns")));
+        }
+        finally
+        {
+            projectInfo.IsReadOnly = wasReadOnly;
+        }
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static MoveTypeToNamespaceParams ValidParams(
+        string? sourceFile = null,
+        string symbolName = "Foo",
+        string targetNamespace = "New.Ns") => new()
+        {
+            SourceFile = sourceFile ?? Path.Combine(Path.GetTempPath(), "RoslynMcpMoveNsMissing.cs"),
+            SymbolName = symbolName,
+            TargetNamespace = targetNamespace
+        };
+
+    private sealed class TempWorkspace : IAsyncDisposable
+    {
+        public required string DirectoryPath { get; init; }
+        public required string ProjectPath { get; init; }
+        public required string SourcePath { get; init; }
+        public required WorkspaceContext Context { get; init; }
+        public string SecondarySourcePath { get; init; } = "";
+
+        public string GetPath(string relativeFile) =>
+            Path.Combine(
+                DirectoryPath,
+                relativeFile.Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar));
+
+        public static Task<TempWorkspace> CreateAsync(string source, string fileName = "Foo.cs") =>
+            CreateAsync((fileName, source));
+
+        public static Task<TempWorkspace> CreateWithExplicitCompileItemsAsync(
+            params (string FileName, string Source)[] files)
+        {
+            var compileItems = string.Join(
+                Environment.NewLine,
+                files.Select(f => $"    <Compile Include=\"{f.FileName}\" />"));
+            var projectXml = $"""
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net9.0</TargetFramework>
+                    <Nullable>enable</Nullable>
+                    <EnableDefaultItems>false</EnableDefaultItems>
+                    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+                  </PropertyGroup>
+                  <ItemGroup>
+                {compileItems}
+                  </ItemGroup>
+                </Project>
+                """;
+            return CreateAsync(projectXml, files);
+        }
+
+        public static Task<TempWorkspace> CreateAsync(params (string FileName, string Source)[] files) =>
+            CreateAsync("""
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net9.0</TargetFramework>
+                    <Nullable>enable</Nullable>
+                  </PropertyGroup>
+                </Project>
+                """, files);
+
+        public static async Task<TempWorkspace> CreateAsync(
+            string projectXml,
+            params (string FileName, string Source)[] files)
+        {
+            Skip.IfNot(ModuleInitializer.MsBuildAvailable, ModuleInitializer.MsBuildError ?? "MSBuild not available");
+
+            var directory = Path.Combine(Path.GetTempPath(), "RoslynMcpMoveNs_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(directory);
+
+            var projectPath = Path.Combine(directory, "TestApp.csproj");
+            await File.WriteAllTextAsync(projectPath, projectXml);
+
+            string? sourcePath = null;
+            string? secondary = null;
+            foreach (var (fileName, source) in files)
+            {
+                var relative = fileName.Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar);
+                var path = Path.Combine(directory, relative);
+                var parent = Path.GetDirectoryName(path);
+                if (!string.IsNullOrEmpty(parent))
+                    Directory.CreateDirectory(parent);
+                await File.WriteAllTextAsync(path, source);
+                if (sourcePath == null)
+                    sourcePath = path;
+                else
+                    secondary ??= path;
+            }
+
+            sourcePath ??= Path.Combine(directory, "Foo.cs");
+
+            try
+            {
+                var provider = new MSBuildWorkspaceProvider();
+                var context = await provider.CreateContextAsync(projectPath);
+                if (context.GetDocumentByPath(sourcePath) == null)
+                {
+                    context.Dispose();
+                    throw new InvalidOperationException($"Workspace loaded but did not include {sourcePath}.");
+                }
+
+                return new TempWorkspace
+                {
+                    DirectoryPath = directory,
+                    ProjectPath = projectPath,
+                    SourcePath = sourcePath,
+                    SecondarySourcePath = secondary ?? "",
+                    Context = context
+                };
+            }
+            catch (Exception ex) when (ex is not SkipException)
+            {
+                try
+                {
+                    Directory.Delete(directory, recursive: true);
+                }
+                catch
+                {
+                    // ignore cleanup failures
+                }
+
+                Skip.If(true, $"Workspace load failed: {ex.Message}");
+                throw;
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            Context.Dispose();
+            await Task.Run(() =>
+            {
+                try
+                {
+                    Directory.Delete(DirectoryPath, recursive: true);
+                }
+                catch
+                {
+                    // ignore locked temp files
+                }
+            });
+        }
+    }
+
+    #endregion
+}

--- a/tests/RoslynMcp.Core.Tests/Refactoring/MoveTypeToNamespaceOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/MoveTypeToNamespaceOperationTests.cs
@@ -72,6 +72,80 @@ public class MoveTypeToNamespaceOperationTests
             dest);
     }
 
+    [Fact]
+    public void IsUnchangedFileLocation_CaseOnlyDistinctPathsWhenDestMissing_IsFalse()
+    {
+        var source = Path.Combine(Path.GetTempPath(), "Old", "Ns", "Foo.cs");
+        var dest = Path.Combine(Path.GetTempPath(), "old", "ns", "Foo.cs");
+
+        Assert.NotEqual(source, dest);
+        Assert.Equal(source, dest, StringComparer.OrdinalIgnoreCase);
+        Assert.False(MoveTypeToNamespaceOperation.IsUnchangedFileLocation(source, dest));
+    }
+
+    [Fact]
+    public void CompileSpecCoversFile_MatchesGlobsAndLiterals()
+    {
+        var projectDir = Path.DirectorySeparatorChar == '/' ? "/tmp/proj" : @"C:\tmp\proj";
+        var source = Path.Combine(projectDir, "Old", "Ns", "Foo.cs");
+        var dest = Path.Combine(projectDir, "New", "Ns", "Foo.cs");
+
+        Assert.True(MoveTypeToNamespaceOperation.CompileSpecCoversFile("Old/Ns/**/*.cs", projectDir, source));
+        Assert.False(MoveTypeToNamespaceOperation.CompileSpecCoversFile("Old/Ns/**/*.cs", projectDir, dest));
+        Assert.True(MoveTypeToNamespaceOperation.CompileSpecCoversFile("**/*.cs", projectDir, source));
+        Assert.True(MoveTypeToNamespaceOperation.CompileSpecCoversFile("**/*.cs", projectDir, dest));
+        Assert.True(MoveTypeToNamespaceOperation.CompileSpecCoversFile("Old/Ns/Foo.cs", projectDir, source));
+        Assert.False(MoveTypeToNamespaceOperation.CompileSpecCoversFile("Old/Ns/Foo.cs", projectDir, dest));
+    }
+
+    [Fact]
+    public void UpdateProjectTextForFileMove_SupplementsExplicitGlob()
+    {
+        const string xml = """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <ItemGroup>
+                <Compile Include="Old/Ns/**/*.cs" />
+              </ItemGroup>
+            </Project>
+            """;
+        var projectDir = Path.DirectorySeparatorChar == '/' ? "/tmp/proj" : @"C:\tmp\proj";
+        var source = Path.Combine(projectDir, "Old", "Ns", "Foo.cs");
+        var dest = Path.Combine(projectDir, "New", "Ns", "Foo.cs");
+
+        var updated = MoveTypeToNamespaceOperation.UpdateProjectTextForFileMove(
+            xml,
+            projectDir,
+            source,
+            dest);
+
+        Assert.Contains("Old/Ns/**/*.cs", updated);
+        Assert.Contains("New/Ns/Foo.cs", updated);
+    }
+
+    [Fact]
+    public void UpdateProjectTextForFileMove_RewritesSemicolonLiteralList()
+    {
+        const string xml = """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <ItemGroup>
+                <Compile Include="Old/Ns/Foo.cs;Consumer.cs" />
+              </ItemGroup>
+            </Project>
+            """;
+        var projectDir = Path.DirectorySeparatorChar == '/' ? "/tmp/proj" : @"C:\tmp\proj";
+        var source = Path.Combine(projectDir, "Old", "Ns", "Foo.cs");
+        var dest = Path.Combine(projectDir, "New", "Ns", "Foo.cs");
+
+        var updated = MoveTypeToNamespaceOperation.UpdateProjectTextForFileMove(
+            xml,
+            projectDir,
+            source,
+            dest);
+
+        Assert.Contains("New/Ns/Foo.cs;Consumer.cs", updated);
+        Assert.DoesNotContain("Old/Ns/Foo.cs", updated);
+    }
+
     #endregion
 
     #region updateFileLocation
@@ -428,6 +502,153 @@ public class MoveTypeToNamespaceOperationTests
         }
     }
 
+    [SkippableFact]
+    public async Task UpdateFileLocationTrue_ExplicitGlobCompileItem_SupplementsDestFile()
+    {
+        const string source = """
+            namespace Old.Ns;
+
+            public class Foo
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateWithCompileIncludesAsync(
+            ["Old/Ns/**/*.cs"],
+            ("Old/Ns/Foo.cs", source));
+        var newFile = workspace.GetPath("New/Ns/Foo.cs");
+        var operation = new MoveTypeToNamespaceOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new MoveTypeToNamespaceParams
+        {
+            SourceFile = workspace.SourcePath,
+            SymbolName = "Foo",
+            TargetNamespace = "New.Ns",
+            UpdateFileLocation = true
+        });
+
+        Assert.True(result.Success);
+        Assert.True(File.Exists(newFile));
+        Assert.False(File.Exists(workspace.GetPath("Old/Ns/Foo.cs")));
+
+        var csproj = await File.ReadAllTextAsync(workspace.ProjectPath);
+        Assert.Contains("Old/Ns/**/*.cs", csproj);
+        Assert.Contains("New/Ns/Foo.cs", csproj);
+        Assert.Contains(workspace.ProjectPath, result.Changes!.FilesModified);
+
+        workspace.Context.Dispose();
+        var provider = new MSBuildWorkspaceProvider();
+        using var reloaded = await provider.CreateContextAsync(workspace.ProjectPath);
+        Assert.NotNull(reloaded.GetDocumentByPath(newFile));
+        Assert.Null(reloaded.GetDocumentByPath(workspace.GetPath("Old/Ns/Foo.cs")));
+    }
+
+    [SkippableFact]
+    public async Task UpdateFileLocationTrue_LinkedFileInSecondProject_RemapsBothDocuments()
+    {
+        const string source = """
+            namespace Old.Ns;
+
+            public class Foo
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateLinkedFileSolutionAsync(
+            ("Old/Ns/Foo.cs", source));
+        var oldFile = workspace.GetPath("Owner/Old/Ns/Foo.cs");
+        var newFile = workspace.GetPath("Owner/New/Ns/Foo.cs");
+        var operation = new MoveTypeToNamespaceOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new MoveTypeToNamespaceParams
+        {
+            SourceFile = oldFile,
+            SymbolName = "Foo",
+            TargetNamespace = "New.Ns",
+            UpdateFileLocation = true
+        });
+
+        Assert.True(result.Success);
+        Assert.True(File.Exists(newFile));
+        Assert.False(File.Exists(oldFile));
+
+        var destDocs = workspace.Context.Solution.Projects
+            .SelectMany(project => project.Documents)
+            .Where(document =>
+                document.FilePath != null
+                && string.Equals(
+                    PathResolver.NormalizePath(document.FilePath),
+                    PathResolver.NormalizePath(newFile),
+                    StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        Assert.Equal(2, destDocs.Count);
+
+        var staleDocs = workspace.Context.Solution.Projects
+            .SelectMany(project => project.Documents)
+            .Where(document =>
+                document.FilePath != null
+                && string.Equals(
+                    PathResolver.NormalizePath(document.FilePath),
+                    PathResolver.NormalizePath(oldFile),
+                    StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        Assert.Empty(staleDocs);
+
+        var linkerCsproj = await File.ReadAllTextAsync(workspace.SecondaryProjectPath);
+        Assert.Contains("New/Ns/Foo.cs", linkerCsproj);
+        Assert.DoesNotContain("Old/Ns/Foo.cs", linkerCsproj);
+
+        workspace.Context.Dispose();
+        var provider = new MSBuildWorkspaceProvider();
+        using var reloaded = await provider.CreateContextAsync(workspace.SolutionPath);
+        Assert.NotNull(reloaded.GetDocumentByPath(newFile));
+        Assert.Null(reloaded.GetDocumentByPath(oldFile));
+        Assert.Equal(
+            2,
+            reloaded.Solution.Projects.SelectMany(p => p.Documents)
+                .Count(d =>
+                    d.FilePath != null
+                    && string.Equals(
+                        PathResolver.NormalizePath(d.FilePath),
+                        PathResolver.NormalizePath(newFile),
+                        StringComparison.OrdinalIgnoreCase)));
+    }
+
+    [SkippableFact]
+    public async Task UpdateFileLocationTrue_CaseOnlyFolderChange_MovesOnCaseSensitiveFileSystem()
+    {
+        const string source = """
+            namespace Old.Ns;
+
+            public class Foo
+            {
+            }
+            """;
+
+        await using var workspace = await TempWorkspace.CreateAsync(source, "Old/Ns/Foo.cs");
+        Skip.If(
+            !IsCaseSensitiveDirectory(workspace.DirectoryPath),
+            "Volume is case-insensitive; case-only paths are the same file.");
+
+        var oldFile = workspace.GetPath("Old/Ns/Foo.cs");
+        var newFile = workspace.GetPath("old/ns/Foo.cs");
+        var operation = new MoveTypeToNamespaceOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new MoveTypeToNamespaceParams
+        {
+            SourceFile = workspace.SourcePath,
+            SymbolName = "Foo",
+            TargetNamespace = "old.ns",
+            UpdateFileLocation = true
+        });
+
+        Assert.True(result.Success);
+        Assert.True(File.Exists(newFile));
+        Assert.False(File.Exists(oldFile));
+        Assert.Contains("namespace old.ns;", await File.ReadAllTextAsync(newFile));
+        Assert.NotNull(workspace.Context.GetDocumentByPath(newFile));
+    }
+
     #endregion
 
     #region Helpers
@@ -442,6 +663,27 @@ public class MoveTypeToNamespaceOperationTests
             TargetNamespace = targetNamespace
         };
 
+    private static bool IsCaseSensitiveDirectory(string directory)
+    {
+        var probe = Path.Combine(directory, "RoslynMcpCaseProbe");
+        Directory.CreateDirectory(probe);
+        try
+        {
+            return !Directory.Exists(Path.Combine(directory, "roslynmcpcaseprobe"));
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(probe);
+            }
+            catch
+            {
+                // ignore cleanup failures
+            }
+        }
+    }
+
     private sealed class TempWorkspace : IAsyncDisposable
     {
         public required string DirectoryPath { get; init; }
@@ -449,6 +691,8 @@ public class MoveTypeToNamespaceOperationTests
         public required string SourcePath { get; init; }
         public required WorkspaceContext Context { get; init; }
         public string SecondarySourcePath { get; init; } = "";
+        public string SecondaryProjectPath { get; init; } = "";
+        public string SolutionPath { get; init; } = "";
 
         public string GetPath(string relativeFile) =>
             Path.Combine(
@@ -459,11 +703,16 @@ public class MoveTypeToNamespaceOperationTests
             CreateAsync((fileName, source));
 
         public static Task<TempWorkspace> CreateWithExplicitCompileItemsAsync(
+            params (string FileName, string Source)[] files) =>
+            CreateWithCompileIncludesAsync(files.Select(f => f.FileName).ToArray(), files);
+
+        public static Task<TempWorkspace> CreateWithCompileIncludesAsync(
+            IReadOnlyList<string> includes,
             params (string FileName, string Source)[] files)
         {
             var compileItems = string.Join(
                 Environment.NewLine,
-                files.Select(f => $"    <Compile Include=\"{f.FileName}\" />"));
+                includes.Select(include => $"    <Compile Include=\"{include}\" />"));
             var projectXml = $"""
                 <Project Sdk="Microsoft.NET.Sdk">
                   <PropertyGroup>
@@ -478,6 +727,127 @@ public class MoveTypeToNamespaceOperationTests
                 </Project>
                 """;
             return CreateAsync(projectXml, files);
+        }
+
+        public static async Task<TempWorkspace> CreateLinkedFileSolutionAsync(
+            params (string FileName, string Source)[] ownerFiles)
+        {
+            Skip.IfNot(ModuleInitializer.MsBuildAvailable, ModuleInitializer.MsBuildError ?? "MSBuild not available");
+
+            var directory = Path.Combine(Path.GetTempPath(), "RoslynMcpMoveNsLink_" + Guid.NewGuid().ToString("N"));
+            var ownerDir = Path.Combine(directory, "Owner");
+            var linkerDir = Path.Combine(directory, "Linker");
+            Directory.CreateDirectory(ownerDir);
+            Directory.CreateDirectory(linkerDir);
+
+            await File.WriteAllTextAsync(Path.Combine(ownerDir, "Owner.csproj"), """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net9.0</TargetFramework>
+                    <Nullable>enable</Nullable>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            string? sourcePath = null;
+            foreach (var (fileName, source) in ownerFiles)
+            {
+                var relative = fileName.Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar);
+                var path = Path.Combine(ownerDir, relative);
+                var parent = Path.GetDirectoryName(path);
+                if (!string.IsNullOrEmpty(parent))
+                    Directory.CreateDirectory(parent);
+                await File.WriteAllTextAsync(path, source);
+                sourcePath ??= path;
+            }
+
+            sourcePath ??= Path.Combine(ownerDir, "Foo.cs");
+            var linkedInclude = string.Join(
+                ';',
+                ownerFiles.Select(f => "../Owner/" + f.FileName.Replace('\\', '/')));
+            await File.WriteAllTextAsync(Path.Combine(linkerDir, "Linker.csproj"), $$"""
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net9.0</TargetFramework>
+                    <Nullable>enable</Nullable>
+                    <EnableDefaultItems>false</EnableDefaultItems>
+                    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <Compile Include="{{linkedInclude}}" />
+                  </ItemGroup>
+                </Project>
+                """);
+
+            var solutionPath = Path.Combine(directory, "TestApp.sln");
+            await File.WriteAllTextAsync(solutionPath, """
+                Microsoft Visual Studio Solution File, Format Version 12.00
+                # Visual Studio Version 17
+                Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Owner", "Owner\Owner.csproj", "{11111111-1111-1111-1111-111111111111}"
+                EndProject
+                Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Linker", "Linker\Linker.csproj", "{22222222-2222-2222-2222-222222222222}"
+                EndProject
+                Global
+                	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                		Debug|Any CPU = Debug|Any CPU
+                	EndGlobalSection
+                	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                		{11111111-1111-1111-1111-111111111111}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                		{11111111-1111-1111-1111-111111111111}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                		{22222222-2222-2222-2222-222222222222}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                		{22222222-2222-2222-2222-222222222222}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                	EndGlobalSection
+                EndGlobal
+                """);
+
+            try
+            {
+                var provider = new MSBuildWorkspaceProvider();
+                var context = await provider.CreateContextAsync(solutionPath);
+                if (context.GetDocumentByPath(sourcePath) == null)
+                {
+                    context.Dispose();
+                    throw new InvalidOperationException($"Workspace loaded but did not include {sourcePath}.");
+                }
+
+                var linkedCount = context.Solution.Projects
+                    .SelectMany(p => p.Documents)
+                    .Count(d =>
+                        d.FilePath != null
+                        && string.Equals(
+                            PathResolver.NormalizePath(d.FilePath),
+                            PathResolver.NormalizePath(sourcePath),
+                            StringComparison.OrdinalIgnoreCase));
+                if (linkedCount < 2)
+                {
+                    context.Dispose();
+                    throw new InvalidOperationException($"Expected linked document in both projects, found {linkedCount}.");
+                }
+
+                return new TempWorkspace
+                {
+                    DirectoryPath = directory,
+                    ProjectPath = Path.Combine(ownerDir, "Owner.csproj"),
+                    SecondaryProjectPath = Path.Combine(linkerDir, "Linker.csproj"),
+                    SolutionPath = solutionPath,
+                    SourcePath = sourcePath,
+                    Context = context
+                };
+            }
+            catch (Exception ex) when (ex is not SkipException)
+            {
+                try
+                {
+                    Directory.Delete(directory, recursive: true);
+                }
+                catch
+                {
+                    // ignore cleanup failures
+                }
+
+                Skip.If(true, $"Workspace load failed: {ex.Message}");
+                throw;
+            }
         }
 
         public static Task<TempWorkspace> CreateAsync(params (string FileName, string Source)[] files) =>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

`move_type_to_namespace` already exposed `updateFileLocation` (default `false`) on the MCP tool and `MoveTypeToNamespaceParams`, but `MoveTypeToNamespaceOperation` never read it.

This change honors the existing flag:

- **`updateFileLocation: false` (default):** today's behavior — rewrite namespace / usings, do not move the file.
- **`updateFileLocation: true`:** move the source file to a folder matching the target namespace (e.g. `MyApp.Services` → `MyApp/Services/`), create missing directories, and update project document paths / explicit compile items so the solution still compiles.
- **Preview:** writes nothing, including folders.

Destination path: if the current folder already matches the old namespace, that folder is remapped (preserving a prefix such as `src/`); otherwise the namespace path is created under the project directory.

Rejects:
- destination file already exists (`3019` TargetFileExists)
- file name collision with another document (`3019`)
- uneditable project / document (`3115` DocumentNotEditable)
- missing file (`2001` SourceFileNotFound)

No new MCP tool. No new error codes (reuses existing codes; does not reuse 3060-3066, 3080-3089, 3090-3104, or `updateFolders` codes 3136-3141).

This is a single-file move after a type namespace change, not a folder rename. Helpers from `rename_file_to_match_type` and `rename_namespace` are reused for collision checks, physical move, and explicit Compile item rewrites.

Review follow-ups on this PR:
- Supplement explicit glob / semicolon-list Compile items so a file-only move is not dropped when default items are disabled (`Old/Ns/**/*.cs` keeps the glob and adds `New/Ns/Foo.cs`).
- Remap every linked document and project file whose path matches the source (not only `plan.DocumentId`).
- Skip the physical move only when `ReferToSameFile` identifies the same filesystem entry, so case-only folder changes proceed on case-sensitive volumes.

## Related Issues

Closes #80

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Test additions or updates

## Testing

- `updateFileLocation: false` leaves the file and rewrites the namespace.
- `updateFileLocation: true` moves the file and updates the namespace (matching-folder remap and project-root `MyApp.Services` → `MyApp/Services/`).
- Preview with `updateFileLocation: true` writes nothing (including folders).
- Destination-exists reject (`3019`); existing dest *folder* without the dest file still succeeds.
- Explicit Compile items are rewritten; readonly project with compile items is rejected as uneditable.
- Explicit glob `Old/Ns/**/*.cs` is supplemented with the dest file; reload still sees the type.
- A file linked into a second project remaps both documents and the linker compile item.
- Case-only `Old.Ns` → `old.ns` moves on a case-sensitive filesystem.

Local results on Linux / .NET 9.0.317:
- 19 `MoveTypeToNamespaceOperationTests` passed (existing P0 cases kept)
- `dotnet format --verify-no-changes` passed
- Release build with `TreatWarningsAsErrors`: 0 warnings

**Test Configuration**:
- OS: Linux
- .NET Version: 9.0.317

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f2c6dbec-fde3-4bf5-94bd-dda120531005?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2c6dbec-fde3-4bf5-94bd-dda120531005&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

