### PR TITLE
Honor sort_usings systemFirst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
-- `sort_usings` now honors `systemFirst`: default `true` keeps today's System / System.* first grouping within regular and static usings; `false` keeps group order (regular, static, alias) but sorts namespaces alphabetically with no System priority. Alias usings stay alphabetical by alias. Preview writes nothing.
+- `sort_usings` now honors `systemFirst`: default `true` keeps today's System / System.* first grouping within regular and static usings; `false` keeps group order (regular, static, alias) but sorts namespaces alphabetically with no System priority. Alias usings stay alphabetical by alias. Global usings stay ahead of non-global usings in both modes (CS8915). Preview writes nothing.
 - `move_type_to_namespace` now honors `updateFileLocation`: when true, moves the source file to a folder matching the target namespace (e.g. `MyApp.Services` → `MyApp/Services/`), creating missing directories and updating project document paths / explicit compile items; preview writes nothing (including folders); rejects destination-exists, file-name collision, uneditable project, and missing file. Default `false` keeps today's namespace-only rewrite.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- `sort_usings` now honors `systemFirst`: default `true` keeps today's System / System.* first grouping within regular and static usings; `false` keeps group order (regular, static, alias) but sorts namespaces alphabetically with no System priority. Alias usings stay alphabetical by alias. Preview writes nothing.
 - `move_type_to_namespace` now honors `updateFileLocation`: when true, moves the source file to a folder matching the target namespace (e.g. `MyApp.Services` → `MyApp/Services/`), creating missing directories and updating project document paths / explicit compile items; preview writes nothing (including folders); rejects destination-exists, file-name collision, uneditable project, and missing file. Default `false` keeps today's namespace-only rewrite.
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ All tools accept a `solutionPath` parameter (absolute path to a `.sln`, `.slnx`,
 |------|-------------|----------------|
 | `add_missing_usings` | Add missing using directives required to resolve unbound type references. Process a single file or all files in the solution. | `sourceFile`, `allFiles` |
 | `remove_unused_usings` | Remove unused using directives. Process a single file or all files in the solution. | `sourceFile`, `allFiles` |
-| `sort_usings` | Sort using directives alphabetically in a C# file. | `sourceFile` |
+| `sort_usings` | Sort using directives alphabetically in a C# file. | `sourceFile`, `systemFirst` |
 
 ### Diagnostics
 

--- a/src/RoslynMcp.Cli/ToolRegistry.cs
+++ b/src/RoslynMcp.Cli/ToolRegistry.cs
@@ -251,7 +251,7 @@ public sealed class ToolRegistry
         r.RegisterRefactoring<RemoveUnusedUsingsOperation, RemoveUnusedUsingsParams>(
             "remove-unused-usings", "Remove unused using directives");
         r.RegisterRefactoring<SortUsingsOperation, SortUsingsParams>(
-            "sort-usings", "Sort using directives alphabetically");
+            "sort-usings", "Sort using directives; systemFirst (default true) places System / System.* first");
 
         // ── Refactoring: Format (1) ───────────────────────────────────
         r.RegisterRefactoring<FormatDocumentOperation, FormatDocumentParams>(

--- a/src/RoslynMcp.Contracts/Models/SortUsingsParams.cs
+++ b/src/RoslynMcp.Contracts/Models/SortUsingsParams.cs
@@ -11,6 +11,12 @@ public sealed class SortUsingsParams
     public required string SourceFile { get; init; }
 
     /// <summary>
+    /// Place System / System.* namespaces first within regular and static groups. Default: true.
+    /// Alias usings remain alphabetical by alias name regardless of this flag.
+    /// </summary>
+    public bool SystemFirst { get; init; } = true;
+
+    /// <summary>
     /// Return computed changes without applying. Default: false.
     /// </summary>
     public bool Preview { get; init; }

--- a/src/RoslynMcp.Core/Refactoring/Organize/SortUsingsOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Organize/SortUsingsOperation.cs
@@ -71,7 +71,7 @@ public sealed class SortUsingsOperation : RefactoringOperationBase<SortUsingsPar
         }
 
         // Sort usings using the standardized sorter
-        var sortedUsings = UsingDirectiveSorter.Sort(root.Usings);
+        var sortedUsings = UsingDirectiveSorter.Sort(root.Usings, @params.SystemFirst);
 
         // Check if the order actually changed
         var alreadySorted = root.Usings

--- a/src/RoslynMcp.Core/Refactoring/Organize/Utilities/UsingDirectiveSorter.cs
+++ b/src/RoslynMcp.Core/Refactoring/Organize/Utilities/UsingDirectiveSorter.cs
@@ -10,6 +10,7 @@ namespace RoslynMcp.Core.Refactoring.Organize.Utilities;
 /// <remarks>
 /// Sort order:
 /// <list type="number">
+///   <item>Global using directives ahead of non-global directives (CS8915), including across regular/static/alias groups</item>
 ///   <item>Regular using directives (System namespaces first when <c>systemFirst</c> is true, then alphabetical)</item>
 ///   <item>Static using directives (System namespaces first when <c>systemFirst</c> is true, then alphabetical)</item>
 ///   <item>Alias using directives (alphabetical by alias name)</item>
@@ -24,6 +25,7 @@ public static class UsingDirectiveSorter
     /// <param name="systemFirst">
     /// When true (default), System / System.* namespaces are placed first within regular and static groups.
     /// When false, namespaces sort alphabetically with no System priority. Alias usings stay alphabetical by alias.
+    /// Global usings stay ahead of non-global usings in both modes.
     /// </param>
     /// <returns>A list of sorted using directives.</returns>
     public static List<UsingDirectiveSyntax> Sort(IEnumerable<UsingDirectiveSyntax> usings, bool systemFirst = true)
@@ -56,41 +58,60 @@ public static class UsingDirectiveSorter
         var sortedStatic = SortByNamespace(staticUsings, systemFirst);
         var sortedAlias = SortByAlias(aliasUsings);
 
-        // Combine in order: regular, static, alias
+        // Combine in order: regular, static, alias — then lift globals ahead of non-globals
+        // so mixed groups cannot produce CS8915 (global usings must precede non-global usings).
         var result = new List<UsingDirectiveSyntax>();
         result.AddRange(sortedRegular);
         result.AddRange(sortedStatic);
         result.AddRange(sortedAlias);
 
-        return result;
+        return OrderGlobalsFirst(result);
     }
 
     /// <summary>
     /// Sorts using directives by namespace, optionally placing System namespaces first.
+    /// Global usings stay ahead of non-global usings within the group.
     /// </summary>
     private static List<UsingDirectiveSyntax> SortByNamespace(List<UsingDirectiveSyntax> usings, bool systemFirst)
     {
-        if (!systemFirst)
+        var ordered = usings.OrderBy(u => IsGlobalUsing(u) ? 0 : 1);
+
+        if (systemFirst)
         {
-            return usings
-                .OrderBy(u => u.Name?.ToString() ?? "", StringComparer.Ordinal)
-                .ToList();
+            ordered = ordered.ThenBy(u => GetSortPriority(u.Name?.ToString() ?? ""));
         }
 
-        return usings
-            .OrderBy(u => GetSortPriority(u.Name?.ToString() ?? ""))
+        return ordered
             .ThenBy(u => u.Name?.ToString() ?? "", StringComparer.Ordinal)
             .ToList();
     }
 
     /// <summary>
     /// Sorts alias using directives by their alias name.
+    /// Global usings stay ahead of non-global usings within the group.
     /// </summary>
     private static List<UsingDirectiveSyntax> SortByAlias(List<UsingDirectiveSyntax> usings)
     {
         return usings
-            .OrderBy(u => u.Alias?.Name.ToString() ?? "", StringComparer.Ordinal)
+            .OrderBy(u => IsGlobalUsing(u) ? 0 : 1)
+            .ThenBy(u => u.Alias?.Name.ToString() ?? "", StringComparer.Ordinal)
             .ToList();
+    }
+
+    /// <summary>
+    /// Keeps every global using ahead of every non-global using while preserving
+    /// relative order (regular, then static, then alias) within each partition.
+    /// </summary>
+    private static List<UsingDirectiveSyntax> OrderGlobalsFirst(List<UsingDirectiveSyntax> usings)
+    {
+        return usings
+            .OrderBy(u => IsGlobalUsing(u) ? 0 : 1)
+            .ToList();
+    }
+
+    private static bool IsGlobalUsing(UsingDirectiveSyntax usingDirective)
+    {
+        return usingDirective.GlobalKeyword.IsKind(SyntaxKind.GlobalKeyword);
     }
 
     /// <summary>

--- a/src/RoslynMcp.Core/Refactoring/Organize/Utilities/UsingDirectiveSorter.cs
+++ b/src/RoslynMcp.Core/Refactoring/Organize/Utilities/UsingDirectiveSorter.cs
@@ -10,8 +10,8 @@ namespace RoslynMcp.Core.Refactoring.Organize.Utilities;
 /// <remarks>
 /// Sort order:
 /// <list type="number">
-///   <item>Regular using directives (System namespaces first, then alphabetical)</item>
-///   <item>Static using directives (System namespaces first, then alphabetical)</item>
+///   <item>Regular using directives (System namespaces first when <c>systemFirst</c> is true, then alphabetical)</item>
+///   <item>Static using directives (System namespaces first when <c>systemFirst</c> is true, then alphabetical)</item>
 ///   <item>Alias using directives (alphabetical by alias name)</item>
 /// </list>
 /// </remarks>
@@ -21,8 +21,12 @@ public static class UsingDirectiveSorter
     /// Sorts using directives following C# conventions.
     /// </summary>
     /// <param name="usings">The using directives to sort.</param>
+    /// <param name="systemFirst">
+    /// When true (default), System / System.* namespaces are placed first within regular and static groups.
+    /// When false, namespaces sort alphabetically with no System priority. Alias usings stay alphabetical by alias.
+    /// </param>
     /// <returns>A list of sorted using directives.</returns>
-    public static List<UsingDirectiveSyntax> Sort(IEnumerable<UsingDirectiveSyntax> usings)
+    public static List<UsingDirectiveSyntax> Sort(IEnumerable<UsingDirectiveSyntax> usings, bool systemFirst = true)
     {
         var usingsList = usings.ToList();
 
@@ -48,8 +52,8 @@ public static class UsingDirectiveSorter
         }
 
         // Sort each category
-        var sortedRegular = SortByNamespace(regularUsings);
-        var sortedStatic = SortByNamespace(staticUsings);
+        var sortedRegular = SortByNamespace(regularUsings, systemFirst);
+        var sortedStatic = SortByNamespace(staticUsings, systemFirst);
         var sortedAlias = SortByAlias(aliasUsings);
 
         // Combine in order: regular, static, alias
@@ -62,10 +66,17 @@ public static class UsingDirectiveSorter
     }
 
     /// <summary>
-    /// Sorts using directives by namespace with System namespaces first.
+    /// Sorts using directives by namespace, optionally placing System namespaces first.
     /// </summary>
-    private static List<UsingDirectiveSyntax> SortByNamespace(List<UsingDirectiveSyntax> usings)
+    private static List<UsingDirectiveSyntax> SortByNamespace(List<UsingDirectiveSyntax> usings, bool systemFirst)
     {
+        if (!systemFirst)
+        {
+            return usings
+                .OrderBy(u => u.Name?.ToString() ?? "", StringComparer.Ordinal)
+                .ToList();
+        }
+
         return usings
             .OrderBy(u => GetSortPriority(u.Name?.ToString() ?? ""))
             .ThenBy(u => u.Name?.ToString() ?? "", StringComparer.Ordinal)

--- a/src/RoslynMcp.Server/Tools/SortUsingsTool.cs
+++ b/src/RoslynMcp.Server/Tools/SortUsingsTool.cs
@@ -32,7 +32,7 @@ public sealed class SortUsingsTool : IToolHandler
     public string Name => "sort_usings";
 
     /// <inheritdoc />
-    public string Description => "Sort using directives alphabetically in a C# file.";
+    public string Description => "Sort using directives in a C# file. When systemFirst is true (default), System / System.* namespaces are placed first within regular and static groups.";
 
     /// <inheritdoc />
     public object InputSchema => new
@@ -50,6 +50,12 @@ public sealed class SortUsingsTool : IToolHandler
             {
                 type = "string",
                 description = "Absolute path to the source file"
+            },
+            systemFirst = new
+            {
+                type = "boolean",
+                description = "Place System / System.* namespaces first within regular and static groups",
+                @default = true
             },
             preview = new
             {
@@ -87,6 +93,7 @@ public sealed class SortUsingsTool : IToolHandler
             var @params = new SortUsingsParams
             {
                 SourceFile = args.SourceFile,
+                SystemFirst = args.SystemFirst ?? true,
                 Preview = args.Preview ?? false
             };
 
@@ -116,6 +123,7 @@ public sealed class SortUsingsTool : IToolHandler
     {
         public string SolutionPath { get; init; } = "";
         public string SourceFile { get; init; } = "";
+        public bool? SystemFirst { get; init; }
         public bool? Preview { get; init; }
     }
 }

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Organize/SortUsingsOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Organize/SortUsingsOperationTests.cs
@@ -1,0 +1,252 @@
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.Refactoring.Organize;
+using RoslynMcp.Core.Workspace;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Refactoring.Organize;
+
+/// <summary>
+/// Operation-level tests for <see cref="SortUsingsOperation"/>, including <c>systemFirst</c>.
+/// </summary>
+public class SortUsingsOperationTests
+{
+    private const string UnsortedSource = """
+        using MyApp.Services;
+        using System.Collections.Generic;
+        using ThirdParty;
+        using System;
+        using static MyApp.Helpers;
+        using static System.Math;
+        using Z = MyApp.Zeta;
+        using A = System.IO;
+
+        namespace TestApp;
+
+        public class Foo
+        {
+        }
+        """;
+
+    [SkippableFact]
+    public async Task SortUsings_DefaultSystemFirst_PlacesSystemNamespacesFirst()
+    {
+        await using var workspace = await TempWorkspace.CreateAsync(UnsortedSource);
+        var operation = new SortUsingsOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new SortUsingsParams
+        {
+            SourceFile = workspace.SourcePath
+        });
+
+        Assert.True(result.Success);
+        Assert.False(result.Preview);
+        Assert.Equal(
+            new[]
+            {
+                "System",
+                "System.Collections.Generic",
+                "MyApp.Services",
+                "ThirdParty",
+                "static System.Math",
+                "static MyApp.Helpers",
+                "A = System.IO",
+                "Z = MyApp.Zeta"
+            },
+            GetUsingKeys(await File.ReadAllTextAsync(workspace.SourcePath)));
+    }
+
+    [SkippableFact]
+    public async Task SortUsings_SystemFirstTrue_PlacesSystemNamespacesFirst()
+    {
+        await using var workspace = await TempWorkspace.CreateAsync(UnsortedSource);
+        var operation = new SortUsingsOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new SortUsingsParams
+        {
+            SourceFile = workspace.SourcePath,
+            SystemFirst = true
+        });
+
+        Assert.True(result.Success);
+        Assert.Equal(
+            new[]
+            {
+                "System",
+                "System.Collections.Generic",
+                "MyApp.Services",
+                "ThirdParty",
+                "static System.Math",
+                "static MyApp.Helpers",
+                "A = System.IO",
+                "Z = MyApp.Zeta"
+            },
+            GetUsingKeys(await File.ReadAllTextAsync(workspace.SourcePath)));
+    }
+
+    [SkippableFact]
+    public async Task SortUsings_SystemFirstFalse_SortsAlphabeticallyWithinGroups()
+    {
+        await using var workspace = await TempWorkspace.CreateAsync(UnsortedSource);
+        var operation = new SortUsingsOperation(workspace.Context);
+
+        var result = await operation.ExecuteAsync(new SortUsingsParams
+        {
+            SourceFile = workspace.SourcePath,
+            SystemFirst = false
+        });
+
+        Assert.True(result.Success);
+        Assert.False(result.Preview);
+        Assert.Equal(
+            new[]
+            {
+                "MyApp.Services",
+                "System",
+                "System.Collections.Generic",
+                "ThirdParty",
+                "static MyApp.Helpers",
+                "static System.Math",
+                "A = System.IO",
+                "Z = MyApp.Zeta"
+            },
+            GetUsingKeys(await File.ReadAllTextAsync(workspace.SourcePath)));
+    }
+
+    [SkippableFact]
+    public async Task SortUsings_Preview_DoesNotWriteFiles()
+    {
+        await using var workspace = await TempWorkspace.CreateAsync(UnsortedSource);
+        var operation = new SortUsingsOperation(workspace.Context);
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var result = await operation.ExecuteAsync(new SortUsingsParams
+        {
+            SourceFile = workspace.SourcePath,
+            SystemFirst = false,
+            Preview = true
+        });
+
+        Assert.True(result.Success);
+        Assert.True(result.Preview);
+        Assert.NotNull(result.PendingChanges);
+        Assert.NotEmpty(result.PendingChanges);
+        Assert.Contains("MyApp.Services", result.PendingChanges[0].AfterSnippet);
+        Assert.Contains("System", result.PendingChanges[0].AfterSnippet);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    [SkippableFact]
+    public async Task SortUsings_PreviewSystemFirstTrue_DoesNotWriteFiles()
+    {
+        await using var workspace = await TempWorkspace.CreateAsync(UnsortedSource);
+        var operation = new SortUsingsOperation(workspace.Context);
+        var before = await File.ReadAllTextAsync(workspace.SourcePath);
+
+        var result = await operation.ExecuteAsync(new SortUsingsParams
+        {
+            SourceFile = workspace.SourcePath,
+            SystemFirst = true,
+            Preview = true
+        });
+
+        Assert.True(result.Success);
+        Assert.True(result.Preview);
+        Assert.NotNull(result.PendingChanges);
+        Assert.NotEmpty(result.PendingChanges);
+        Assert.Equal(before, await File.ReadAllTextAsync(workspace.SourcePath));
+    }
+
+    private static List<string> GetUsingKeys(string source)
+    {
+        var root = CSharpSyntaxTree.ParseText(source).GetCompilationUnitRoot();
+        return root.Usings.Select(ToUsingKey).ToList();
+    }
+
+    private static string ToUsingKey(UsingDirectiveSyntax usingDirective)
+    {
+        var name = usingDirective.Name?.ToString() ?? string.Empty;
+        if (usingDirective.Alias != null)
+            return $"{usingDirective.Alias.Name} = {name}";
+        if (usingDirective.StaticKeyword.IsKind(SyntaxKind.StaticKeyword))
+            return $"static {name}";
+        return name;
+    }
+
+    private sealed class TempWorkspace : IAsyncDisposable
+    {
+        public required string DirectoryPath { get; init; }
+        public required string SourcePath { get; init; }
+        public required WorkspaceContext Context { get; init; }
+
+        public static async Task<TempWorkspace> CreateAsync(string source, string fileName = "Foo.cs")
+        {
+            Skip.IfNot(ModuleInitializer.MsBuildAvailable, ModuleInitializer.MsBuildError ?? "MSBuild not available");
+
+            var directory = Path.Combine(Path.GetTempPath(), "RoslynMcpSortUsings_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(directory);
+
+            var projectPath = Path.Combine(directory, "TestApp.csproj");
+            var sourcePath = Path.Combine(directory, fileName);
+
+            await File.WriteAllTextAsync(projectPath, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net9.0</TargetFramework>
+                    <Nullable>enable</Nullable>
+                  </PropertyGroup>
+                </Project>
+                """);
+            await File.WriteAllTextAsync(sourcePath, source);
+
+            try
+            {
+                var provider = new MSBuildWorkspaceProvider();
+                var context = await provider.CreateContextAsync(projectPath);
+                if (context.GetDocumentByPath(sourcePath) == null)
+                {
+                    context.Dispose();
+                    throw new InvalidOperationException($"Workspace loaded but did not include {sourcePath}.");
+                }
+
+                return new TempWorkspace
+                {
+                    DirectoryPath = directory,
+                    SourcePath = sourcePath,
+                    Context = context
+                };
+            }
+            catch (Exception ex) when (ex is not SkipException)
+            {
+                try
+                {
+                    Directory.Delete(directory, recursive: true);
+                }
+                catch
+                {
+                    // ignore cleanup failures
+                }
+
+                Skip.If(true, $"Workspace load failed: {ex.Message}");
+                throw;
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            Context.Dispose();
+            await Task.Run(() =>
+            {
+                try
+                {
+                    Directory.Delete(DirectoryPath, recursive: true);
+                }
+                catch
+                {
+                    // ignore locked temp files
+                }
+            });
+        }
+    }
+}

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Organize/SortUsingsOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Organize/SortUsingsOperationTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using RoslynMcp.Contracts.Models;

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Organize/Utilities/UsingDirectiveSorterTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Organize/Utilities/UsingDirectiveSorterTests.cs
@@ -55,6 +55,40 @@ public class UsingDirectiveSorterTests
     }
 
     [Fact]
+    public void Sort_SystemFirstTrue_KeepsSystemFirst()
+    {
+        var usings = ParseUsings(
+            "using MyApp.Services;",
+            "using System.Collections.Generic;",
+            "using ThirdParty;",
+            "using System;");
+
+        var sorted = UsingDirectiveSorter.Sort(usings, systemFirst: true);
+
+        Assert.Equal("System", GetNamespaceName(sorted[0]));
+        Assert.Equal("System.Collections.Generic", GetNamespaceName(sorted[1]));
+        Assert.Equal("MyApp.Services", GetNamespaceName(sorted[2]));
+        Assert.Equal("ThirdParty", GetNamespaceName(sorted[3]));
+    }
+
+    [Fact]
+    public void Sort_SystemFirstFalse_SortsAlphabeticallyWithoutSystemPriority()
+    {
+        var usings = ParseUsings(
+            "using MyApp.Services;",
+            "using System.Collections.Generic;",
+            "using ThirdParty;",
+            "using System;");
+
+        var sorted = UsingDirectiveSorter.Sort(usings, systemFirst: false);
+
+        Assert.Equal("MyApp.Services", GetNamespaceName(sorted[0]));
+        Assert.Equal("System", GetNamespaceName(sorted[1]));
+        Assert.Equal("System.Collections.Generic", GetNamespaceName(sorted[2]));
+        Assert.Equal("ThirdParty", GetNamespaceName(sorted[3]));
+    }
+
+    [Fact]
     public void Sort_SystemPrefixedNonSystem_NotGroupedWithSystem()
     {
         // Arrange - "SystemX" should NOT be grouped with "System"
@@ -143,6 +177,24 @@ public class UsingDirectiveSorterTests
         Assert.Equal("System.Math", GetNamespaceName(sorted[1]));
         Assert.Equal("MyApp.Helpers", GetNamespaceName(sorted[2]));
         Assert.Equal("ThirdParty.Utils", GetNamespaceName(sorted[3]));
+    }
+
+    [Fact]
+    public void Sort_SystemFirstFalse_StaticUsingsAlphabeticalWithoutSystemPriority()
+    {
+        var usings = ParseUsings(
+            "using static MyApp.Helpers;",
+            "using static System.Math;",
+            "using static ThirdParty.Utils;",
+            "using static System.Console;");
+
+        var sorted = UsingDirectiveSorter.Sort(usings, systemFirst: false);
+
+        Assert.Equal("MyApp.Helpers", GetNamespaceName(sorted[0]));
+        Assert.Equal("System.Console", GetNamespaceName(sorted[1]));
+        Assert.Equal("System.Math", GetNamespaceName(sorted[2]));
+        Assert.Equal("ThirdParty.Utils", GetNamespaceName(sorted[3]));
+        Assert.All(sorted, u => Assert.True(IsStaticUsing(u)));
     }
 
     #endregion
@@ -242,6 +294,52 @@ public class UsingDirectiveSorterTests
         Assert.True(IsStaticUsing(sorted[5]));
 
         // Group 3: Alias usings (alphabetical by alias name)
+        Assert.Equal("A", GetAliasName(sorted[6]));
+        Assert.True(IsAliasUsing(sorted[6]));
+
+        Assert.Equal("Z", GetAliasName(sorted[7]));
+        Assert.True(IsAliasUsing(sorted[7]));
+    }
+
+    [Fact]
+    public void Sort_SystemFirstFalse_KeepsGroupOrderAndSortsNamespacesAlphabetically()
+    {
+        var usings = ParseUsings(
+            "using Z = MyApp.Zeta;",
+            "using static ThirdParty.Extensions;",
+            "using ThirdParty;",
+            "using static System.Math;",
+            "using System.Linq;",
+            "using A = MyApp.Alpha;",
+            "using System;",
+            "using MyApp.Services;");
+
+        var sorted = UsingDirectiveSorter.Sort(usings, systemFirst: false);
+
+        Assert.Equal(8, sorted.Count);
+
+        Assert.Equal("MyApp.Services", GetNamespaceName(sorted[0]));
+        Assert.False(IsStaticUsing(sorted[0]));
+        Assert.False(IsAliasUsing(sorted[0]));
+
+        Assert.Equal("System", GetNamespaceName(sorted[1]));
+        Assert.False(IsStaticUsing(sorted[1]));
+        Assert.False(IsAliasUsing(sorted[1]));
+
+        Assert.Equal("System.Linq", GetNamespaceName(sorted[2]));
+        Assert.False(IsStaticUsing(sorted[2]));
+        Assert.False(IsAliasUsing(sorted[2]));
+
+        Assert.Equal("ThirdParty", GetNamespaceName(sorted[3]));
+        Assert.False(IsStaticUsing(sorted[3]));
+        Assert.False(IsAliasUsing(sorted[3]));
+
+        Assert.Equal("System.Math", GetNamespaceName(sorted[4]));
+        Assert.True(IsStaticUsing(sorted[4]));
+
+        Assert.Equal("ThirdParty.Extensions", GetNamespaceName(sorted[5]));
+        Assert.True(IsStaticUsing(sorted[5]));
+
         Assert.Equal("A", GetAliasName(sorted[6]));
         Assert.True(IsAliasUsing(sorted[6]));
 

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Organize/Utilities/UsingDirectiveSorterTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Organize/Utilities/UsingDirectiveSorterTests.cs
@@ -247,6 +247,80 @@ public class UsingDirectiveSorterTests
 
     #endregion
 
+    #region Global Using Tests
+
+    [Fact]
+    public void Sort_SystemFirstFalse_GlobalSystemThenRegularMyApp_StaysGlobalFirst()
+    {
+        var usings = ParseUsings(
+            "global using System;",
+            "using MyApp;");
+
+        var sorted = UsingDirectiveSorter.Sort(usings, systemFirst: false);
+
+        Assert.Equal(2, sorted.Count);
+        Assert.True(IsGlobalUsing(sorted[0]));
+        Assert.Equal("System", GetNamespaceName(sorted[0]));
+        Assert.False(IsGlobalUsing(sorted[1]));
+        Assert.Equal("MyApp", GetNamespaceName(sorted[1]));
+    }
+
+    [Fact]
+    public void Sort_SystemFirstTrue_GlobalNonSystemThenRegularSystem_StaysGlobalFirst()
+    {
+        var usings = ParseUsings(
+            "global using MyApp;",
+            "using System;");
+
+        var sorted = UsingDirectiveSorter.Sort(usings, systemFirst: true);
+
+        Assert.Equal(2, sorted.Count);
+        Assert.True(IsGlobalUsing(sorted[0]));
+        Assert.Equal("MyApp", GetNamespaceName(sorted[0]));
+        Assert.False(IsGlobalUsing(sorted[1]));
+        Assert.Equal("System", GetNamespaceName(sorted[1]));
+    }
+
+    [Fact]
+    public void Sort_MixedGlobalStaticAndRegular_GlobalsStayAheadOfNonGlobals()
+    {
+        var usings = ParseUsings(
+            "using MyApp;",
+            "global using static System.Math;",
+            "using static ThirdParty.Utils;",
+            "global using System;");
+
+        var sortedTrue = UsingDirectiveSorter.Sort(usings, systemFirst: true);
+        Assert.Equal(4, sortedTrue.Count);
+        Assert.True(IsGlobalUsing(sortedTrue[0]));
+        Assert.False(IsStaticUsing(sortedTrue[0]));
+        Assert.Equal("System", GetNamespaceName(sortedTrue[0]));
+        Assert.True(IsGlobalUsing(sortedTrue[1]));
+        Assert.True(IsStaticUsing(sortedTrue[1]));
+        Assert.Equal("System.Math", GetNamespaceName(sortedTrue[1]));
+        Assert.False(IsGlobalUsing(sortedTrue[2]));
+        Assert.False(IsStaticUsing(sortedTrue[2]));
+        Assert.Equal("MyApp", GetNamespaceName(sortedTrue[2]));
+        Assert.False(IsGlobalUsing(sortedTrue[3]));
+        Assert.True(IsStaticUsing(sortedTrue[3]));
+        Assert.Equal("ThirdParty.Utils", GetNamespaceName(sortedTrue[3]));
+
+        var sortedFalse = UsingDirectiveSorter.Sort(usings, systemFirst: false);
+        Assert.True(IsGlobalUsing(sortedFalse[0]));
+        Assert.False(IsStaticUsing(sortedFalse[0]));
+        Assert.Equal("System", GetNamespaceName(sortedFalse[0]));
+        Assert.True(IsGlobalUsing(sortedFalse[1]));
+        Assert.True(IsStaticUsing(sortedFalse[1]));
+        Assert.Equal("System.Math", GetNamespaceName(sortedFalse[1]));
+        Assert.False(IsGlobalUsing(sortedFalse[2]));
+        Assert.Equal("MyApp", GetNamespaceName(sortedFalse[2]));
+        Assert.False(IsGlobalUsing(sortedFalse[3]));
+        Assert.True(IsStaticUsing(sortedFalse[3]));
+        Assert.Equal("ThirdParty.Utils", GetNamespaceName(sortedFalse[3]));
+    }
+
+    #endregion
+
     #region Mixed and Edge Case Tests
 
     [Fact]
@@ -429,6 +503,11 @@ using System;";
     private static bool IsAliasUsing(UsingDirectiveSyntax usingDirective)
     {
         return usingDirective.Alias != null;
+    }
+
+    private static bool IsGlobalUsing(UsingDirectiveSyntax usingDirective)
+    {
+        return usingDirective.GlobalKeyword.IsKind(SyntaxKind.GlobalKeyword);
     }
 
     #endregion

--- a/tests/RoslynMcp.Server.Tests/Tools/SortUsingsToolTests.cs
+++ b/tests/RoslynMcp.Server.Tests/Tools/SortUsingsToolTests.cs
@@ -85,7 +85,20 @@ public class SortUsingsToolTests
         Assert.True(properties.TryGetProperty("sourceFile", out _));
 
         // Assert - Optional properties
+        Assert.True(properties.TryGetProperty("systemFirst", out _));
         Assert.True(properties.TryGetProperty("preview", out _));
+    }
+
+    [Fact]
+    public void GetDefinition_SystemFirstProperty_DefaultsToTrue()
+    {
+        var schema = _tool.InputSchema;
+        var json = JsonSerializer.Serialize(schema);
+        var doc = JsonDocument.Parse(json);
+        var systemFirst = doc.RootElement.GetProperty("properties").GetProperty("systemFirst");
+
+        Assert.Equal("boolean", systemFirst.GetProperty("type").GetString());
+        Assert.True(systemFirst.GetProperty("default").GetBoolean());
     }
 
     [Fact]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Expansion interface contract 4.1 already lists `systemFirst` on `sort_usings`, but `UsingDirectiveSorter.Sort` always put System / System.* first and the MCP tool / `SortUsingsParams` did not expose the flag.

This change honors the existing contract:

- **`systemFirst: true` (default):** today's behavior — System / System.* first within regular and static groups, then alphabetical. Alias group stays alphabetical by alias.
- **`systemFirst: false`:** keep group order (regular, static, alias) but sort namespaces alphabetically with no System priority.
- **Global usings:** stay ahead of every non-global using in both modes, including across regular/static/alias groups (CS8915).
- **Preview:** writes nothing.

No new MCP tool. Extends the existing `sort_usings` params and schema. No new error codes (does not reuse 3060-3066, 3080-3089, 3090-3104, or `updateFolders` codes 3136-3141).

`add_missing_usings` / `remove_unused_usings` keep the default System-first sort.

## Related Issues

Closes #82

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Test additions or updates

## Testing

- Default / `systemFirst: true` keeps System first within regular and static groups.
- `systemFirst: false` is pure alphabetical within groups (regular, static, alias).
- `systemFirst: false` keeps `global using System;` ahead of `using MyApp;`.
- `systemFirst: true` keeps `global using MyApp;` ahead of `using System;`.
- Mixed global static / regular keeps all globals ahead of non-globals.
- Preview writes nothing (file content unchanged).
- MCP schema exposes `systemFirst` as optional boolean defaulting to `true`.

Local results on Linux / .NET 9.0.317:
- 24 `UsingDirectiveSorter` + `SortUsingsOperation` tests passed (including 3 CS8915 global-using cases)
- `dotnet format --verify-no-changes` passed
- Release build with `TreatWarningsAsErrors`: 0 warnings

**Test Configuration**:
- OS: Linux
- .NET Version: 9.0.317

## Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7c3773f-e239-45d3-98b8-fe6e78770781?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7c3773f-e239-45d3-98b8-fe6e78770781&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

