### PR TITLE
Reject line < 1 in change_signature and convert_to_async

### DIFF
--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertToAsyncOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertToAsyncOperation.cs
@@ -70,6 +70,9 @@ public sealed class ConvertToAsyncOperation : RefactoringOperationBase<ConvertTo
         if (!PathResolver.IsValidCSharpFilePath(@params.SourceFile))
             throw new RefactoringException(ErrorCodes.InvalidSourcePath, "sourceFile must be a .cs file.");
 
+        if (@params.Line.HasValue && @params.Line.Value < 1)
+            throw new RefactoringException(ErrorCodes.InvalidLineNumber, "Line number must be >= 1.");
+
         if (@params.Column.HasValue && @params.Column.Value < 1)
             throw new RefactoringException(ErrorCodes.InvalidColumnNumber, "column must be >= 1.");
 

--- a/src/RoslynMcp.Core/Refactoring/Signature/ChangeSignatureOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Signature/ChangeSignatureOperation.cs
@@ -47,6 +47,9 @@ public sealed class ChangeSignatureOperation : RefactoringOperationBase<ChangeSi
         if (!PathResolver.IsValidCSharpFilePath(@params.SourceFile))
             throw new RefactoringException(ErrorCodes.InvalidSourcePath, "sourceFile must be a .cs file.");
 
+        if (@params.Line.HasValue && @params.Line.Value < 1)
+            throw new RefactoringException(ErrorCodes.InvalidLineNumber, "Line number must be >= 1.");
+
         if (@params.Column.HasValue && @params.Column.Value < 1)
             throw new RefactoringException(ErrorCodes.InvalidColumnNumber, "column must be >= 1.");
 

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertToAsyncOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertToAsyncOperationTests.cs
@@ -471,6 +471,34 @@ public class ConvertToAsyncOperationTests
     }
 
     [Fact]
+    public void Validate_InvalidLine_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            ConvertToAsyncOperation.Validate(new ConvertToAsyncParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                MethodName = "Process",
+                Line = 0
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidLineNumber, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_NegativeLine_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            ConvertToAsyncOperation.Validate(new ConvertToAsyncParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                MethodName = "Process",
+                Line = -1
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidLineNumber, ex.ErrorCode);
+    }
+
+    [Fact]
     public void Validate_AllFilesFalse_WithoutSourceFile_Throws()
     {
         var ex = Assert.Throws<RefactoringException>(() =>
@@ -535,6 +563,21 @@ public class ConvertToAsyncOperationTests
         Assert.Equal(ErrorCodes.MissingRequiredParam, ex.ErrorCode);
         Assert.Contains("allFiles", ex.Message, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("line", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Validate_AllFilesTrue_WithInvalidLine_ThrowsMissingRequiredParam()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            ConvertToAsyncOperation.Validate(new ConvertToAsyncParams
+            {
+                AllFiles = true,
+                Line = 0
+            }));
+
+        Assert.Equal(ErrorCodes.MissingRequiredParam, ex.ErrorCode);
+        Assert.Contains("allFiles cannot be combined with methodName, line, or column.", ex.Message);
+        Assert.NotEqual(ErrorCodes.InvalidLineNumber, ex.ErrorCode);
     }
 
     [Fact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Signature/ChangeSignatureOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Signature/ChangeSignatureOperationTests.cs
@@ -90,6 +90,38 @@ public class ChangeSignatureOperationTests
     }
 
     [Fact]
+    public void Validate_InvalidLine_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            ChangeSignatureOperation.Validate(new ChangeSignatureParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                MethodName = "Process",
+                Parameters = KeepXAddFlag(),
+                Line = 0
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidLineNumber, ex.ErrorCode);
+        Assert.Equal("1006", ex.ErrorCode);
+    }
+
+    [Fact]
+    public void Validate_NegativeLine_Throws()
+    {
+        var ex = Assert.Throws<RefactoringException>(() =>
+            ChangeSignatureOperation.Validate(new ChangeSignatureParams
+            {
+                SourceFile = AbsoluteTestPath(),
+                MethodName = "Process",
+                Parameters = KeepXAddFlag(),
+                Line = -1
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidLineNumber, ex.ErrorCode);
+        Assert.Equal("1006", ex.ErrorCode);
+    }
+
+    [Fact]
     public void Validate_MissingMethodName_Throws()
     {
         var ex = Assert.Throws<RefactoringException>(() =>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

`change_signature` and `convert_to_async` already take an optional 1-based `line` for method disambiguation and already reject `column < 1`, but they were the only two `*Operation` types that used `.Line` and threw `InvalidColumnNumber` without ever throwing `InvalidLineNumber`. A caller passing `line: 0` got a misleading downstream "method not found" instead of the input-validation error the rest of the surface returns.

This adds the sibling `line >= 1` guard to both `Validate` methods (`ErrorCodes.InvalidLineNumber`, `"Line number must be >= 1."`), placed immediately before each existing column check. `convert_to_async`'s `allFiles` mutual-exclusion check keeps precedence, so `allFiles: true` with a `line` still throws `MissingRequiredParam`.

No docs, schema, or CLI help already documented these per-tool `line >= 1` rules, so none were changed.

## Related Issues

Closes #368

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test additions or updates

## Testing

- [x] New tests added for new functionality
- [x] All existing tests pass (affected classes)
- [x] `dotnet build RoslynMcp.sln -c Release /p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors
- [x] `dotnet format RoslynMcp.sln --verify-no-changes` — clean

**Test Configuration**:
- OS: Linux
- .NET Version: 9.0.308

Workspace-free `Validate(...)` tests:
- `ChangeSignatureOperationTests`: `Line = 0` and negative `Line` throw `InvalidLineNumber`
- `ConvertToAsyncOperationTests`: same two cases, plus `AllFiles = true` with `Line = 0` still throws `MissingRequiredParam` (never `InvalidLineNumber`)

`dotnet test` filter for `ChangeSignatureOperationTests|ConvertToAsyncOperationTests`: **87 passed**, 0 failed.

## Additional Notes

Files touched:
- `src/RoslynMcp.Core/Refactoring/Signature/ChangeSignatureOperation.cs`
- `src/RoslynMcp.Core/Refactoring/Convert/ConvertToAsyncOperation.cs`
- `tests/RoslynMcp.Core.Tests/Refactoring/Signature/ChangeSignatureOperationTests.cs`
- `tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertToAsyncOperationTests.cs`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb3731d1-ea02-404f-9ad5-fd4b059c32fd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb3731d1-ea02-404f-9ad5-fd4b059c32fd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

