### PR TITLE
Delegate RenameNamespaceOperation.SpanCoversLine column branch to SpanCoversColumn

### DIFF
--- a/src/RoslynMcp.Core/Refactoring/Rename/RenameNamespaceOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Rename/RenameNamespaceOperation.cs
@@ -491,13 +491,7 @@ public sealed class RenameNamespaceOperation : RefactoringOperationBase<RenameNa
         if (!column.HasValue)
             return true;
 
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-        if (line == startLine && column.Value < startCol)
-            return false;
-        if (line == endLine && column.Value > endCol)
-            return false;
-        return true;
+        return SpanCoversColumn(span, line, column.Value);
     }
 
     /// <summary>

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Rename/RenameNamespaceOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Rename/RenameNamespaceOperationTests.cs
@@ -1410,6 +1410,43 @@ public class RenameNamespaceOperationTests
         Assert.False(RenameNamespaceOperation.SpanCoversColumn(span, line, startCol - 1));
     }
 
+    [Fact]
+    public void SpanCoversLine_WithColumn_TreatsEndAsExclusive()
+    {
+        const string source = "namespace A { class X {} }namespace B { class Y {} }";
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var ns = tree.GetRoot().DescendantNodes().OfType<BaseNamespaceDeclarationSyntax>()
+            .First(n => n.Name.ToString() == "A");
+        var span = ns.GetLocation().GetLineSpan();
+        var line = span.StartLinePosition.Line + 1;
+        var startCol = span.StartLinePosition.Character + 1;
+        var endCol = span.EndLinePosition.Character + 1;
+
+        Assert.True(RenameNamespaceOperation.SpanCoversLine(span, line, startCol));
+        Assert.True(RenameNamespaceOperation.SpanCoversLine(span, line, endCol - 1));
+        Assert.False(RenameNamespaceOperation.SpanCoversLine(span, line, endCol));
+        Assert.False(RenameNamespaceOperation.SpanCoversLine(span, line, startCol - 1));
+
+        const string multiLineSource = """
+            namespace A
+            {
+                class X {}
+            }
+            """;
+        var multiLineTree = CSharpSyntaxTree.ParseText(multiLineSource);
+        var multiLineNs = multiLineTree.GetRoot().DescendantNodes().OfType<BaseNamespaceDeclarationSyntax>()
+            .First(n => n.Name.ToString() == "A");
+        var multiLineSpan = multiLineNs.GetLocation().GetLineSpan();
+        var startLine = multiLineSpan.StartLinePosition.Line + 1;
+        var endLine = multiLineSpan.EndLinePosition.Line + 1;
+
+        for (var coveredLine = startLine; coveredLine <= endLine; coveredLine++)
+            Assert.True(RenameNamespaceOperation.SpanCoversLine(multiLineSpan, coveredLine, column: null));
+
+        Assert.False(RenameNamespaceOperation.SpanCoversLine(multiLineSpan, startLine - 1, column: null));
+        Assert.False(RenameNamespaceOperation.SpanCoversLine(multiLineSpan, endLine + 1, column: null));
+    }
+
     [SkippableFact]
     public async Task RenameNamespace_OmittedColumn_SameLine_ThrowsSymbolAmbiguous()
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

`RenameNamespaceOperation` still had two covering-span helpers with contradictory end-column semantics. `SpanCoversColumn` (from #350) correctly treats `FileLinePositionSpan.EndLinePosition` as exclusive (`column >= endCol` rejects), but the older `SpanCoversLine(span, line, int? column)` overload duplicated column logic inline with the pre-#350 inclusive end (`column.Value > endCol` rejects).

This PR removes that dead residue by delegating the column branch to `SpanCoversColumn`, exactly mirroring the already-correct sibling operations:

- `RenameFileToMatchTypeOperation.SpanCoversLine` (#352)
- `ConvertAnonymousToClassOperation.SpanCoversLine` (#365)
- `ConvertTupleToStructOperation.SpanCoversLine` (#367)

The line-range check and `column: null` short-circuit (whole multi-line declaration coverage) are unchanged. The sole production call site at L318–320 still passes `column: null`, so `rename_namespace` tool behavior is unchanged today; if a future caller passes a column, it now gets the same exclusive-end contract as the rest of the #338–#367 series.

## Test

- Added `SpanCoversLine_WithColumn_TreatsEndAsExclusive` mirroring the existing `SpanCoversColumn_TreatsEndAsExclusive` assertions (`true` at `startCol` and `endCol - 1`, `false` at `endCol` and `startCol - 1`), plus a `column: null` multi-line coverage case.
- `dotnet format --verify-no-changes` clean.
- Full `dotnet test` suite: 4505 passed, 0 failed.

Closes #370
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-304d5581-b737-400f-98c4-4553285bb55b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-304d5581-b737-400f-98c4-4553285bb55b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

