### PR TITLE
Make ConvertExpressionBodyOperation.SpanCoversColumn test-visible

### DIFF
--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertExpressionBodyOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertExpressionBodyOperation.cs
@@ -315,7 +315,7 @@ public sealed class ConvertExpressionBodyOperation : RefactoringOperationBase<Co
     /// inclusive would let the first character of an adjacent member also
     /// match the previous declaration.
     /// </summary>
-    private static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
+    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
     {
         var startLine = span.StartLinePosition.Line + 1;
         var endLine = span.EndLinePosition.Line + 1;

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertExpressionBodyOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertExpressionBodyOperationTests.cs
@@ -1020,6 +1020,28 @@ public class ConvertExpressionBodyOperationTests
 
     #endregion
 
+    #region SpanCoversColumn
+
+    [Fact]
+    public void SpanCoversColumn_TreatsEndAsExclusive()
+    {
+        const string source = "class C { public int A()=>1;public int B()=>2; }";
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var method = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>()
+            .First(m => m.Identifier.Text == "A");
+        var span = method.GetLocation().GetLineSpan();
+        var line = span.StartLinePosition.Line + 1;
+        var startCol = span.StartLinePosition.Character + 1;
+        var endCol = span.EndLinePosition.Character + 1;
+
+        Assert.True(ConvertExpressionBodyOperation.SpanCoversColumn(span, line, startCol));
+        Assert.True(ConvertExpressionBodyOperation.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(ConvertExpressionBodyOperation.SpanCoversColumn(span, line, endCol));
+        Assert.False(ConvertExpressionBodyOperation.SpanCoversColumn(span, line, startCol - 1));
+    }
+
+    #endregion
+
     #region Helpers
 
     private static void AssertMethodIsExpressionBodied(string source, string name)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Description

`ConvertExpressionBodyOperation.SpanCoversColumn` was the only covering-span helper still `private static`. Every sibling already exposes the same helper as `internal static` so tests can pin exclusive-end semantics (`column >= endCol` rejects).

This leftover changes only accessibility and adds the same pin test the siblings already have. The method body, XML contract, signature, and call sites are unchanged. `MemberCoversColumn`, `IdentifierCoversColumn`, and `GetIdentifierToken` stay private. `convert_expression_body` behavior is unchanged.

## 🔗 Related Issues

Closes #372

## 🎯 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🔧 Refactoring (no functional changes)
- [x] ✅ Test additions or updates
- [ ] 🏗️ Build/CI changes

## 🧪 Testing

- [x] All existing tests pass
- [x] New tests added for new functionality
- [ ] Manual testing performed

**Test Configuration**:
- OS: Linux
- .NET Version: 9.0.308

Local: `dotnet test tests/RoslynMcp.Core.Tests/RoslynMcp.Core.Tests.csproj --filter "FullyQualifiedName~ConvertExpressionBodyOperationTests"` — 40 passed (includes `SpanCoversColumn_TreatsEndAsExclusive`). `dotnet format --verify-no-changes` clean. Release build with `TreatWarningsAsErrors=true` — 0 warnings.

## ✅ Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added XML documentation for public APIs
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## 📋 Additional Notes

Out of scope per #372: no helper consolidation, no tool/schema/README/CLI changes, Dependabot PRs left alone.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-041b4f80-56b8-4a8b-9f3c-32a892c4c391?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-041b4f80-56b8-4a8b-9f3c-32a892c4c391&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

