### PR TITLE
Make convert_tuple/anonymous SpanCoversLine test-visible

### DIFF
--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertAnonymousToClassOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertAnonymousToClassOperation.cs
@@ -792,7 +792,7 @@ public sealed class ConvertAnonymousToClassOperation : RefactoringOperationBase<
         return true;
     }
 
-    private static bool SpanCoversLine(FileLinePositionSpan span, int line, int? column)
+    internal static bool SpanCoversLine(FileLinePositionSpan span, int line, int? column)
     {
         var startLine = span.StartLinePosition.Line + 1;
         var endLine = span.EndLinePosition.Line + 1;

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertTupleToStructOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertTupleToStructOperation.cs
@@ -1027,7 +1027,7 @@ public sealed class ConvertTupleToStructOperation : RefactoringOperationBase<Con
         return -1;
     }
 
-    private static bool SpanCoversLine(FileLinePositionSpan span, int line, int? column)
+    internal static bool SpanCoversLine(FileLinePositionSpan span, int line, int? column)
     {
         var startLine = span.StartLinePosition.Line + 1;
         var endLine = span.EndLinePosition.Line + 1;

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertAnonymousToClassOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertAnonymousToClassOperationTests.cs
@@ -566,6 +566,48 @@ public class ConvertAnonymousToClassOperationTests
         Assert.False(ConvertAnonymousToClassOperation.SpanCoversColumn(span, line, startCol - 1));
     }
 
+    [Fact]
+    public void SpanCoversLine_WithColumn_TreatsEndAsExclusive()
+    {
+        var tree = CSharpSyntaxTree.ParseText(SameLineAnonymousSource);
+        var first = tree.GetRoot().DescendantNodes().OfType<AnonymousObjectCreationExpressionSyntax>()
+            .First(n => n.ToString().Contains("Name", StringComparison.Ordinal));
+        var span = first.GetLocation().GetLineSpan();
+        var line = span.StartLinePosition.Line + 1;
+        var startCol = span.StartLinePosition.Character + 1;
+        var endCol = span.EndLinePosition.Character + 1;
+
+        Assert.True(ConvertAnonymousToClassOperation.SpanCoversLine(span, line, startCol));
+        Assert.True(ConvertAnonymousToClassOperation.SpanCoversLine(span, line, endCol - 1));
+        Assert.False(ConvertAnonymousToClassOperation.SpanCoversLine(span, line, endCol));
+        Assert.False(ConvertAnonymousToClassOperation.SpanCoversLine(span, line, startCol - 1));
+
+        const string multiLineSource = """
+            class C
+            {
+                void M()
+                {
+                    var first = new
+                    {
+                        Name = "Ada"
+                    };
+                }
+            }
+            """;
+        var multiLineTree = CSharpSyntaxTree.ParseText(multiLineSource);
+        var multiLineFirst = multiLineTree.GetRoot().DescendantNodes().OfType<AnonymousObjectCreationExpressionSyntax>()
+            .First(n => n.ToString().Contains("Name", StringComparison.Ordinal));
+        var multiLineSpan = multiLineFirst.GetLocation().GetLineSpan();
+        var startLine = multiLineSpan.StartLinePosition.Line + 1;
+        var endLine = multiLineSpan.EndLinePosition.Line + 1;
+
+        for (var coveredLine = startLine; coveredLine <= endLine; coveredLine++)
+            Assert.True(ConvertAnonymousToClassOperation.SpanCoversLine(multiLineSpan, coveredLine, column: null));
+
+        Assert.False(ConvertAnonymousToClassOperation.SpanCoversLine(multiLineSpan, startLine - 1, column: null));
+        Assert.False(ConvertAnonymousToClassOperation.SpanCoversLine(multiLineSpan, endLine + 1, column: null));
+    }
+
     #endregion
 
     #region Rejects

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertTupleToStructOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertTupleToStructOperationTests.cs
@@ -571,6 +571,48 @@ public class ConvertTupleToStructOperationTests
         Assert.False(ConvertTupleToStructOperation.SpanCoversColumn(span, line, startCol - 1));
     }
 
+    [Fact]
+    public void SpanCoversLine_WithColumn_TreatsEndAsExclusive()
+    {
+        var tree = CSharpSyntaxTree.ParseText(SameLineTupleSource);
+        var first = tree.GetRoot().DescendantNodes().OfType<TupleExpressionSyntax>()
+            .First(n => n.ToString().Contains("1, 2", StringComparison.Ordinal));
+        var span = first.GetLocation().GetLineSpan();
+        var line = span.StartLinePosition.Line + 1;
+        var startCol = span.StartLinePosition.Character + 1;
+        var endCol = span.EndLinePosition.Character + 1;
+
+        Assert.True(ConvertTupleToStructOperation.SpanCoversLine(span, line, startCol));
+        Assert.True(ConvertTupleToStructOperation.SpanCoversLine(span, line, endCol - 1));
+        Assert.False(ConvertTupleToStructOperation.SpanCoversLine(span, line, endCol));
+        Assert.False(ConvertTupleToStructOperation.SpanCoversLine(span, line, startCol - 1));
+
+        const string multiLineSource = """
+            class C
+            {
+                void M()
+                {
+                    var first = (
+                        1,
+                        2
+                    );
+                }
+            }
+            """;
+        var multiLineTree = CSharpSyntaxTree.ParseText(multiLineSource);
+        var multiLineFirst = multiLineTree.GetRoot().DescendantNodes().OfType<TupleExpressionSyntax>()
+            .First(n => n.ToString().Contains("1", StringComparison.Ordinal));
+        var multiLineSpan = multiLineFirst.GetLocation().GetLineSpan();
+        var startLine = multiLineSpan.StartLinePosition.Line + 1;
+        var endLine = multiLineSpan.EndLinePosition.Line + 1;
+
+        for (var coveredLine = startLine; coveredLine <= endLine; coveredLine++)
+            Assert.True(ConvertTupleToStructOperation.SpanCoversLine(multiLineSpan, coveredLine, column: null));
+
+        Assert.False(ConvertTupleToStructOperation.SpanCoversLine(multiLineSpan, startLine - 1, column: null));
+        Assert.False(ConvertTupleToStructOperation.SpanCoversLine(multiLineSpan, endLine + 1, column: null));
+    }
+
     #endregion
 
     #region Rejects


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Description

`ConvertTupleToStructOperation.SpanCoversLine` and `ConvertAnonymousToClassOperation.SpanCoversLine` were the only covering-span line helpers still `private static`. Every sibling already exposes the same helper as `internal static` so tests can pin exclusive-end column semantics and null-column line coverage.

This leftover changes only accessibility and adds `SpanCoversLine_WithColumn_TreatsEndAsExclusive` to both convert test files, mirroring `RenameNamespaceOperationTests`. The method bodies, signatures, and call sites are unchanged. `convert_tuple_to_struct` / `convert_anonymous_to_class` behavior is unchanged.

## 🔗 Related Issues

Closes #374

## 🎯 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🔧 Refactoring (no functional changes)
- [x] ✅ Test additions or updates
- [ ] 🏗️ Build/CI changes

## 🧪 Testing

- [x] All existing tests pass
- [x] New tests added for new functionality
- [ ] Manual testing performed

**Test Configuration**:
- OS: Linux
- .NET Version: 9.0.308

Local:
- `dotnet test tests/RoslynMcp.Core.Tests/RoslynMcp.Core.Tests.csproj --filter "FullyQualifiedName~ConvertTupleToStructOperationTests.SpanCovers|FullyQualifiedName~ConvertAnonymousToClassOperationTests.SpanCovers"` — 4 passed (`SpanCoversColumn_TreatsEndAsExclusive` + `SpanCoversLine_WithColumn_TreatsEndAsExclusive` on both operations).
- Same project with the two full test classes — 69 passed.
- `dotnet format --verify-no-changes` clean.
- `dotnet build RoslynMcp.sln -c Release --no-restore /p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors.

## ✅ Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added XML documentation for public APIs
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## 📋 Additional Notes

Out of scope per #374: no helper consolidation, no tool/schema/README/CLI changes, Dependabot PRs left alone.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9e64948-0caa-4de6-9c8b-94cfc64fb3d9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9e64948-0caa-4de6-9c8b-94cfc64fb3d9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

