### PR TITLE
Honor inline_method call-site exclusive-end covering-span column

### DIFF
--- a/src/RoslynMcp.Core/Refactoring/Inline/InlineMethodOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Inline/InlineMethodOperation.cs
@@ -539,7 +539,7 @@ public sealed class InlineMethodOperation : RefactoringOperationBase<InlineMetho
         return null;
     }
 
-    private static bool MatchesCallSiteLocation(
+    internal static bool MatchesCallSiteLocation(
         Document document,
         InvocationExpressionSyntax invocation,
         CallSiteLocation location)
@@ -548,23 +548,7 @@ public sealed class InlineMethodOperation : RefactoringOperationBase<InlineMetho
             return false;
 
         var span = invocation.GetLocation().GetLineSpan();
-        var startLine = span.StartLinePosition.Line + 1;
-        var startColumn = span.StartLinePosition.Character + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var endColumn = span.EndLinePosition.Character + 1;
-        if (location.Line < startLine || location.Line > endLine)
-            return false;
-
-        if (startLine == endLine)
-        {
-            return location.Column >= startColumn && location.Column <= endColumn;
-        }
-
-        if (location.Line == startLine)
-            return location.Column >= startColumn;
-        if (location.Line == endLine)
-            return location.Column <= endColumn;
-        return true;
+        return SpanCoversColumn(span, location.Line, location.Column);
     }
 
     private static async Task ValidateCallSitesAsync(

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Inline/InlineMethodOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Inline/InlineMethodOperationTests.cs
@@ -920,7 +920,7 @@ public class InlineMethodOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        var workspace = new AdhocWorkspace();
+        using var workspace = new AdhocWorkspace();
         var project = workspace.AddProject("P", LanguageNames.CSharp);
         var document = project.AddDocument("Calls.cs", source, filePath: filePath);
 

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Inline/InlineMethodOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Inline/InlineMethodOperationTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using RoslynMcp.Contracts.Errors;
@@ -903,6 +904,34 @@ public class InlineMethodOperationTests
         Assert.True(InlineMethodOperation.SpanCoversColumn(span, line, endCol - 1));
         Assert.False(InlineMethodOperation.SpanCoversColumn(span, line, endCol));
         Assert.False(InlineMethodOperation.SpanCoversColumn(span, line, startCol - 1));
+    }
+
+    [Fact]
+    public void MatchesCallSiteLocation_TreatsEndAsExclusive()
+    {
+        const string source = "class C { void M() { Log();Log(); } void Log() {} }";
+        const string filePath = "Calls.cs";
+
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var first = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .First();
+        var span = first.GetLocation().GetLineSpan();
+        var line = span.StartLinePosition.Line + 1;
+        var startCol = span.StartLinePosition.Character + 1;
+        var endCol = span.EndLinePosition.Character + 1;
+
+        var workspace = new AdhocWorkspace();
+        var project = workspace.AddProject("P", LanguageNames.CSharp);
+        var document = project.AddDocument("Calls.cs", source, filePath: filePath);
+
+        Assert.True(InlineMethodOperation.MatchesCallSiteLocation(
+            document, first, new CallSiteLocation { File = filePath, Line = line, Column = startCol }));
+        Assert.True(InlineMethodOperation.MatchesCallSiteLocation(
+            document, first, new CallSiteLocation { File = filePath, Line = line, Column = endCol - 1 }));
+        Assert.False(InlineMethodOperation.MatchesCallSiteLocation(
+            document, first, new CallSiteLocation { File = filePath, Line = line, Column = endCol }));
+        Assert.False(InlineMethodOperation.MatchesCallSiteLocation(
+            document, first, new CallSiteLocation { File = filePath, Line = line, Column = startCol - 1 }));
     }
 
     [SkippableFact]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Description

`InlineMethodOperation.MatchesCallSiteLocation` treated `FileLinePositionSpan.EndLinePosition` as inclusive (`location.Column <= endColumn`). Every other covering-span helper on master — including `SpanCoversColumn` in the same file, already used by method pick — rejects `column >= endCol`.

That let the first character of an adjacent invocation also match the previous call. After the file-path check, `MatchesCallSiteLocation` now delegates column coverage to existing exclusive-end `SpanCoversColumn`. The helper is `internal static` so tests can pin it.

## 🔗 Related Issues

Closes #376

## 🎯 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [x] ✅ Test additions or updates
- [ ] 🏗️ Build/CI changes

## 🧪 Testing

- [x] New `MatchesCallSiteLocation_TreatsEndAsExclusive` asserts the first of two adjacent `Log();Log();` invocations is true at `startCol` / `endCol - 1` and false at `endCol` / `startCol - 1`.
- [x] Copilot leftover-scope review: `using var workspace = new AdhocWorkspace()` so the only `AdhocWorkspace` in this file is disposed.
- [x] `dotnet format --verify-no-changes` clean
- [x] `dotnet build -warnaserror` warning-free
- [x] All `InlineMethodOperationTests` pass (38 passed, 0 skipped)

**Test Configuration**:
- OS: Linux (Ubuntu 24.04)
- .NET Version: 9.0.317

## ✅ Checklist

- [x] Diff limited to `InlineMethodOperation.cs` + `InlineMethodOperationTests.cs`
- [x] Omitted-column method pick (identifier start-line) left unchanged
- [x] No helper consolidation, sibling-operation, params, schema, README, or CLI changes
- [x] `dotnet format` clean and warning-free build

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc10eb9f-5d25-47b5-9584-659930a74128?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc10eb9f-5d25-47b5-9584-659930a74128&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

