### PR TITLE
Honor exclusive-end line in optional-column SpanCoversLine omit-column path

### DIFF
--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertAnonymousToClassOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertAnonymousToClassOperation.cs
@@ -798,6 +798,8 @@ public sealed class ConvertAnonymousToClassOperation : RefactoringOperationBase<
         var endLine = span.EndLinePosition.Line + 1;
         if (line < startLine || line > endLine)
             return false;
+        if (line == endLine && span.EndLinePosition.Character == 0)
+            return false;
 
         if (!column.HasValue)
             return true;

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertTupleToStructOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertTupleToStructOperation.cs
@@ -1033,6 +1033,8 @@ public sealed class ConvertTupleToStructOperation : RefactoringOperationBase<Con
         var endLine = span.EndLinePosition.Line + 1;
         if (line < startLine || line > endLine)
             return false;
+        if (line == endLine && span.EndLinePosition.Character == 0)
+            return false;
 
         if (!column.HasValue)
             return true;

--- a/src/RoslynMcp.Core/Refactoring/Rename/RenameFileToMatchTypeOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Rename/RenameFileToMatchTypeOperation.cs
@@ -727,6 +727,8 @@ public sealed class RenameFileToMatchTypeOperation : RefactoringOperationBase<Re
         var endLine = span.EndLinePosition.Line + 1;
         if (line < startLine || line > endLine)
             return false;
+        if (line == endLine && span.EndLinePosition.Character == 0)
+            return false;
 
         if (!column.HasValue)
             return true;

--- a/src/RoslynMcp.Core/Refactoring/Rename/RenameNamespaceOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Rename/RenameNamespaceOperation.cs
@@ -487,6 +487,8 @@ public sealed class RenameNamespaceOperation : RefactoringOperationBase<RenameNa
         var endLine = span.EndLinePosition.Line + 1;
         if (line < startLine || line > endLine)
             return false;
+        if (line == endLine && span.EndLinePosition.Character == 0)
+            return false;
 
         if (!column.HasValue)
             return true;

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertAnonymousToClassOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertAnonymousToClassOperationTests.cs
@@ -608,6 +608,19 @@ public class ConvertAnonymousToClassOperationTests
         Assert.False(ConvertAnonymousToClassOperation.SpanCoversLine(multiLineSpan, endLine + 1, column: null));
     }
 
+    [Fact]
+    public void SpanCoversLine_TreatsEndAsExclusive()
+    {
+        var span = new FileLinePositionSpan(
+            "t.cs",
+            new LinePosition(0, 0),
+            new LinePosition(2, 0));
+
+        Assert.True(ConvertAnonymousToClassOperation.SpanCoversLine(span, 1, column: null));
+        Assert.True(ConvertAnonymousToClassOperation.SpanCoversLine(span, 2, column: null));
+        Assert.False(ConvertAnonymousToClassOperation.SpanCoversLine(span, 3, column: null));
+    }
+
     #endregion
 
     #region Rejects

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertTupleToStructOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertTupleToStructOperationTests.cs
@@ -613,6 +613,19 @@ public class ConvertTupleToStructOperationTests
         Assert.False(ConvertTupleToStructOperation.SpanCoversLine(multiLineSpan, endLine + 1, column: null));
     }
 
+    [Fact]
+    public void SpanCoversLine_TreatsEndAsExclusive()
+    {
+        var span = new FileLinePositionSpan(
+            "t.cs",
+            new LinePosition(0, 0),
+            new LinePosition(2, 0));
+
+        Assert.True(ConvertTupleToStructOperation.SpanCoversLine(span, 1, column: null));
+        Assert.True(ConvertTupleToStructOperation.SpanCoversLine(span, 2, column: null));
+        Assert.False(ConvertTupleToStructOperation.SpanCoversLine(span, 3, column: null));
+    }
+
     #endregion
 
     #region Rejects

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Rename/RenameFileToMatchTypeOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Rename/RenameFileToMatchTypeOperationTests.cs
@@ -1,5 +1,7 @@
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
 using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
@@ -552,6 +554,19 @@ public class RenameFileToMatchTypeOperationTests
         Assert.True(File.Exists(workspace.SourcePath));
         Assert.False(File.Exists(Path.Combine(workspace.DirectoryPath, "Alpha.cs")));
         Assert.False(File.Exists(Path.Combine(workspace.DirectoryPath, "Beta.cs")));
+    }
+
+    [Fact]
+    public void SpanCoversLine_TreatsEndAsExclusive()
+    {
+        var span = new FileLinePositionSpan(
+            "t.cs",
+            new LinePosition(0, 0),
+            new LinePosition(2, 0));
+
+        Assert.True(RenameFileToMatchTypeOperation.SpanCoversLine(span, 1, column: null));
+        Assert.True(RenameFileToMatchTypeOperation.SpanCoversLine(span, 2, column: null));
+        Assert.False(RenameFileToMatchTypeOperation.SpanCoversLine(span, 3, column: null));
     }
 
     #endregion

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Rename/RenameNamespaceOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Rename/RenameNamespaceOperationTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
 using RoslynMcp.Contracts.Enums;
 using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
@@ -1445,6 +1446,19 @@ public class RenameNamespaceOperationTests
 
         Assert.False(RenameNamespaceOperation.SpanCoversLine(multiLineSpan, startLine - 1, column: null));
         Assert.False(RenameNamespaceOperation.SpanCoversLine(multiLineSpan, endLine + 1, column: null));
+    }
+
+    [Fact]
+    public void SpanCoversLine_TreatsEndAsExclusive()
+    {
+        var span = new FileLinePositionSpan(
+            "t.cs",
+            new LinePosition(0, 0),
+            new LinePosition(2, 0));
+
+        Assert.True(RenameNamespaceOperation.SpanCoversLine(span, 1, column: null));
+        Assert.True(RenameNamespaceOperation.SpanCoversLine(span, 2, column: null));
+        Assert.False(RenameNamespaceOperation.SpanCoversLine(span, 3, column: null));
     }
 
     [SkippableFact]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Description

The four optional-column `SpanCoversLine(FileLinePositionSpan, int line, int? column)` helpers treated `line == endLine` as covered when `column` was omitted, even if `EndLinePosition.Character == 0`.

`FileLinePositionSpan.EndLinePosition` is exclusive. A span that ends at the start of a line does not cover that line. Pure-line siblings (`EncapsulateFieldOperation.SpanCoversLine` and others) already reject that case. This leftover adds the same check on the omit-column path:

```csharp
if (line == endLine && span.EndLinePosition.Character == 0)
    return false;
```

after the line-range check and before `if (!column.HasValue) return true;`.

Helpers updated:
- `ConvertAnonymousToClassOperation.SpanCoversLine`
- `ConvertTupleToStructOperation.SpanCoversLine`
- `RenameNamespaceOperation.SpanCoversLine`
- `RenameFileToMatchTypeOperation.SpanCoversLine`

Column-path `SpanCoversColumn` bodies are unchanged.

## 🔗 Related Issues

Closes #378

## 🎯 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [x] ✅ Test additions or updates
- [ ] 🏗️ Build/CI changes

## 🧪 Testing

- [x] New omit-column `SpanCoversLine_TreatsEndAsExclusive` tests added for all four helpers
- [x] All existing tests pass in the four affected test classes (202 passed)
- [x] All `SpanCoversLine_TreatsEndAsExclusive` tests pass (18, including the four new ones)
- [x] `dotnet build` warning-free (`TreatWarningsAsErrors=true`, analyzers + code style)
- [x] `dotnet format --verify-no-changes` clean

**Test Configuration**:
- OS: Linux
- .NET Version: 9.0.317

Each new test constructs `FileLinePositionSpan` from `LinePosition(0, 0)` to `LinePosition(2, 0)` and asserts true for lines 1–2, false for line 3, calling `SpanCoversLine(span, line, column: null)`. Existing `SpanCoversLine_WithColumn_TreatsEndAsExclusive` tests are unchanged.

## ✅ Checklist

- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added XML documentation for public APIs
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## 📋 Additional Notes

Diff is limited to four helpers + four tests. No shared-type consolidation. `SimplifyNameOperation.SpanTouchesLine`, `ConvertToBlockBodyOperation.ContainsLine`, and Dependabot PRs are untouched.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51bd097a-37d2-4774-a9e0-298d3a8acdc0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51bd097a-37d2-4774-a9e0-298d3a8acdc0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

