### PR TITLE
Add convert_to_async SpanCoversColumn_TreatsEndAsExclusive

### DIFF
--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertToAsyncOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertToAsyncOperationTests.cs
@@ -1708,6 +1708,28 @@ public class ConvertToAsyncOperationTests
 
     #endregion
 
+    #region SpanCoversColumn
+
+    [Fact]
+    public void SpanCoversColumn_TreatsEndAsExclusive()
+    {
+        const string source = "class C { public void A(){Task.Delay(1);}public void B(){Task.Delay(2);} }";
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var method = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>()
+            .First(m => m.Identifier.Text == "A");
+        var span = method.GetLocation().GetLineSpan();
+        var line = span.StartLinePosition.Line + 1;
+        var startCol = span.StartLinePosition.Character + 1;
+        var endCol = span.EndLinePosition.Character + 1;
+
+        Assert.True(ConvertToAsyncOperation.SpanCoversColumn(span, line, startCol));
+        Assert.True(ConvertToAsyncOperation.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(ConvertToAsyncOperation.SpanCoversColumn(span, line, endCol));
+        Assert.False(ConvertToAsyncOperation.SpanCoversColumn(span, line, startCol - 1));
+    }
+
+    #endregion
+
     #region Helpers
 
     private static string NormalizeNewlines(string text) => text.Replace("\r\n", "\n");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Description

`ConvertToAsyncOperation.SpanCoversColumn` is already exclusive-end (`column >= endCol` rejects) and `internal static`, but `ConvertToAsyncOperationTests` never called it. Every other covering-span sibling already pins `SpanCoversColumn_TreatsEndAsExclusive`. `convert_to_async` only had `FindMethod_AdjacentMethods_ExclusiveEndDoesNotStealNextMethod`, which exercises method pick, not the helper.

This leftover adds that pin only. The helper body, `FindMethod`, and tool surface are unchanged.

## 🔗 Related Issues

Closes #380

## 🎯 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [x] ✅ Test additions or updates
- [ ] 🏗️ Build/CI changes

## 🧪 Testing

- [x] All existing tests pass
- [x] New tests added for new functionality

`ConvertToAsyncOperationTests.SpanCoversColumn_TreatsEndAsExclusive` mirrors `ConvertExpressionBodyOperationTests` (~L1025-1041): two adjacent methods on one line, true at `startCol` and `endCol - 1`, false at `endCol` and `startCol - 1`, calling `ConvertToAsyncOperation.SpanCoversColumn`.

Local (net9.0 / Linux):
- `ConvertToAsyncOperationTests`: 66 passed (includes `SpanCoversColumn_TreatsEndAsExclusive`)
- `dotnet format tests/RoslynMcp.Core.Tests/RoslynMcp.Core.Tests.csproj --verify-no-changes` clean
- Release build with `TreatWarningsAsErrors=true`: 0 warnings

**Test Configuration**:
- OS: Linux
- .NET Version: 9.0.317

## ✅ Checklist

- [x] Diff limited to `ConvertToAsyncOperationTests.cs`
- [x] `ConvertToAsyncOperation.SpanCoversColumn` left unchanged
- [x] Omitted-column / start-line `FindMethod` left unchanged
- [x] No helper consolidation, sibling-operation, AllFiles, schema, README, CLI, or Dependabot changes
- [x] `dotnet format` clean and warning-free build

## 📋 Additional Notes

Out of scope per #380: no production change unless the new test proves the helper is inclusive (it is exclusive on master `0de373cd5302e12ce3beff85b98fe104aa068b8c`). One leftover only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c4a71bf-676e-40c5-84e7-3a59f77d6cac?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c4a71bf-676e-40c5-84e7-3a59f77d6cac&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

