### PR TITLE
Honor exclusive-end line in ContainsLine and SpanTouchesLine

### DIFF
--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertToBlockBodyOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertToBlockBodyOperation.cs
@@ -250,12 +250,24 @@ public sealed class ConvertToBlockBodyOperation : RefactoringOperationBase<Conve
         return true;
     }
 
-    private static bool ContainsLine(SyntaxNode node, int line)
+    /// <summary>
+    /// 1-based line coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
+    /// is exclusive, so a span that ends at the start of a line does not
+    /// cover that line. Treating the end as inclusive would let the first
+    /// line of an adjacent member also match the previous declaration. Same
+    /// exclusive-end idea as <c>EncapsulateFieldOperation.SpanCoversLine</c>.
+    /// </summary>
+    internal static bool ContainsLine(SyntaxNode node, int line)
     {
         var span = node.GetLocation().GetLineSpan();
         var start = span.StartLinePosition.Line + 1;
         var end = span.EndLinePosition.Line + 1;
-        return line >= start && line <= end;
+
+        if (line < start || line > end)
+            return false;
+        if (line == end && span.EndLinePosition.Character == 0)
+            return false;
+        return true;
     }
 
     private static bool IsConvertibleKind(SyntaxNode node) => node is

--- a/src/RoslynMcp.Core/Refactoring/Convert/SimplifyNameOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/SimplifyNameOperation.cs
@@ -1014,12 +1014,24 @@ public sealed class SimplifyNameOperation : RefactoringOperationBase<SimplifyNam
         return false;
     }
 
-    private static bool SpanTouchesLine(SyntaxNode node, int line)
+    /// <summary>
+    /// 1-based line coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
+    /// is exclusive, so a span that ends at the start of a line does not
+    /// cover that line. Treating the end as inclusive would let the first
+    /// line of an adjacent name also match the previous name. Same
+    /// exclusive-end idea as <c>EncapsulateFieldOperation.SpanCoversLine</c>.
+    /// </summary>
+    internal static bool SpanTouchesLine(SyntaxNode node, int line)
     {
         var span = node.GetLocation().GetLineSpan();
         var startLine = span.StartLinePosition.Line + 1;
         var endLine = span.EndLinePosition.Line + 1;
-        return line >= startLine && line <= endLine;
+
+        if (line < startLine || line > endLine)
+            return false;
+        if (line == endLine && span.EndLinePosition.Character == 0)
+            return false;
+        return true;
     }
 
     /// <summary>

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertToBlockBodyOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertToBlockBodyOperationTests.cs
@@ -666,6 +666,23 @@ public class ConvertToBlockBodyOperationTests
         Assert.False(ConvertToBlockBodyOperation.SpanCoversColumn(span, line, startCol - 1));
     }
 
+    [Fact]
+    public void ContainsLine_TreatsEndAsExclusive()
+    {
+        // Trailing newline puts the compilation unit's exclusive end at (2, 0),
+        // the same FileLinePositionSpan EncapsulateFieldOperationTests pins.
+        const string source = "class C\n{}\n";
+        var node = CSharpSyntaxTree.ParseText(source).GetRoot();
+        var span = node.GetLocation().GetLineSpan();
+
+        Assert.Equal(new LinePosition(0, 0), span.StartLinePosition);
+        Assert.Equal(new LinePosition(2, 0), span.EndLinePosition);
+
+        Assert.True(ConvertToBlockBodyOperation.ContainsLine(node, 1));
+        Assert.True(ConvertToBlockBodyOperation.ContainsLine(node, 2));
+        Assert.False(ConvertToBlockBodyOperation.ContainsLine(node, 3));
+    }
+
     #endregion
 
     #region P0 Preview

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/SimplifyNameOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/SimplifyNameOperationTests.cs
@@ -285,6 +285,23 @@ public class SimplifyNameOperationTests
     }
 
     [Fact]
+    public void SpanTouchesLine_TreatsEndAsExclusive()
+    {
+        // Trailing newline puts the compilation unit's exclusive end at (2, 0),
+        // the same FileLinePositionSpan EncapsulateFieldOperationTests pins.
+        const string source = "class C\n{}\n";
+        var node = CSharpSyntaxTree.ParseText(source).GetRoot();
+        var span = node.GetLocation().GetLineSpan();
+
+        Assert.Equal(new LinePosition(0, 0), span.StartLinePosition);
+        Assert.Equal(new LinePosition(2, 0), span.EndLinePosition);
+
+        Assert.True(SimplifyNameOperation.SpanTouchesLine(node, 1));
+        Assert.True(SimplifyNameOperation.SpanTouchesLine(node, 2));
+        Assert.False(SimplifyNameOperation.SpanTouchesLine(node, 3));
+    }
+
+    [Fact]
     public void GetRightmostIdentifier_QualifiedGeneric()
     {
         var name = SyntaxFactory.ParseName("System.Collections.Generic.List<int>");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 📝 Description

`ConvertToBlockBodyOperation.ContainsLine` and `SimplifyNameOperation.SpanTouchesLine` treated `FileLinePositionSpan.EndLinePosition` as inclusive (`line >= start && line <= end`).

`FileLinePositionSpan.EndLinePosition` is exclusive. A span that ends at the start of a line (`Character == 0`) does not cover that line. Every `SpanCoversLine` sibling already rejects that case. These two differently named helpers were deferred by #378/#379.

After the line-range check, both helpers now reject the exclusive end-of-span line:

```csharp
if (line == end && span.EndLinePosition.Character == 0) return false;
```

Both helpers are `internal static` so tests can pin them. `SpanCoversColumn` bodies are unchanged. Helpers are not consolidated into a shared type.

## 🔗 Related Issues

Closes #382

## 🎯 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [x] ✅ Test additions or updates
- [ ] 🏗️ Build/CI changes

## 🧪 Testing

- [x] All existing tests pass
- [x] New tests added for new functionality
- [x] Local build and format verified

`ContainsLine_TreatsEndAsExclusive` and `SpanTouchesLine_TreatsEndAsExclusive` parse a fixture whose `GetLineSpan()` ends at `(2, 0)` and assert true for lines 1–2, false for line 3 — the same exclusive-end case as `EncapsulateFieldOperationTests.SpanCoversLine_TreatsEndAsExclusive`.

Local (net9.0 / Linux):
- `ContainsLine_TreatsEndAsExclusive` + `SpanTouchesLine_TreatsEndAsExclusive`: 2 passed
- `ConvertToBlockBodyOperationTests` + `SimplifyNameOperationTests`: 82 passed
- `dotnet format RoslynMcp.sln --verify-no-changes` clean
- Release build with `TreatWarningsAsErrors=true` + analyzers + code style: 0 warnings

**Test Configuration**:
- OS: Linux
- .NET Version: 9.0.317

## ✅ Checklist

- [x] Diff limited to the two helpers and two pin tests
- [x] `SpanCoversColumn` left unchanged
- [x] No helper consolidation, AllFiles, schema, README, CLI, or Dependabot changes
- [x] `dotnet format` clean and warning-free build

## 📋 Additional Notes

One leftover only. Out of scope per #382: shared helper type, `SpanCoversColumn`, convert_to_block_body / rename_namespace / generate_property AllFiles, Dependabot PRs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2db63d92-c1f6-4b30-9675-f7349394965e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2db63d92-c1f6-4b30-9675-f7349394965e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

