### PR TITLE
Honor extract_constant endLine/endColumn validation (#385)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+- `extract_constant` now validates `endLine` / `endColumn` like `extract_method` (reject `< 1` and exclusive-end empty/inverted selections with `InvalidLineNumber` / `InvalidColumnNumber` / `InvalidSelectionRange`) before indexing source lines
+
 ## [0.5.0] - 2026-09-07
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Fixed
-- `extract_constant` now validates `endLine` / `endColumn` like `extract_method` (reject `< 1` and exclusive-end empty/inverted selections with `InvalidLineNumber` / `InvalidColumnNumber` / `InvalidSelectionRange`) before indexing source lines
+- `extract_constant` now validates `endLine` / `endColumn` like `extract_method` (reject `< 1` and exclusive-end empty/inverted selections with `InvalidLineNumber` / `InvalidColumnNumber` / `InvalidSelectionRange`) and resolves positions with the same bounds-checked helper so out-of-range ends map to those errors instead of crashing
 
 ## [0.5.0] - 2026-09-07
 

--- a/src/RoslynMcp.Core/Refactoring/Extract/ExtractConstantOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/ExtractConstantOperation.cs
@@ -78,10 +78,10 @@ public sealed class ExtractConstantOperation : RefactoringOperationBase<ExtractC
             throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse file.");
         }
 
-        // Get text span from line/column
+        // Get text span from line/column (bounds-checked like extract_method)
         var sourceText = await document.GetTextAsync(cancellationToken);
-        var startPosition = sourceText.Lines[@params.StartLine - 1].Start + @params.StartColumn - 1;
-        var endPosition = sourceText.Lines[@params.EndLine - 1].Start + @params.EndColumn - 1;
+        var startPosition = GetPosition(sourceText, @params.StartLine, @params.StartColumn);
+        var endPosition = GetPosition(sourceText, @params.EndLine, @params.EndColumn);
         var span = TextSpan.FromBounds(startPosition, endPosition);
 
         // Find literal at span
@@ -327,5 +327,30 @@ public sealed class ExtractConstantOperation : RefactoringOperationBase<ExtractC
         if (string.IsNullOrEmpty(name)) return false;
         if (!char.IsLetter(name[0]) && name[0] != '_') return false;
         return name.All(c => char.IsLetterOrDigit(c) || c == '_');
+    private static int GetPosition(SourceText text, int line, int column)
+    {
+        var lineIndex = line - 1; // Convert to 0-based
+
+        if (lineIndex < 0 || lineIndex >= text.Lines.Count)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidLineNumber,
+                $"Line {line} is out of range. File has {text.Lines.Count} lines.");
+        }
+
+        var lineInfo = text.Lines[lineIndex];
+        var columnIndex = column - 1; // Convert to 0-based
+        var lineLength = lineInfo.End - lineInfo.Start;
+
+        if (columnIndex < 0 || columnIndex > lineLength)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidColumnNumber,
+                $"Column {column} is out of range for line {line} (line has {lineLength} characters).");
+        }
+
+        return lineInfo.Start + columnIndex;
+    }
+
     }
 }

--- a/src/RoslynMcp.Core/Refactoring/Extract/ExtractConstantOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/ExtractConstantOperation.cs
@@ -46,11 +46,15 @@ public sealed class ExtractConstantOperation : RefactoringOperationBase<ExtractC
         if (!File.Exists(@params.SourceFile))
             throw new RefactoringException(ErrorCodes.SourceFileNotFound, $"Source file not found: {@params.SourceFile}");
 
-        if (@params.StartLine < 1)
-            throw new RefactoringException(ErrorCodes.InvalidLineNumber, "startLine must be >= 1.");
+        if (@params.StartLine < 1 || @params.EndLine < 1)
+            throw new RefactoringException(ErrorCodes.InvalidLineNumber, "Line numbers must be >= 1.");
 
-        if (@params.StartColumn < 1)
-            throw new RefactoringException(ErrorCodes.InvalidColumnNumber, "startColumn must be >= 1.");
+        if (@params.StartColumn < 1 || @params.EndColumn < 1)
+            throw new RefactoringException(ErrorCodes.InvalidColumnNumber, "Column numbers must be >= 1.");
+
+        if (@params.StartLine > @params.EndLine ||
+            (@params.StartLine == @params.EndLine && @params.StartColumn >= @params.EndColumn))
+            throw new RefactoringException(ErrorCodes.InvalidSelectionRange, "Selection start must be before end.");
 
         if (!IsValidIdentifier(@params.ConstantName))
             throw new RefactoringException(ErrorCodes.InvalidSymbolName, $"Invalid constant name: {@params.ConstantName}");

--- a/src/RoslynMcp.Core/Refactoring/Extract/ExtractConstantOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/ExtractConstantOperation.cs
@@ -327,6 +327,8 @@ public sealed class ExtractConstantOperation : RefactoringOperationBase<ExtractC
         if (string.IsNullOrEmpty(name)) return false;
         if (!char.IsLetter(name[0]) && name[0] != '_') return false;
         return name.All(c => char.IsLetterOrDigit(c) || c == '_');
+    }
+
     private static int GetPosition(SourceText text, int line, int column)
     {
         var lineIndex = line - 1; // Convert to 0-based
@@ -352,5 +354,4 @@ public sealed class ExtractConstantOperation : RefactoringOperationBase<ExtractC
         return lineInfo.Start + columnIndex;
     }
 
-    }
 }

--- a/tests/RoslynMcp.Core.Tests/Refactoring/ExtractConstantParamsValidationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/ExtractConstantParamsValidationTests.cs
@@ -1,0 +1,141 @@
+using RoslynMcp.Contracts.Errors;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.Refactoring;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Refactoring;
+
+/// <summary>
+/// Tests for ExtractConstantParams validation (mirrors ExtractConstantOperation.ValidateParams rules for end bounds).
+/// </summary>
+public class ExtractConstantParamsValidationTests
+{
+    private static string AbsoluteTestPath(string extension = ".cs") =>
+        OperatingSystem.IsWindows()
+            ? $"C:\\test\\file{extension}"
+            : $"/test/file{extension}";
+
+    [Fact]
+    public void ValidateParams_InvalidEndLine_ThrowsException()
+    {
+        var @params = new ExtractConstantParams
+        {
+            SourceFile = AbsoluteTestPath(),
+            StartLine = 1,
+            StartColumn = 1,
+            EndLine = 0,
+            EndColumn = 10,
+            ConstantName = "ExtractedConstant"
+        };
+
+        var ex = Assert.Throws<RefactoringException>(() =>
+            ThrowIfInvalidParams(@params));
+
+        Assert.Equal(ErrorCodes.InvalidLineNumber, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void ValidateParams_InvalidEndColumn_ThrowsException()
+    {
+        var @params = new ExtractConstantParams
+        {
+            SourceFile = AbsoluteTestPath(),
+            StartLine = 1,
+            StartColumn = 1,
+            EndLine = 5,
+            EndColumn = 0,
+            ConstantName = "ExtractedConstant"
+        };
+
+        var ex = Assert.Throws<RefactoringException>(() =>
+            ThrowIfInvalidParams(@params));
+
+        Assert.Equal(ErrorCodes.InvalidColumnNumber, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void ValidateParams_SelectionEndBeforeStart_ThrowsException()
+    {
+        var @params = new ExtractConstantParams
+        {
+            SourceFile = AbsoluteTestPath(),
+            StartLine = 5,
+            StartColumn = 1,
+            EndLine = 3,
+            EndColumn = 10,
+            ConstantName = "ExtractedConstant"
+        };
+
+        var ex = Assert.Throws<RefactoringException>(() =>
+            ThrowIfInvalidParams(@params));
+
+        Assert.Equal(ErrorCodes.InvalidSelectionRange, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void ValidateParams_SameLineExclusiveEndEqualStart_ThrowsException()
+    {
+        var @params = new ExtractConstantParams
+        {
+            SourceFile = AbsoluteTestPath(),
+            StartLine = 5,
+            StartColumn = 10,
+            EndLine = 5,
+            EndColumn = 10,
+            ConstantName = "ExtractedConstant"
+        };
+
+        var ex = Assert.Throws<RefactoringException>(() =>
+            ThrowIfInvalidParams(@params));
+
+        Assert.Equal(ErrorCodes.InvalidSelectionRange, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void ValidateParams_SameLineColumnEndBeforeStart_ThrowsException()
+    {
+        var @params = new ExtractConstantParams
+        {
+            SourceFile = AbsoluteTestPath(),
+            StartLine = 5,
+            StartColumn = 10,
+            EndLine = 5,
+            EndColumn = 5,
+            ConstantName = "ExtractedConstant"
+        };
+
+        var ex = Assert.Throws<RefactoringException>(() =>
+            ThrowIfInvalidParams(@params));
+
+        Assert.Equal(ErrorCodes.InvalidSelectionRange, ex.ErrorCode);
+    }
+
+    /// <summary>
+    /// Mimics ExtractConstantOperation.ValidateParams line/column/selection rules (before File.Exists),
+    /// matching ExtractMethodParamsValidationTests so invalid ends are asserted without a real file.
+    /// </summary>
+    private static void ThrowIfInvalidParams(ExtractConstantParams @params)
+    {
+        if (string.IsNullOrWhiteSpace(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "sourceFile is required.");
+
+        if (string.IsNullOrWhiteSpace(@params.ConstantName))
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "constantName is required.");
+
+        if (!Path.IsPathRooted(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.InvalidSourcePath, "sourceFile must be an absolute path.");
+
+        if (@params.StartLine < 1 || @params.EndLine < 1)
+            throw new RefactoringException(ErrorCodes.InvalidLineNumber, "Line numbers must be >= 1.");
+
+        if (@params.StartColumn < 1 || @params.EndColumn < 1)
+            throw new RefactoringException(ErrorCodes.InvalidColumnNumber, "Column numbers must be >= 1.");
+
+        if (@params.StartLine > @params.EndLine ||
+            (@params.StartLine == @params.EndLine && @params.StartColumn >= @params.EndColumn))
+            throw new RefactoringException(ErrorCodes.InvalidSelectionRange, "Selection start must be before end.");
+
+        if (!File.Exists(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.SourceFileNotFound, $"Source file not found: {@params.SourceFile}");
+    }
+}


### PR DESCRIPTION
## Summary
Fixes leftover #385: `extract_constant` now validates `endLine` / `endColumn` the same way as `extract_method` (IV-E5 exclusive-end), so bad ends hit `InvalidLineNumber` / `InvalidColumnNumber` / `InvalidSelectionRange` instead of indexing `Lines[EndLine - 1]` unsafely.

## Changes
- `ExtractConstantOperation.ValidateParams`: combined start/end line and column checks; reject empty/inverted exclusive-end selections
- `ExtractConstantParamsValidationTests`: endLine=0, endColumn=0, inverted range, same-line EndColumn==StartColumn
- CHANGELOG `[Unreleased]` Fixed entry

Closes #385

## Test plan
- [x] New Core.Tests validation cases for invalid ends
- [ ] CI Build and Test + Code Quality green
