### PR TITLE
Fix extract_variable endLine/endColumn exclusive-end validation

### DIFF
--- a/src/RoslynMcp.Core/Refactoring/Extract/ExtractVariableOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/ExtractVariableOperation.cs
@@ -41,15 +41,15 @@ public sealed class ExtractVariableOperation : RefactoringOperationBase<ExtractV
         if (!File.Exists(@params.SourceFile))
             throw new RefactoringException(ErrorCodes.SourceFileNotFound, $"Source file not found: {@params.SourceFile}");
 
-        if (@params.StartLine < 1)
-            throw new RefactoringException(ErrorCodes.InvalidLineNumber, "startLine must be >= 1.");
+        if (@params.StartLine < 1 || @params.EndLine < 1)
+            throw new RefactoringException(ErrorCodes.InvalidLineNumber, "Line numbers must be >= 1.");
 
-        if (@params.StartColumn < 1)
-            throw new RefactoringException(ErrorCodes.InvalidColumnNumber, "startColumn must be >= 1.");
+        if (@params.StartColumn < 1 || @params.EndColumn < 1)
+            throw new RefactoringException(ErrorCodes.InvalidColumnNumber, "Column numbers must be >= 1.");
 
-        if (@params.EndLine < @params.StartLine ||
-            (@params.EndLine == @params.StartLine && @params.EndColumn < @params.StartColumn))
-            throw new RefactoringException(ErrorCodes.InvalidSelectionRange, "End must be after start.");
+        if (@params.StartLine > @params.EndLine ||
+            (@params.StartLine == @params.EndLine && @params.StartColumn >= @params.EndColumn))
+            throw new RefactoringException(ErrorCodes.InvalidSelectionRange, "Selection start must be before end.");
 
         if (!IsValidIdentifier(@params.VariableName))
             throw new RefactoringException(ErrorCodes.InvalidSymbolName, $"Invalid variable name: {@params.VariableName}");
@@ -70,10 +70,10 @@ public sealed class ExtractVariableOperation : RefactoringOperationBase<ExtractV
             throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse file.");
         }
 
-        // Get text span from line/column
+        // Get text span from line/column (bounds-checked like extract_method / extract_constant)
         var sourceText = await document.GetTextAsync(cancellationToken);
-        var startPosition = sourceText.Lines[@params.StartLine - 1].Start + @params.StartColumn - 1;
-        var endPosition = sourceText.Lines[@params.EndLine - 1].Start + @params.EndColumn - 1;
+        var startPosition = GetPosition(sourceText, @params.StartLine, @params.StartColumn);
+        var endPosition = GetPosition(sourceText, @params.EndLine, @params.EndColumn);
         var span = TextSpan.FromBounds(startPosition, endPosition);
 
         // Find expression at span
@@ -576,6 +576,32 @@ public sealed class ExtractVariableOperation : RefactoringOperationBase<ExtractV
         };
 
         return RefactoringResult.PreviewResult(operationId, pendingChanges);
+    }
+
+
+    private static int GetPosition(SourceText text, int line, int column)
+    {
+        var lineIndex = line - 1; // Convert to 0-based
+
+        if (lineIndex < 0 || lineIndex >= text.Lines.Count)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidLineNumber,
+                $"Line {line} is out of range. File has {text.Lines.Count} lines.");
+        }
+
+        var lineInfo = text.Lines[lineIndex];
+        var columnIndex = column - 1; // Convert to 0-based
+        var lineLength = lineInfo.End - lineInfo.Start;
+
+        if (columnIndex < 0 || columnIndex > lineLength)
+        {
+            throw new RefactoringException(
+                ErrorCodes.InvalidColumnNumber,
+                $"Column {column} is out of range for line {line} (line has {lineLength} characters).");
+        }
+
+        return lineInfo.Start + columnIndex;
     }
 
     private static bool IsValidIdentifier(string name)

--- a/tests/RoslynMcp.Core.Tests/Refactoring/ExtractVariableParamsValidationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/ExtractVariableParamsValidationTests.cs
@@ -1,0 +1,141 @@
+using RoslynMcp.Contracts.Errors;
+using RoslynMcp.Contracts.Models;
+using RoslynMcp.Core.Refactoring;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Refactoring;
+
+/// <summary>
+/// Tests for ExtractVariableParams validation (mirrors ExtractVariableOperation.ValidateParams rules for end bounds).
+/// </summary>
+public class ExtractVariableParamsValidationTests
+{
+    private static string AbsoluteTestPath(string extension = ".cs") =>
+        OperatingSystem.IsWindows()
+            ? $"C:\\test\\file{extension}"
+            : $"/test/file{extension}";
+
+    [Fact]
+    public void ValidateParams_InvalidEndLine_ThrowsException()
+    {
+        var @params = new ExtractVariableParams
+        {
+            SourceFile = AbsoluteTestPath(),
+            StartLine = 1,
+            StartColumn = 1,
+            EndLine = 0,
+            EndColumn = 10,
+            VariableName = "extracted"
+        };
+
+        var ex = Assert.Throws<RefactoringException>(() =>
+            ThrowIfInvalidParams(@params));
+
+        Assert.Equal(ErrorCodes.InvalidLineNumber, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void ValidateParams_InvalidEndColumn_ThrowsException()
+    {
+        var @params = new ExtractVariableParams
+        {
+            SourceFile = AbsoluteTestPath(),
+            StartLine = 1,
+            StartColumn = 1,
+            EndLine = 5,
+            EndColumn = 0,
+            VariableName = "extracted"
+        };
+
+        var ex = Assert.Throws<RefactoringException>(() =>
+            ThrowIfInvalidParams(@params));
+
+        Assert.Equal(ErrorCodes.InvalidColumnNumber, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void ValidateParams_SelectionEndBeforeStart_ThrowsException()
+    {
+        var @params = new ExtractVariableParams
+        {
+            SourceFile = AbsoluteTestPath(),
+            StartLine = 5,
+            StartColumn = 1,
+            EndLine = 3,
+            EndColumn = 10,
+            VariableName = "extracted"
+        };
+
+        var ex = Assert.Throws<RefactoringException>(() =>
+            ThrowIfInvalidParams(@params));
+
+        Assert.Equal(ErrorCodes.InvalidSelectionRange, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void ValidateParams_SameLineExclusiveEndEqualStart_ThrowsException()
+    {
+        var @params = new ExtractVariableParams
+        {
+            SourceFile = AbsoluteTestPath(),
+            StartLine = 5,
+            StartColumn = 10,
+            EndLine = 5,
+            EndColumn = 10,
+            VariableName = "extracted"
+        };
+
+        var ex = Assert.Throws<RefactoringException>(() =>
+            ThrowIfInvalidParams(@params));
+
+        Assert.Equal(ErrorCodes.InvalidSelectionRange, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void ValidateParams_SameLineColumnEndBeforeStart_ThrowsException()
+    {
+        var @params = new ExtractVariableParams
+        {
+            SourceFile = AbsoluteTestPath(),
+            StartLine = 5,
+            StartColumn = 10,
+            EndLine = 5,
+            EndColumn = 5,
+            VariableName = "extracted"
+        };
+
+        var ex = Assert.Throws<RefactoringException>(() =>
+            ThrowIfInvalidParams(@params));
+
+        Assert.Equal(ErrorCodes.InvalidSelectionRange, ex.ErrorCode);
+    }
+
+    /// <summary>
+    /// Mimics ExtractVariableOperation.ValidateParams line/column/selection rules (before File.Exists),
+    /// matching ExtractConstantParamsValidationTests so invalid ends are asserted without a real file.
+    /// </summary>
+    private static void ThrowIfInvalidParams(ExtractVariableParams @params)
+    {
+        if (string.IsNullOrWhiteSpace(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "sourceFile is required.");
+
+        if (string.IsNullOrWhiteSpace(@params.VariableName))
+            throw new RefactoringException(ErrorCodes.MissingRequiredParam, "variableName is required.");
+
+        if (!Path.IsPathRooted(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.InvalidSourcePath, "sourceFile must be an absolute path.");
+
+        if (@params.StartLine < 1 || @params.EndLine < 1)
+            throw new RefactoringException(ErrorCodes.InvalidLineNumber, "Line numbers must be >= 1.");
+
+        if (@params.StartColumn < 1 || @params.EndColumn < 1)
+            throw new RefactoringException(ErrorCodes.InvalidColumnNumber, "Column numbers must be >= 1.");
+
+        if (@params.StartLine > @params.EndLine ||
+            (@params.StartLine == @params.EndLine && @params.StartColumn >= @params.EndColumn))
+            throw new RefactoringException(ErrorCodes.InvalidSelectionRange, "Selection start must be before end.");
+
+        if (!File.Exists(@params.SourceFile))
+            throw new RefactoringException(ErrorCodes.SourceFileNotFound, $"Source file not found: {@params.SourceFile}");
+    }
+}


### PR DESCRIPTION
## Summary
- Align `ExtractVariableOperation.ValidateParams` with BA IV-E4 / `extract_method` / #385 `extract_constant`: reject `endLine`/`endColumn` &lt; 1, and use exclusive-end (`StartColumn &gt;= EndColumn` on the same line) so empty selections fail with `InvalidSelectionRange` instead of building an empty `TextSpan`.
- Add bounds-checked `GetPosition` (same pattern as #385) when resolving the selection span.
- Add `ExtractVariableParamsValidationTests` covering `endLine=0`, `endColumn=0`, and same-line `EndColumn == StartColumn`. Existing operation tests already cover a valid exclusive-end extract.

Closes #386

## Test plan
- [ ] CI: `ExtractVariableParamsValidationTests` + existing `ExtractVariableOperationTests`
- [ ] Manual: same-line caret (`endColumn == startColumn`) → 1008; `endLine`/`endColumn` 0 → 1006/1007; normal exclusive-end extract still succeeds