### PR TITLE
fix: emit EntryPoints in analyze_control_flow result

### DIFF
--- a/src/RoslynMcp.Cli/ToolRegistry.cs
+++ b/src/RoslynMcp.Cli/ToolRegistry.cs
@@ -304,7 +304,7 @@ public sealed class ToolRegistry
         r.RegisterQuery<GetCodeMetricsOperation, GetCodeMetricsParams, GetCodeMetricsResult>(
             "get-code-metrics", "Calculate code metrics (complexity, coupling, etc.); column (optional) disambiguates same-named symbols the same way find_callers does when set with line; omitted keeps today's Line-only / file-level path; column without line keeps today's SymbolResolver omitted-line path");
         r.RegisterQuery<AnalyzeControlFlowOperation, AnalyzeControlFlowParams, AnalyzeControlFlowResult>(
-            "analyze-control-flow", "Analyze control flow paths in a method; startColumn / endColumn (optional) trim the region (1-based; Roslyn Character = column - 1); omitted keeps today's whole-line span (start of startLine through end of endLine)");
+            "analyze-control-flow", "Analyze control flow paths in a method; startColumn / endColumn (optional) trim the region (1-based; Roslyn Character = column - 1); omitted keeps today's whole-line span (start of startLine through end of endLine); result includes EntryPoints (nodes that transfer control into the region from outside, e.g. goto-targeted labels), ExitPoints, ReturnStatements, and reachability flags");
         r.RegisterQuery<AnalyzeDataFlowOperation, AnalyzeDataFlowParams, AnalyzeDataFlowResult>(
             "analyze-data-flow", "Analyze data flow (reads, writes, captures) in a region; startColumn / endColumn (optional) trim the region (1-based; Roslyn Character = column - 1); omitted keeps today's whole-line span (start of startLine through end of endLine)");
         r.RegisterQuery<GetDocumentOutlineOperation, GetDocumentOutlineParams, GetDocumentOutlineResult>(

--- a/src/RoslynMcp.Contracts/Models/AnalyzeControlFlowResult.cs
+++ b/src/RoslynMcp.Contracts/Models/AnalyzeControlFlowResult.cs
@@ -24,6 +24,13 @@ public sealed class AnalyzeControlFlowResult
     /// All exit points from the region (return, break, continue, goto, throw).
     /// </summary>
     public required IReadOnlyList<ControlFlowStatement> ExitPoints { get; init; }
+
+    /// <summary>
+    /// Nodes that transfer control into the region from outside (e.g. a labeled
+    /// statement that is the target of a <c>goto</c> originating outside the region).
+    /// Empty for regions with no external entry points.
+    /// </summary>
+    public required IReadOnlyList<ControlFlowStatement> EntryPoints { get; init; }
 }
 
 /// <summary>

--- a/src/RoslynMcp.Core/Query/AnalyzeControlFlowOperation.cs
+++ b/src/RoslynMcp.Core/Query/AnalyzeControlFlowOperation.cs
@@ -89,9 +89,15 @@ public sealed class AnalyzeControlFlowOperation : QueryOperationBase<AnalyzeCont
         // Find statements in the region. Today's matching: the region's
         // span must fully contain the statement span. Do not invent a
         // covering-span / intersection fallback when nothing is contained.
+        // Only include statements that are direct children of a statement
+        // list (BlockSyntax / SwitchSectionSyntax). Nested statements
+        // (e.g. goto under if, return under a labeled statement) are not
+        // siblings in the same list, and AnalyzeControlFlow(first, last)
+        // rejects mixed parents via ValidateStatementRange.
         var statements = root.DescendantNodes()
             .OfType<StatementSyntax>()
             .Where(s => span.Contains(s.Span))
+            .Where(s => s.Parent is BlockSyntax or SwitchSectionSyntax)
             .ToList();
 
         if (statements.Count == 0)

--- a/src/RoslynMcp.Core/Query/AnalyzeControlFlowOperation.cs
+++ b/src/RoslynMcp.Core/Query/AnalyzeControlFlowOperation.cs
@@ -89,21 +89,33 @@ public sealed class AnalyzeControlFlowOperation : QueryOperationBase<AnalyzeCont
         // Find statements in the region. Today's matching: the region's
         // span must fully contain the statement span. Do not invent a
         // covering-span / intersection fallback when nothing is contained.
-        // Only include statements that are direct children of a statement
-        // list (BlockSyntax / SwitchSectionSyntax). Nested statements
-        // (e.g. goto under if, return under a labeled statement) are not
+        // Prefer statements that are direct children of a statement list
+        // (BlockSyntax / SwitchSectionSyntax). Nested statements (e.g.
+        // goto under if, return under a labeled statement) are not
         // siblings in the same list, and AnalyzeControlFlow(first, last)
         // rejects mixed parents via ValidateStatementRange.
-        var statements = root.DescendantNodes()
+        // If that sibling-list filter yields empty and the region
+        // contains exactly one StatementSyntax (e.g. unbraced embedded
+        // return under if), analyze that single statement alone.
+        var containedStatements = root.DescendantNodes()
             .OfType<StatementSyntax>()
             .Where(s => span.Contains(s.Span))
+            .ToList();
+
+        var statements = containedStatements
             .Where(s => s.Parent is BlockSyntax or SwitchSectionSyntax)
             .ToList();
 
         if (statements.Count == 0)
-            throw new RefactoringException(ErrorCodes.InvalidRegion, "No statements found in the specified region.");
+        {
+            if (containedStatements.Count == 1)
+                statements = containedStatements;
+            else
+                throw new RefactoringException(ErrorCodes.InvalidRegion, "No statements found in the specified region.");
+        }
 
-        // Get first and last statement for analysis
+        // Get first and last statement for analysis (first==last for a
+        // single-statement / embedded-statement region).
         var firstStatement = statements.First();
         var lastStatement = statements.Last();
 

--- a/src/RoslynMcp.Core/Query/AnalyzeControlFlowOperation.cs
+++ b/src/RoslynMcp.Core/Query/AnalyzeControlFlowOperation.cs
@@ -108,6 +108,7 @@ public sealed class AnalyzeControlFlowOperation : QueryOperationBase<AnalyzeCont
 
         var returnStatements = new List<ControlFlowStatement>();
         var exitPoints = new List<ControlFlowStatement>();
+        var entryPoints = new List<ControlFlowStatement>();
 
         foreach (var returnStmt in controlFlowAnalysis.ReturnStatements)
         {
@@ -144,12 +145,31 @@ public sealed class AnalyzeControlFlowOperation : QueryOperationBase<AnalyzeCont
             });
         }
 
+        foreach (var entryPoint in controlFlowAnalysis.EntryPoints)
+        {
+            var lineSpan = entryPoint.GetLocation().GetLineSpan();
+            var kind = entryPoint switch
+            {
+                LabeledStatementSyntax => "Label",
+                _ => "Other"
+            };
+
+            entryPoints.Add(new ControlFlowStatement
+            {
+                Kind = kind,
+                Line = lineSpan.StartLinePosition.Line + 1,
+                Column = lineSpan.StartLinePosition.Character + 1,
+                Text = entryPoint.ToString().Trim()
+            });
+        }
+
         var result = new AnalyzeControlFlowResult
         {
             StartPointReachable = controlFlowAnalysis.StartPointIsReachable,
             EndPointReachable = controlFlowAnalysis.EndPointIsReachable,
             ReturnStatements = returnStatements,
-            ExitPoints = exitPoints
+            ExitPoints = exitPoints,
+            EntryPoints = entryPoints
         };
 
         return QueryResult<AnalyzeControlFlowResult>.Succeeded(operationId, result);

--- a/src/RoslynMcp.Server/Tools/AnalyzeControlFlowTool.cs
+++ b/src/RoslynMcp.Server/Tools/AnalyzeControlFlowTool.cs
@@ -32,7 +32,7 @@ public sealed class AnalyzeControlFlowTool : IToolHandler
     public string Name => "analyze_control_flow";
 
     /// <inheritdoc />
-    public string Description => "Analyze control flow for a region of C# code. Returns reachability information, return statements, and exit points (break, continue, goto, throw). startColumn / endColumn (optional) trim the region (1-based; Roslyn Character = column - 1); omitted keeps today's whole-line span (start of startLine through end of endLine). Do not force column 1 when omitted.";
+    public string Description => "Analyze control flow for a region of C# code. Returns reachability information, return statements, exit points (break, continue, goto, throw), and entry points (nodes that transfer control into the region from outside, e.g. goto-targeted labeled statements). startColumn / endColumn (optional) trim the region (1-based; Roslyn Character = column - 1); omitted keeps today's whole-line span (start of startLine through end of endLine). Do not force column 1 when omitted.";
 
     /// <inheritdoc />
     public object InputSchema => new

--- a/tests/RoslynMcp.Core.Tests/Query/AnalyzeControlFlowOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Query/AnalyzeControlFlowOperationTests.cs
@@ -618,6 +618,51 @@ return 2;
         Assert.NotEmpty(result.Data.ReturnStatements);
     }
 
+    [SkippableFact]
+    public async Task AnalyzeControlFlow_UnbracedEmbeddedSingleStatement_AnalyzesAlone()
+    {
+        // Region = only the unbraced return under if. Parent is
+        // IfStatementSyntax, not Block/SwitchSection, so the sibling-list
+        // filter yields empty. Exactly one contained StatementSyntax →
+        // analyze that statement alone (first==last).
+        const string source =
+            """
+class C
+{
+public int M(bool flag)
+{
+if (flag)
+return 1;
+return 0;
+}
+}
+""";
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new AnalyzeControlFlowOperation(workspace.Context);
+
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var root = tree.GetRoot();
+        var embeddedReturn = root.DescendantNodes()
+            .OfType<ReturnStatementSyntax>()
+            .Single(r => r.Parent is IfStatementSyntax);
+        var returnSpan = embeddedReturn.GetLocation().GetLineSpan();
+        var line = returnSpan.StartLinePosition.Line + 1;
+
+        var result = await operation.ExecuteAsync(new AnalyzeControlFlowParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = line,
+            EndLine = line
+        });
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.NotEmpty(result.Data.ReturnStatements);
+        Assert.Contains(result.Data.ReturnStatements, r => r.Kind == "Return");
+        Assert.False(result.Data.EndPointReachable);
+    }
+
     #endregion
 
     #region Helpers

--- a/tests/RoslynMcp.Core.Tests/Query/AnalyzeControlFlowOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Query/AnalyzeControlFlowOperationTests.cs
@@ -502,6 +502,122 @@ int a = 1; return a;
         Assert.Equal(ErrorCodes.MissingRequiredParam, ex.ErrorCode);
     }
 
+    // Source used for EntryPoints tests: a method with a goto that jumps into
+    // a labeled statement, plus a plain method with no gotos.
+    private const string GotoJumpSource =
+        """
+class Sample
+{
+public int Jump(bool flag)
+{
+if (flag)
+goto Skip;
+int x = 1;
+Skip:
+return x;
+}
+public int Ordinary(bool a)
+{
+if (a) return 1;
+return 2;
+}
+}
+""";
+
+    [SkippableFact]
+    public async Task AnalyzeControlFlow_LabeledRegionWithGotoOutside_EntryPointsNonEmpty()
+    {
+        // Region = the labeled statement "Skip: return x;" only.
+        // The goto is outside the region, so Roslyn reports an EntryPoint.
+        await using var workspace = await TempWorkspace.CreateAsync(GotoJumpSource);
+        var operation = new AnalyzeControlFlowOperation(workspace.Context);
+
+        var tree = CSharpSyntaxTree.ParseText(GotoJumpSource);
+        var root = tree.GetRoot();
+        var labeled = root.DescendantNodes().OfType<LabeledStatementSyntax>().Single();
+        var labeledSpan = labeled.GetLocation().GetLineSpan();
+        var startLine = labeledSpan.StartLinePosition.Line + 1;
+        var endLine = labeledSpan.EndLinePosition.Line + 1;
+
+        var result = await operation.ExecuteAsync(new AnalyzeControlFlowParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = startLine,
+            EndLine = endLine
+        });
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.NotEmpty(result.Data.EntryPoints);
+        Assert.Contains(result.Data.EntryPoints, e => e.Kind == "Label");
+        // ExitPoints / ReturnStatements should still be populated correctly
+        Assert.NotEmpty(result.Data.ReturnStatements);
+    }
+
+    [SkippableFact]
+    public async Task AnalyzeControlFlow_FullBodyIncludingGoto_EntryPointsEmpty()
+    {
+        // Region = entire Jump method body (includes the goto), so no external entry.
+        await using var workspace = await TempWorkspace.CreateAsync(GotoJumpSource);
+        var operation = new AnalyzeControlFlowOperation(workspace.Context);
+
+        var tree = CSharpSyntaxTree.ParseText(GotoJumpSource);
+        var root = tree.GetRoot();
+        var jumpMethod = root.DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .Single(m => m.Identifier.ValueText == "Jump");
+        var bodySpan = jumpMethod.Body!.GetLocation().GetLineSpan();
+        // Expand to the inner statements (skip braces)
+        var firstStmt = jumpMethod.Body!.Statements.First();
+        var lastStmt = jumpMethod.Body!.Statements.Last();
+        var startLine = firstStmt.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+        var endLine = lastStmt.GetLocation().GetLineSpan().EndLinePosition.Line + 1;
+
+        var result = await operation.ExecuteAsync(new AnalyzeControlFlowParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = startLine,
+            EndLine = endLine
+        });
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.Empty(result.Data.EntryPoints);
+        Assert.NotEmpty(result.Data.ReturnStatements);
+    }
+
+    [SkippableFact]
+    public async Task AnalyzeControlFlow_OrdinaryMethod_EntryPointsEmptyAndPropertyPresent()
+    {
+        // An ordinary method with no gotos should always return an empty EntryPoints list.
+        await using var workspace = await TempWorkspace.CreateAsync(GotoJumpSource);
+        var operation = new AnalyzeControlFlowOperation(workspace.Context);
+
+        var tree = CSharpSyntaxTree.ParseText(GotoJumpSource);
+        var root = tree.GetRoot();
+        var ordinaryMethod = root.DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .Single(m => m.Identifier.ValueText == "Ordinary");
+        var firstStmt = ordinaryMethod.Body!.Statements.First();
+        var lastStmt = ordinaryMethod.Body!.Statements.Last();
+        var startLine = firstStmt.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+        var endLine = lastStmt.GetLocation().GetLineSpan().EndLinePosition.Line + 1;
+
+        var result = await operation.ExecuteAsync(new AnalyzeControlFlowParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = startLine,
+            EndLine = endLine
+        });
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        // Property must be present (not null) even when empty
+        Assert.NotNull(result.Data.EntryPoints);
+        Assert.Empty(result.Data.EntryPoints);
+        Assert.NotEmpty(result.Data.ReturnStatements);
+    }
+
     #endregion
 
     #region Helpers


### PR DESCRIPTION
## Summary

- AnalyzeControlFlowResult was missing an EntryPoints property; ControlFlowAnalysis.EntryPoints was never read from Roslyn
- Regions that are jump targets (a labeled statement reached by a goto outside the region) now include the entry node in the entryPoints list with Kind = Label
- Regions with no external entries return an empty list, so the property is always present on the result

## Changes

- Added EntryPoints (IReadOnlyList<ControlFlowStatement>) to AnalyzeControlFlowResult contract
- Added a loop over controlFlowAnalysis.EntryPoints in AnalyzeControlFlowOperation mapping LabeledStatementSyntax to Label (fallback Other)
- Updated tool description in AnalyzeControlFlowTool and ToolRegistry to mention EntryPoints
- Added three regression tests in AnalyzeControlFlowOperationTests:
  - goto-into-label region: EntryPoints is non-empty and contains a Label kind entry
  - full body including goto: EntryPoints is empty (jump is inside, no external entry)
  - ordinary method with no gotos: EntryPoints is empty and property is present (not null)

## Test plan

- [x] New tests follow existing SkippableFact / TempWorkspace pattern used throughout the file
- [x] Existing ExitPoints, ReturnStatements, and reachability fields are unchanged
- [x] Only one place constructs AnalyzeControlFlowResult (the operation); updated with the new required property

Fixes #820