### PR TITLE
Release v0.6.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roslyn-mcp",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "Roslyn-powered C# refactoring MCP server — 50 tools for code navigation, analysis, generation, and refactoring across entire .NET solutions",
   "author": {
     "name": "Joshua Ramirez"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -312,7 +312,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - Cross-platform .NET global tool (`roslyn-mcp`)
 - MCP protocol support for Claude Code and Claude Desktop
 
-[Unreleased]: https://github.com/JoshuaRamirez/RoslynMcpServer/compare/v0.5.2...HEAD
+[Unreleased]: https://github.com/JoshuaRamirez/RoslynMcpServer/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/JoshuaRamirez/RoslynMcpServer/compare/v0.5.2...v0.6.0
 [0.5.2]: https://github.com/JoshuaRamirez/RoslynMcpServer/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/JoshuaRamirez/RoslynMcpServer/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/JoshuaRamirez/RoslynMcpServer/compare/v0.4.1...v0.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-09-11
+
+### Added
+- `analyze_control_flow` now emits `EntryPoints` — regions that are jump targets from outside (e.g. a labeled statement reached by `goto`) appear in the list with `Kind = Label`; regions with no external entries return an empty list so the property is always present (#826)
+
 ## [0.5.2] - 2026-09-09
 
 ### Fixed

--- a/src/RoslynMcp.Cli/RoslynMcp.Cli.csproj
+++ b/src/RoslynMcp.Cli/RoslynMcp.Cli.csproj
@@ -14,7 +14,7 @@
     <ToolCommandName>roslyn-cli</ToolCommandName>
 
     <PackageId>RoslynMcp.Cli</PackageId>
-    <Version>0.5.2</Version>
+    <Version>0.6.0</Version>
     <Authors>Joshua Ramirez</Authors>
     <Company>RedJay</Company>
     <Description>Standalone CLI for 42 Roslyn-powered C# refactoring, analysis, and navigation tools.</Description>

--- a/src/RoslynMcp.Contracts/RoslynMcp.Contracts.csproj
+++ b/src/RoslynMcp.Contracts/RoslynMcp.Contracts.csproj
@@ -9,7 +9,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>RoslynMcp.Contracts</PackageId>
-    <Version>0.5.2</Version>
+    <Version>0.6.0</Version>
     <Authors>Joshua Ramirez</Authors>
     <Company>RedJay</Company>
     <Description>Contract definitions and models for Roslyn MCP Server - Model Context Protocol integration for C# refactoring operations powered by Roslyn.</Description>

--- a/src/RoslynMcp.Core/RoslynMcp.Core.csproj
+++ b/src/RoslynMcp.Core/RoslynMcp.Core.csproj
@@ -9,7 +9,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>RoslynMcp.Core</PackageId>
-    <Version>0.5.2</Version>
+    <Version>0.6.0</Version>
     <Authors>Joshua Ramirez</Authors>
     <Company>RedJay</Company>
     <Description>Core library for Roslyn MCP Server providing C# refactoring operations including move type, rename symbol, extract method, and more. Powered by Roslyn and MSBuild.</Description>

--- a/src/RoslynMcp.Server/RoslynMcp.Server.csproj
+++ b/src/RoslynMcp.Server/RoslynMcp.Server.csproj
@@ -15,7 +15,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>RoslynMcp.Server</PackageId>
-    <Version>0.5.2</Version>
+    <Version>0.6.0</Version>
     <Authors>Joshua Ramirez</Authors>
     <Company>RedJay</Company>
     <Description>MCP Server for Roslyn-powered C# refactoring operations. Install as a global tool to use with Claude Code, Claude Desktop, or other MCP clients. Provides 50 tools: 27 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 8 code conversion tools.</Description>


### PR DESCRIPTION
## Summary
Continuous deployment release **v0.6.0** after #826 landed on master (`analyze_control_flow` EntryPoints).

### Included
- `analyze_control_flow` emits `EntryPoints` for regions that are jump targets from outside (e.g. labeled statements reached by `goto`); empty list when none (#826)

### Version bumps
- NuGet packages Contracts/Core/Server/Cli: 0.5.2 → 0.6.0
- `.claude-plugin/plugin.json`: 0.5.2 → 0.6.0
- CHANGELOG: Unreleased → `[0.6.0] - 2026-09-11` Added

## Test plan
- [x] Master CI green after #826
- [ ] Release PR CI green
- [ ] GitHub release `v0.6.0` publishes NuGet packages