### PR TITLE
fix: sibling-list filter for analyze_data_flow (#931)

### DIFF
--- a/src/RoslynMcp.Core/Query/AnalyzeDataFlowOperation.cs
+++ b/src/RoslynMcp.Core/Query/AnalyzeDataFlowOperation.cs
@@ -88,14 +88,34 @@ public sealed class AnalyzeDataFlowOperation : QueryOperationBase<AnalyzeDataFlo
         // Find statements in the region. Today's matching: the region's
         // span must fully contain the statement span. Do not invent a
         // covering-span / intersection fallback when nothing is contained.
-        var statements = root.DescendantNodes()
+        // Prefer statements that are direct children of a statement list
+        // (BlockSyntax / SwitchSectionSyntax). Nested statements (e.g.
+        // under if, or the enclosing BlockSyntax itself mixed with its
+        // children) are not siblings in the same list, and
+        // AnalyzeDataFlow(first, last) rejects mixed parents via
+        // ValidateStatementRange.
+        // If that sibling-list filter yields empty and the region
+        // contains exactly one StatementSyntax (e.g. unbraced embedded
+        // return under if), analyze that single statement alone.
+        var containedStatements = root.DescendantNodes()
             .OfType<StatementSyntax>()
             .Where(s => span.Contains(s.Span))
             .ToList();
 
-        if (statements.Count == 0)
-            throw new RefactoringException(ErrorCodes.InvalidRegion, "No statements found in the specified region.");
+        var statements = containedStatements
+            .Where(s => s.Parent is BlockSyntax or SwitchSectionSyntax)
+            .ToList();
 
+        if (statements.Count == 0)
+        {
+            if (containedStatements.Count == 1)
+                statements = containedStatements;
+            else
+                throw new RefactoringException(ErrorCodes.InvalidRegion, "No statements found in the specified region.");
+        }
+
+        // Get first and last statement for analysis (first==last for a
+        // single-statement / embedded-statement region).
         var firstStatement = statements.First();
         var lastStatement = statements.Last();
 

--- a/src/RoslynMcp.Core/Query/AnalyzeDataFlowOperation.cs
+++ b/src/RoslynMcp.Core/Query/AnalyzeDataFlowOperation.cs
@@ -88,11 +88,13 @@ public sealed class AnalyzeDataFlowOperation : QueryOperationBase<AnalyzeDataFlo
         // Find statements in the region. Today's matching: the region's
         // span must fully contain the statement span. Do not invent a
         // covering-span / intersection fallback when nothing is contained.
-        // Prefer statements that are direct children of a statement list
-        // (BlockSyntax / SwitchSectionSyntax). Nested statements (e.g.
-        // under if, or the enclosing BlockSyntax itself mixed with its
-        // children) are not siblings in the same list, and
-        // AnalyzeDataFlow(first, last) rejects mixed parents via
+        // Prefer statements that are direct children of ONE statement-list
+        // parent (BlockSyntax / SwitchSectionSyntax). Parent-type alone
+        // still admits siblings from nested lists (e.g. method body ending
+        // in if { return }: outer-block stmts + inner-block return).
+        // Among candidates, pick the outermost contained list parent
+        // (the Block/SwitchSection that contains the others) and keep
+        // only its direct children so First/Last share a parent for
         // ValidateStatementRange.
         // If that sibling-list filter yields empty and the region
         // contains exactly one StatementSyntax (e.g. unbraced embedded
@@ -102,9 +104,38 @@ public sealed class AnalyzeDataFlowOperation : QueryOperationBase<AnalyzeDataFlo
             .Where(s => span.Contains(s.Span))
             .ToList();
 
-        var statements = containedStatements
+        var listParentCandidates = containedStatements
             .Where(s => s.Parent is BlockSyntax or SwitchSectionSyntax)
             .ToList();
+
+        var statements = listParentCandidates;
+        if (listParentCandidates.Count > 0)
+        {
+            var parents = listParentCandidates
+                .Select(s => s.Parent!)
+                .Distinct()
+                .ToList();
+
+            // Outermost contained statement-list parent: contains every
+            // other candidate parent (or is the only one).
+            var outermostParent = parents.FirstOrDefault(p =>
+                parents.All(other => other == p || p.Contains(other)));
+
+            if (outermostParent != null)
+            {
+                statements = listParentCandidates
+                    .Where(s => s.Parent == outermostParent)
+                    .ToList();
+            }
+            else
+            {
+                // No single parent contains the others (cross-list region).
+                // Reject rather than hand mixed parents to Roslyn.
+                throw new RefactoringException(
+                    ErrorCodes.InvalidRegion,
+                    "Selected statements are not within the same statement list.");
+            }
+        }
 
         if (statements.Count == 0)
         {

--- a/tests/RoslynMcp.Core.Tests/Query/AnalyzeDataFlowOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Query/AnalyzeDataFlowOperationTests.cs
@@ -502,6 +502,165 @@ int a = 1; return a;
         Assert.Equal(ErrorCodes.MissingRequiredParam, ex.ErrorCode);
     }
 
+    // Fixture for sibling-list filter parity with analyze_control_flow (#931).
+    // Whole-method / braces+body regions contain BlockSyntax + nested
+    // statements; without Parent is Block/SwitchSection filter, First/Last
+    // hit ValidateStatementRange.
+    private const string BracedBlockSource =
+        """
+class C
+{
+    int x = 1;
+    int ExprBody() => x + 2;
+    int Prop => x;
+    void Block()
+    {
+        var y = x;
+        System.Console.Write(y);
+    }
+}
+""";
+
+    [SkippableFact]
+    public async Task AnalyzeDataFlow_InnerStatementsOnly_Succeeds()
+    {
+        // Region = inner statements only (no enclosing BlockSyntax).
+        // Regression: still succeeds after sibling-list filter.
+        await using var workspace = await TempWorkspace.CreateAsync(BracedBlockSource);
+        var operation = new AnalyzeDataFlowOperation(workspace.Context);
+
+        var tree = CSharpSyntaxTree.ParseText(BracedBlockSource);
+        var root = tree.GetRoot();
+        var method = root.DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .Single(m => m.Identifier.ValueText == "Block");
+        var firstStmt = method.Body!.Statements.First();
+        var lastStmt = method.Body!.Statements.Last();
+        var startLine = firstStmt.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+        var endLine = lastStmt.GetLocation().GetLineSpan().EndLinePosition.Line + 1;
+
+        var result = await operation.ExecuteAsync(new AnalyzeDataFlowParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = startLine,
+            EndLine = endLine
+        });
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.Contains("y", result.Data.WrittenInside);
+        Assert.Contains("y", result.Data.ReadInside);
+        Assert.Contains("this", result.Data.ReadInside);
+    }
+
+    [SkippableFact]
+    public async Task AnalyzeDataFlow_WholeMethodIncludingBraces_SucceedsWithSiblingFilter()
+    {
+        // Region = whole Block method (signature through closing brace).
+        // Contained StatementSyntax includes enclosing Block + nested
+        // statements (mixed parents). Sibling-list filter keeps only the
+        // statement-list children so AnalyzeDataFlow succeeds.
+        await using var workspace = await TempWorkspace.CreateAsync(BracedBlockSource);
+        var operation = new AnalyzeDataFlowOperation(workspace.Context);
+
+        var tree = CSharpSyntaxTree.ParseText(BracedBlockSource);
+        var root = tree.GetRoot();
+        var method = root.DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .Single(m => m.Identifier.ValueText == "Block");
+        var methodSpan = method.GetLocation().GetLineSpan();
+        var startLine = methodSpan.StartLinePosition.Line + 1;
+        var endLine = methodSpan.EndLinePosition.Line + 1;
+
+        var result = await operation.ExecuteAsync(new AnalyzeDataFlowParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = startLine,
+            EndLine = endLine
+        });
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.Contains("y", result.Data.WrittenInside);
+        Assert.Contains("y", result.Data.ReadInside);
+        Assert.Contains("this", result.Data.ReadInside);
+    }
+
+    [SkippableFact]
+    public async Task AnalyzeDataFlow_BracesAndBodyOnly_SucceedsWithSiblingFilter()
+    {
+        // Region = braces + body only (previously failed: Block + nested).
+        await using var workspace = await TempWorkspace.CreateAsync(BracedBlockSource);
+        var operation = new AnalyzeDataFlowOperation(workspace.Context);
+
+        var tree = CSharpSyntaxTree.ParseText(BracedBlockSource);
+        var root = tree.GetRoot();
+        var method = root.DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .Single(m => m.Identifier.ValueText == "Block");
+        var bodySpan = method.Body!.GetLocation().GetLineSpan();
+        var startLine = bodySpan.StartLinePosition.Line + 1;
+        var endLine = bodySpan.EndLinePosition.Line + 1;
+
+        var result = await operation.ExecuteAsync(new AnalyzeDataFlowParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = startLine,
+            EndLine = endLine
+        });
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.Contains("y", result.Data.WrittenInside);
+        Assert.Contains("y", result.Data.ReadInside);
+        Assert.Contains("this", result.Data.ReadInside);
+    }
+
+    [SkippableFact]
+    public async Task AnalyzeDataFlow_UnbracedEmbeddedSingleStatement_AnalyzesAlone()
+    {
+        // Region = only the unbraced return under if. Parent is
+        // IfStatementSyntax, not Block/SwitchSection, so the sibling-list
+        // filter yields empty. Exactly one contained StatementSyntax →
+        // analyze that statement alone (first==last).
+        const string source =
+            """
+class C
+{
+public int M(bool flag)
+{
+if (flag)
+return 1;
+return 0;
+}
+}
+""";
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new AnalyzeDataFlowOperation(workspace.Context);
+
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var root = tree.GetRoot();
+        var embeddedReturn = root.DescendantNodes()
+            .OfType<ReturnStatementSyntax>()
+            .Single(r => r.Parent is IfStatementSyntax);
+        var returnSpan = embeddedReturn.GetLocation().GetLineSpan();
+        var line = returnSpan.StartLinePosition.Line + 1;
+
+        var result = await operation.ExecuteAsync(new AnalyzeDataFlowParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = line,
+            EndLine = line
+        });
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        // Literal return has no named locals; success without RoslynError is the contract.
+        Assert.NotNull(result.Data.ReadInside);
+        Assert.NotNull(result.Data.WrittenInside);
+    }
+
     #endregion
 
     #region Helpers

--- a/tests/RoslynMcp.Core.Tests/Query/AnalyzeDataFlowOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Query/AnalyzeDataFlowOperationTests.cs
@@ -661,6 +661,56 @@ return 0;
         Assert.NotNull(result.Data.WrittenInside);
     }
 
+    [SkippableFact]
+    public async Task AnalyzeDataFlow_TrailingNestedBlock_RestrictsToOneStatementListParent()
+    {
+        // Method ending in if { return }: parent-type filter alone would
+        // keep outer-block statements AND the nested return (different
+        // parents) so First/Last fail ValidateStatementRange. One-parent
+        // restriction keeps only the outermost contained list.
+        const string source =
+            """
+class C
+{
+    void M(bool flag, int x)
+    {
+        var y = x;
+        System.Console.Write(y);
+        if (flag)
+        {
+            return;
+        }
+    }
+}
+""";
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new AnalyzeDataFlowOperation(workspace.Context);
+
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var root = tree.GetRoot();
+        var method = root.DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .Single(m => m.Identifier.ValueText == "M");
+        var methodSpan = method.GetLocation().GetLineSpan();
+        var startLine = methodSpan.StartLinePosition.Line + 1;
+        var endLine = methodSpan.EndLinePosition.Line + 1;
+
+        var result = await operation.ExecuteAsync(new AnalyzeDataFlowParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = startLine,
+            EndLine = endLine
+        });
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.Contains("y", result.Data.WrittenInside);
+        Assert.Contains("y", result.Data.ReadInside);
+        Assert.Contains("x", result.Data.ReadInside);
+        Assert.Contains("flag", result.Data.ReadInside);
+    }
+
     #endregion
 
     #region Helpers


### PR DESCRIPTION
## Summary
- Mirror `AnalyzeControlFlowOperation` sibling-list policy in `analyze_data_flow`: prefer `StatementSyntax` whose `Parent` is `BlockSyntax` or `SwitchSectionSyntax`.
- When that filter is empty and exactly one contained statement remains (e.g. unbraced embedded return under `if`), analyze that statement alone.
- No covering-span / intersection fallback.

Braced method / braces+body regions previously mixed the enclosing `BlockSyntax` with nested statements, so `AnalyzeDataFlow(first, last)` hit Roslyn `ValidateStatementRange` (“statements not within the same statement list”) → `RoslynError` / InvalidRegion. Twin of the #820/#826 control-flow fix.

Closes #931

## Test plan
- [x] `dotnet test` filter `FullyQualifiedName~AnalyzeDataFlowOperationTests` — 30 passed
- [x] Inner statements-only region still succeeds
- [x] Whole method including braces succeeds (sibling filter)
- [x] Braces+body region succeeds (previously failing cross-nest)
- [x] Unbraced embedded single statement analyzes alone