### PR TITLE
fix: analyze_data_flow expression-bodied regions (#932)

### DIFF
--- a/src/RoslynMcp.Core/Query/AnalyzeDataFlowOperation.cs
+++ b/src/RoslynMcp.Core/Query/AnalyzeDataFlowOperation.cs
@@ -16,6 +16,9 @@ namespace RoslynMcp.Core.Query;
 /// Omitted columns keep today's whole-line span (start of <c>startLine</c>
 /// through end of <c>endLine</c>). Do not force column 1 when omitted.
 /// Statement matching stays today's <c>span.Contains(s.Span)</c>.
+/// When the region contains no <see cref="StatementSyntax"/>, falls back to
+/// <c>AnalyzeDataFlow(ExpressionSyntax)</c> preferring a contained
+/// <see cref="ArrowExpressionClauseSyntax.Expression"/> (expression-bodied members).
 /// </summary>
 public sealed class AnalyzeDataFlowOperation : QueryOperationBase<AnalyzeDataFlowParams, AnalyzeDataFlowResult>
 {
@@ -137,20 +140,44 @@ public sealed class AnalyzeDataFlowOperation : QueryOperationBase<AnalyzeDataFlo
             }
         }
 
-        if (statements.Count == 0)
+        if (statements.Count == 0 && containedStatements.Count == 1)
+            statements = containedStatements;
+
+        DataFlowAnalysis? dataFlowAnalysis;
+
+        if (statements.Count > 0)
         {
-            if (containedStatements.Count == 1)
-                statements = containedStatements;
-            else
-                throw new RefactoringException(ErrorCodes.InvalidRegion, "No statements found in the specified region.");
+            // Get first and last statement for analysis (first==last for a
+            // single-statement / embedded-statement region).
+            var firstStatement = statements.First();
+            var lastStatement = statements.Last();
+            dataFlowAnalysis = semanticModel.AnalyzeDataFlow(firstStatement, lastStatement);
         }
+        else if (containedStatements.Count == 0)
+        {
+            // Expression-bodied fallback (#932): region has no StatementSyntax
+            // (e.g. `int ExprBody() => x + 2;` / `int Prop => x;`). Prefer
+            // ArrowExpressionClauseSyntax.Expression when the region fully
+            // contains that expression, then AnalyzeDataFlow(ExpressionSyntax).
+            // Do not invent covering-span / intersection fallbacks.
+            var arrowExpression = root.DescendantNodes()
+                .OfType<ArrowExpressionClauseSyntax>()
+                .Select(clause => clause.Expression)
+                .FirstOrDefault(expression => span.Contains(expression.Span));
 
-        // Get first and last statement for analysis (first==last for a
-        // single-statement / embedded-statement region).
-        var firstStatement = statements.First();
-        var lastStatement = statements.Last();
+            if (arrowExpression == null)
+            {
+                throw new RefactoringException(
+                    ErrorCodes.InvalidRegion,
+                    "No statements found in the specified region.");
+            }
 
-        var dataFlowAnalysis = semanticModel.AnalyzeDataFlow(firstStatement, lastStatement);
+            dataFlowAnalysis = semanticModel.AnalyzeDataFlow(arrowExpression);
+        }
+        else
+        {
+            throw new RefactoringException(ErrorCodes.InvalidRegion, "No statements found in the specified region.");
+        }
 
         if (dataFlowAnalysis == null || !dataFlowAnalysis.Succeeded)
             throw new RefactoringException(ErrorCodes.InvalidRegion, "Data flow analysis failed for the specified region.");

--- a/src/RoslynMcp.Core/Query/AnalyzeDataFlowOperation.cs
+++ b/src/RoslynMcp.Core/Query/AnalyzeDataFlowOperation.cs
@@ -17,8 +17,9 @@ namespace RoslynMcp.Core.Query;
 /// through end of <c>endLine</c>). Do not force column 1 when omitted.
 /// Statement matching stays today's <c>span.Contains(s.Span)</c>.
 /// When the region contains no <see cref="StatementSyntax"/>, falls back to
-/// <c>AnalyzeDataFlow(ExpressionSyntax)</c> preferring a contained
+/// <c>AnalyzeDataFlow(ExpressionSyntax)</c> for exactly one contained
 /// <see cref="ArrowExpressionClauseSyntax.Expression"/> (expression-bodied members).
+/// Multiple contained arrows are <c>InvalidRegion</c>.
 /// </summary>
 public sealed class AnalyzeDataFlowOperation : QueryOperationBase<AnalyzeDataFlowParams, AnalyzeDataFlowResult>
 {
@@ -156,23 +157,33 @@ public sealed class AnalyzeDataFlowOperation : QueryOperationBase<AnalyzeDataFlo
         else if (containedStatements.Count == 0)
         {
             // Expression-bodied fallback (#932): region has no StatementSyntax
-            // (e.g. `int ExprBody() => x + 2;` / `int Prop => x;`). Prefer
-            // ArrowExpressionClauseSyntax.Expression when the region fully
-            // contains that expression, then AnalyzeDataFlow(ExpressionSyntax).
-            // Do not invent covering-span / intersection fallbacks.
-            var arrowExpression = root.DescendantNodes()
+            // (e.g. `int ExprBody() => x + 2;` / `int Prop => x;`). Collect
+            // every ArrowExpressionClauseSyntax.Expression fully contained in
+            // the region, then AnalyzeDataFlow(ExpressionSyntax) only when
+            // exactly one matches. Multiple arrows (ambiguous multi-member
+            // span) or zero → InvalidRegion. Do not invent covering-span /
+            // intersection / EqualsValueClause fallbacks.
+            var arrowExpressions = root.DescendantNodes()
                 .OfType<ArrowExpressionClauseSyntax>()
                 .Select(clause => clause.Expression)
-                .FirstOrDefault(expression => span.Contains(expression.Span));
+                .Where(expression => span.Contains(expression.Span))
+                .ToList();
 
-            if (arrowExpression == null)
+            if (arrowExpressions.Count == 0)
             {
                 throw new RefactoringException(
                     ErrorCodes.InvalidRegion,
                     "No statements found in the specified region.");
             }
 
-            dataFlowAnalysis = semanticModel.AnalyzeDataFlow(arrowExpression);
+            if (arrowExpressions.Count > 1)
+            {
+                throw new RefactoringException(
+                    ErrorCodes.InvalidRegion,
+                    "Ambiguous region: multiple expression-bodied members (arrow expressions) are fully contained. Narrow the region to a single arrow expression.");
+            }
+
+            dataFlowAnalysis = semanticModel.AnalyzeDataFlow(arrowExpressions[0]);
         }
         else
         {

--- a/tests/RoslynMcp.Core.Tests/Query/AnalyzeDataFlowOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Query/AnalyzeDataFlowOperationTests.cs
@@ -581,6 +581,39 @@ class C
     }
 
     [SkippableFact]
+    public async Task AnalyzeDataFlow_MultiArrowExpressionRegion_ThrowsInvalidRegion()
+    {
+        // Region spans both ExprBody and Prop lines — two fully contained
+        // ArrowExpressionClause expressions. Must be InvalidRegion (not
+        // silently analyzing only the first via FirstOrDefault).
+        await using var workspace = await TempWorkspace.CreateAsync(BracedBlockSource);
+        var operation = new AnalyzeDataFlowOperation(workspace.Context);
+
+        var tree = CSharpSyntaxTree.ParseText(BracedBlockSource);
+        var root = tree.GetRoot();
+        var method = root.DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .Single(m => m.Identifier.ValueText == "ExprBody");
+        var prop = root.DescendantNodes()
+            .OfType<PropertyDeclarationSyntax>()
+            .Single(p => p.Identifier.ValueText == "Prop");
+        var startLine = method.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+        var endLine = prop.GetLocation().GetLineSpan().EndLinePosition.Line + 1;
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new AnalyzeDataFlowParams
+            {
+                SourceFile = workspace.SourcePath,
+                StartLine = startLine,
+                EndLine = endLine
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidRegion, ex.ErrorCode);
+        Assert.Contains("multiple", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("arrow", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [SkippableFact]
     public async Task AnalyzeDataFlow_InnerStatementsOnly_Succeeds()
     {
         // Region = inner statements only (no enclosing BlockSyntax).

--- a/tests/RoslynMcp.Core.Tests/Query/AnalyzeDataFlowOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Query/AnalyzeDataFlowOperationTests.cs
@@ -522,6 +522,65 @@ class C
 """;
 
     [SkippableFact]
+    public async Task AnalyzeDataFlow_ExpressionBodiedMethod_SucceedsViaExpressionOverload()
+    {
+        // Region = whole ExprBody line (`int ExprBody() => x + 2;`).
+        // Zero StatementSyntax → expression fallback uses ArrowExpression
+        // `x + 2` via AnalyzeDataFlow(ExpressionSyntax).
+        await using var workspace = await TempWorkspace.CreateAsync(BracedBlockSource);
+        var operation = new AnalyzeDataFlowOperation(workspace.Context);
+
+        var tree = CSharpSyntaxTree.ParseText(BracedBlockSource);
+        var root = tree.GetRoot();
+        var method = root.DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .Single(m => m.Identifier.ValueText == "ExprBody");
+        var methodSpan = method.GetLocation().GetLineSpan();
+        var line = methodSpan.StartLinePosition.Line + 1;
+
+        var result = await operation.ExecuteAsync(new AnalyzeDataFlowParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = line,
+            EndLine = line
+        });
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.Contains("this", result.Data.ReadInside);
+        Assert.Contains("this", result.Data.DataFlowsIn);
+    }
+
+    [SkippableFact]
+    public async Task AnalyzeDataFlow_ExpressionBodiedProperty_SucceedsViaExpressionOverload()
+    {
+        // Region = whole Prop line (`int Prop => x;`). Zero StatementSyntax
+        // → expression fallback on ArrowExpression `x`.
+        await using var workspace = await TempWorkspace.CreateAsync(BracedBlockSource);
+        var operation = new AnalyzeDataFlowOperation(workspace.Context);
+
+        var tree = CSharpSyntaxTree.ParseText(BracedBlockSource);
+        var root = tree.GetRoot();
+        var prop = root.DescendantNodes()
+            .OfType<PropertyDeclarationSyntax>()
+            .Single(p => p.Identifier.ValueText == "Prop");
+        var propSpan = prop.GetLocation().GetLineSpan();
+        var line = propSpan.StartLinePosition.Line + 1;
+
+        var result = await operation.ExecuteAsync(new AnalyzeDataFlowParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = line,
+            EndLine = line
+        });
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.Contains("this", result.Data.ReadInside);
+        Assert.Contains("this", result.Data.DataFlowsIn);
+    }
+
+    [SkippableFact]
     public async Task AnalyzeDataFlow_InnerStatementsOnly_Succeeds()
     {
         // Region = inner statements only (no enclosing BlockSyntax).


### PR DESCRIPTION
## Summary
- When `analyze_data_flow` finds no `StatementSyntax` in the region, fall back to `ArrowExpressionClauseSyntax.Expression` and call `SemanticModel.AnalyzeDataFlow(ExpressionSyntax)`.
- Keeps the existing statement-list path (including #931 outermost one-parent filter).
- If neither statements nor a contained arrow expression exist, still throws `InvalidRegion`.

Closes #932

## Test plan
- [x] `AnalyzeDataFlow_ExpressionBodiedMethod_SucceedsViaExpressionOverload` — ExprBody line Succeeded with ReadInside/DataFlowsIn including `this`
- [x] `AnalyzeDataFlow_ExpressionBodiedProperty_SucceedsViaExpressionOverload` — Prop line Succeeded with ReadInside/DataFlowsIn including `this`
- [x] `AnalyzeDataFlow_InnerStatementsOnly_Succeeds` — statement-region regression still passes
- [x] Full `AnalyzeDataFlowOperationTests` — 33 passed