### PR TITLE
fix: analyze_data_flow EqualsValueClause initializer regions (#933)

### DIFF
--- a/src/RoslynMcp.Core/Query/AnalyzeDataFlowOperation.cs
+++ b/src/RoslynMcp.Core/Query/AnalyzeDataFlowOperation.cs
@@ -20,6 +20,9 @@ namespace RoslynMcp.Core.Query;
 /// <c>AnalyzeDataFlow(ExpressionSyntax)</c> for exactly one contained
 /// <see cref="ArrowExpressionClauseSyntax.Expression"/> (expression-bodied members).
 /// Multiple contained arrows are <c>InvalidRegion</c>.
+/// When there are also no arrow expressions, falls back to exactly one
+/// contained <see cref="EqualsValueClauseSyntax.Value"/> (field/const/static/local
+/// initializer). Zero or multiple contained Values are <c>InvalidRegion</c>.
 /// </summary>
 public sealed class AnalyzeDataFlowOperation : QueryOperationBase<AnalyzeDataFlowParams, AnalyzeDataFlowResult>
 {
@@ -161,20 +164,12 @@ public sealed class AnalyzeDataFlowOperation : QueryOperationBase<AnalyzeDataFlo
             // every ArrowExpressionClauseSyntax.Expression fully contained in
             // the region, then AnalyzeDataFlow(ExpressionSyntax) only when
             // exactly one matches. Multiple arrows (ambiguous multi-member
-            // span) or zero → InvalidRegion. Do not invent covering-span /
-            // intersection / EqualsValueClause fallbacks.
+            // span) → InvalidRegion. Do not invent covering-span / intersection.
             var arrowExpressions = root.DescendantNodes()
                 .OfType<ArrowExpressionClauseSyntax>()
                 .Select(clause => clause.Expression)
                 .Where(expression => span.Contains(expression.Span))
                 .ToList();
-
-            if (arrowExpressions.Count == 0)
-            {
-                throw new RefactoringException(
-                    ErrorCodes.InvalidRegion,
-                    "No statements found in the specified region.");
-            }
 
             if (arrowExpressions.Count > 1)
             {
@@ -183,7 +178,39 @@ public sealed class AnalyzeDataFlowOperation : QueryOperationBase<AnalyzeDataFlo
                     "Ambiguous region: multiple expression-bodied members (arrow expressions) are fully contained. Narrow the region to a single arrow expression.");
             }
 
-            dataFlowAnalysis = semanticModel.AnalyzeDataFlow(arrowExpressions[0]);
+            if (arrowExpressions.Count == 1)
+            {
+                dataFlowAnalysis = semanticModel.AnalyzeDataFlow(arrowExpressions[0]);
+            }
+            else
+            {
+                // EqualsValueClause initializer fallback (#933): no statements
+                // and no arrow expressions (field/const/static/local initializer
+                // line, or column-trimmed local Value). Prefer exactly one
+                // EqualsValueClause.Value fully contained in the region.
+                // Multiple Values (ambiguous) or zero → InvalidRegion.
+                var initializerValues = root.DescendantNodes()
+                    .OfType<EqualsValueClauseSyntax>()
+                    .Select(clause => clause.Value)
+                    .Where(value => span.Contains(value.Span))
+                    .ToList();
+
+                if (initializerValues.Count == 0)
+                {
+                    throw new RefactoringException(
+                        ErrorCodes.InvalidRegion,
+                        "No statements found in the specified region.");
+                }
+
+                if (initializerValues.Count > 1)
+                {
+                    throw new RefactoringException(
+                        ErrorCodes.InvalidRegion,
+                        "Ambiguous region: multiple EqualsValueClause initializer values are fully contained. Narrow the region to a single initializer expression.");
+                }
+
+                dataFlowAnalysis = semanticModel.AnalyzeDataFlow(initializerValues[0]);
+            }
         }
         else
         {

--- a/src/RoslynMcp.Core/Query/AnalyzeDataFlowOperation.cs
+++ b/src/RoslynMcp.Core/Query/AnalyzeDataFlowOperation.cs
@@ -188,9 +188,12 @@ public sealed class AnalyzeDataFlowOperation : QueryOperationBase<AnalyzeDataFlo
                 // and no arrow expressions (field/const/static/local initializer
                 // line, or column-trimmed local Value). Prefer exactly one
                 // EqualsValueClause.Value fully contained in the region.
+                // Exclude ParameterSyntax defaults (e.g. lambda `(int x = 1) =>`)
+                // so a single declaration initializer is not rejected as multi.
                 // Multiple Values (ambiguous) or zero → InvalidRegion.
                 var initializerValues = root.DescendantNodes()
                     .OfType<EqualsValueClauseSyntax>()
+                    .Where(clause => clause.Parent is not ParameterSyntax)
                     .Select(clause => clause.Value)
                     .Where(value => span.Contains(value.Span))
                     .ToList();

--- a/tests/RoslynMcp.Core.Tests/Query/AnalyzeDataFlowOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Query/AnalyzeDataFlowOperationTests.cs
@@ -753,6 +753,185 @@ return 0;
         Assert.NotNull(result.Data.WrittenInside);
     }
 
+    // Fixture for EqualsValueClause initializer fallback (#933).
+    // Field/const/static lines are not StatementSyntax; local Value-only
+    // column trim does not fully contain LocalDeclarationStatement.
+    private const string InitializerSource =
+        """
+class C
+{
+    const int K = 10;
+    static int S = K + 1;
+    int f = K + 2;
+    void M(int p)
+    {
+        int z = S + p;
+        System.Console.Write(z);
+    }
+}
+""";
+
+    [SkippableFact]
+    public async Task AnalyzeDataFlow_FieldInitializerWholeLine_SucceedsViaEqualsValueClause()
+    {
+        // Region = whole field line (`int f = K + 2;`). Zero StatementSyntax
+        // → EqualsValueClause.Value fallback via AnalyzeDataFlow(ExpressionSyntax).
+        await using var workspace = await TempWorkspace.CreateAsync(InitializerSource);
+        var operation = new AnalyzeDataFlowOperation(workspace.Context);
+
+        var tree = CSharpSyntaxTree.ParseText(InitializerSource);
+        var root = tree.GetRoot();
+        var field = root.DescendantNodes()
+            .OfType<FieldDeclarationSyntax>()
+            .Single(f => f.Declaration.Variables.Any(v => v.Identifier.ValueText == "f"));
+        var line = field.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+
+        var result = await operation.ExecuteAsync(new AnalyzeDataFlowParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = line,
+            EndLine = line
+        });
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.NotNull(result.Data.ReadInside);
+        Assert.NotNull(result.Data.WrittenInside);
+    }
+
+    [SkippableFact]
+    public async Task AnalyzeDataFlow_StaticFieldInitializerWholeLine_SucceedsViaEqualsValueClause()
+    {
+        // Region = whole static field line (`static int S = K + 1;`).
+        await using var workspace = await TempWorkspace.CreateAsync(InitializerSource);
+        var operation = new AnalyzeDataFlowOperation(workspace.Context);
+
+        var tree = CSharpSyntaxTree.ParseText(InitializerSource);
+        var root = tree.GetRoot();
+        var field = root.DescendantNodes()
+            .OfType<FieldDeclarationSyntax>()
+            .Single(f => f.Declaration.Variables.Any(v => v.Identifier.ValueText == "S"));
+        var line = field.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+
+        var result = await operation.ExecuteAsync(new AnalyzeDataFlowParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = line,
+            EndLine = line
+        });
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.NotNull(result.Data.ReadInside);
+        Assert.NotNull(result.Data.WrittenInside);
+    }
+
+    [SkippableFact]
+    public async Task AnalyzeDataFlow_LocalInitializerValueOnlyColumns_SucceedsViaEqualsValueClause()
+    {
+        // Region = column-trimmed EqualsValueClause.Value (`S + p`) inside
+        // `int z = S + p;`. LocalDeclarationStatement is NOT fully contained
+        // → expression fallback; ReadInside/DataFlowsIn include p.
+        await using var workspace = await TempWorkspace.CreateAsync(InitializerSource);
+        var operation = new AnalyzeDataFlowOperation(workspace.Context);
+
+        var tree = CSharpSyntaxTree.ParseText(InitializerSource);
+        var root = tree.GetRoot();
+        var local = root.DescendantNodes()
+            .OfType<LocalDeclarationStatementSyntax>()
+            .Single();
+        var value = local.Declaration.Variables[0].Initializer!.Value;
+        var valueSpan = value.GetLocation().GetLineSpan();
+        var line = valueSpan.StartLinePosition.Line + 1;
+        var startColumn = valueSpan.StartLinePosition.Character + 1;
+        var endColumn = valueSpan.EndLinePosition.Character + 1;
+
+        // Sanity: Value-only span does not contain the full local declaration.
+        var text = SourceText.From(InitializerSource);
+        var region = AnalyzeDataFlowOperation.BuildRegionSpan(
+            text, Params(line, line, startColumn, endColumn));
+        Assert.False(region.Contains(local.Span));
+        Assert.True(region.Contains(value.Span));
+
+        var result = await operation.ExecuteAsync(new AnalyzeDataFlowParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = line,
+            EndLine = line,
+            StartColumn = startColumn,
+            EndColumn = endColumn
+        });
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.Contains("p", result.Data.ReadInside);
+        Assert.Contains("p", result.Data.DataFlowsIn);
+        // Expression path does not treat the local declarator as WrittenInside.
+        Assert.DoesNotContain("z", result.Data.WrittenInside);
+    }
+
+    [SkippableFact]
+    public async Task AnalyzeDataFlow_LocalDeclarationWholeLine_StillSucceedsViaStatementPath()
+    {
+        // Region = whole `int z = S + p;` line. LocalDeclarationStatement is
+        // fully contained → statement path regression (WrittenInside includes z).
+        await using var workspace = await TempWorkspace.CreateAsync(InitializerSource);
+        var operation = new AnalyzeDataFlowOperation(workspace.Context);
+
+        var tree = CSharpSyntaxTree.ParseText(InitializerSource);
+        var root = tree.GetRoot();
+        var local = root.DescendantNodes()
+            .OfType<LocalDeclarationStatementSyntax>()
+            .Single();
+        var line = local.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+
+        var result = await operation.ExecuteAsync(new AnalyzeDataFlowParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = line,
+            EndLine = line
+        });
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.Contains("p", result.Data.ReadInside);
+        Assert.Contains("p", result.Data.DataFlowsIn);
+        Assert.Contains("z", result.Data.WrittenInside);
+    }
+
+    [SkippableFact]
+    public async Task AnalyzeDataFlow_MultiEqualsValueClauseRegion_ThrowsInvalidRegion()
+    {
+        // Region spans static S and field f lines — two fully contained
+        // EqualsValueClause.Values, zero statements, zero arrows.
+        // Must be InvalidRegion (ambiguous), same spirit as multi-arrow.
+        await using var workspace = await TempWorkspace.CreateAsync(InitializerSource);
+        var operation = new AnalyzeDataFlowOperation(workspace.Context);
+
+        var tree = CSharpSyntaxTree.ParseText(InitializerSource);
+        var root = tree.GetRoot();
+        var staticField = root.DescendantNodes()
+            .OfType<FieldDeclarationSyntax>()
+            .Single(f => f.Declaration.Variables.Any(v => v.Identifier.ValueText == "S"));
+        var instanceField = root.DescendantNodes()
+            .OfType<FieldDeclarationSyntax>()
+            .Single(f => f.Declaration.Variables.Any(v => v.Identifier.ValueText == "f"));
+        var startLine = staticField.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+        var endLine = instanceField.GetLocation().GetLineSpan().EndLinePosition.Line + 1;
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new AnalyzeDataFlowParams
+            {
+                SourceFile = workspace.SourcePath,
+                StartLine = startLine,
+                EndLine = endLine
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidRegion, ex.ErrorCode);
+        Assert.Contains("multiple", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("EqualsValueClause", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     [SkippableFact]
     public async Task AnalyzeDataFlow_TrailingNestedBlock_RestrictsToOneStatementListParent()
     {

--- a/tests/RoslynMcp.Core.Tests/Query/AnalyzeDataFlowOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Query/AnalyzeDataFlowOperationTests.cs
@@ -900,6 +900,67 @@ class C
     }
 
     [SkippableFact]
+    public async Task AnalyzeDataFlow_LambdaInitializerWithParameterDefault_IgnoresNestedParameterEquals()
+    {
+        // C# 12+ style: declaration initializer Value is a lambda that itself
+        // contains a ParameterSyntax default EqualsValueClause. Without filtering
+        // Parameter parents, Count>1 rejects a single declaration initializer.
+        const string source =
+            """
+class C
+{
+    void M()
+    {
+        System.Func<int, int> f = (int x = 1) => x;
+        System.Console.Write(f(2));
+    }
+}
+""";
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new AnalyzeDataFlowOperation(workspace.Context);
+
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var root = tree.GetRoot();
+        var local = root.DescendantNodes()
+            .OfType<LocalDeclarationStatementSyntax>()
+            .Single();
+        var line = local.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+
+        // Whole local line contains LocalDeclarationStatement → statement path.
+        // Use Value-only columns so EqualsValueClause fallback is exercised.
+        var value = local.Declaration.Variables[0].Initializer!.Value;
+        var valueSpan = value.GetLocation().GetLineSpan();
+        var startColumn = valueSpan.StartLinePosition.Character + 1;
+        var endColumn = valueSpan.EndLinePosition.Character + 1;
+
+        var text = SourceText.From(source);
+        var region = AnalyzeDataFlowOperation.BuildRegionSpan(
+            text, Params(line, line, startColumn, endColumn));
+        Assert.False(region.Contains(local.Span));
+        Assert.True(region.Contains(value.Span));
+        // Nested parameter default EqualsValueClause is also fully contained.
+        var paramDefault = root.DescendantNodes()
+            .OfType<EqualsValueClauseSyntax>()
+            .Single(c => c.Parent is ParameterSyntax);
+        Assert.True(region.Contains(paramDefault.Value.Span));
+
+        var result = await operation.ExecuteAsync(new AnalyzeDataFlowParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = line,
+            EndLine = line,
+            StartColumn = startColumn,
+            EndColumn = endColumn
+        });
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.NotNull(result.Data.ReadInside);
+        Assert.NotNull(result.Data.WrittenInside);
+    }
+
+    [SkippableFact]
     public async Task AnalyzeDataFlow_MultiEqualsValueClauseRegion_ThrowsInvalidRegion()
     {
         // Region spans static S and field f lines — two fully contained


### PR DESCRIPTION
## Summary
- After the statement-list path (#931) and single-arrow expression-bodied path (#932) find nothing, fall back to exactly one contained `EqualsValueClause.Value` and call `AnalyzeDataFlow(ExpressionSyntax)`.
- Zero contained Values → `InvalidRegion`; more than one → `InvalidRegion` (ambiguous), same spirit as multi-arrow reject.
- Field/const/static initializer whole-line regions and column-trimmed local initializer Values now succeed; statement and arrow regressions kept.

Closes #933

## Test plan
- [x] `dotnet test --filter FullyQualifiedName~AnalyzeDataFlowOperationTests` (39 passed)
- [ ] CI Build & Test + CodeQL green
- [ ] Copilot/Codex review threads resolved