### PR TITLE
fix: analyze_control_flow same-list outermost parent (#936)

### DIFF
--- a/src/RoslynMcp.Core/Query/AnalyzeControlFlowOperation.cs
+++ b/src/RoslynMcp.Core/Query/AnalyzeControlFlowOperation.cs
@@ -89,11 +89,15 @@ public sealed class AnalyzeControlFlowOperation : QueryOperationBase<AnalyzeCont
         // Find statements in the region. Today's matching: the region's
         // span must fully contain the statement span. Do not invent a
         // covering-span / intersection fallback when nothing is contained.
-        // Prefer statements that are direct children of a statement list
-        // (BlockSyntax / SwitchSectionSyntax). Nested statements (e.g.
-        // goto under if, return under a labeled statement) are not
-        // siblings in the same list, and AnalyzeControlFlow(first, last)
-        // rejects mixed parents via ValidateStatementRange.
+        // Prefer statements that are direct children of ONE statement-list
+        // parent (BlockSyntax / SwitchSectionSyntax). Parent-type alone
+        // still admits siblings from nested lists (e.g. return 1 under
+        // if (a) and return 2 under if (b)): each Parent is a different
+        // BlockSyntax, so kind filter alone hands mixed parents to
+        // ValidateStatementRange → ArgumentException → RoslynError (#936).
+        // Among candidates, pick the outermost contained list parent
+        // (parity with AnalyzeDataFlowOperation / #931) and keep only its
+        // direct children so First/Last share a parent.
         // If that sibling-list filter yields empty and the region
         // contains exactly one StatementSyntax (e.g. unbraced embedded
         // return under if), analyze that single statement alone.
@@ -102,9 +106,38 @@ public sealed class AnalyzeControlFlowOperation : QueryOperationBase<AnalyzeCont
             .Where(s => span.Contains(s.Span))
             .ToList();
 
-        var statements = containedStatements
+        var listParentCandidates = containedStatements
             .Where(s => s.Parent is BlockSyntax or SwitchSectionSyntax)
             .ToList();
+
+        var statements = listParentCandidates;
+        if (listParentCandidates.Count > 0)
+        {
+            var parents = listParentCandidates
+                .Select(s => s.Parent!)
+                .Distinct()
+                .ToList();
+
+            // Outermost contained statement-list parent: contains every
+            // other candidate parent (or is the only one).
+            var outermostParent = parents.FirstOrDefault(p =>
+                parents.All(other => other == p || p.Contains(other)));
+
+            if (outermostParent != null)
+            {
+                statements = listParentCandidates
+                    .Where(s => s.Parent == outermostParent)
+                    .ToList();
+            }
+            else
+            {
+                // No single parent contains the others (cross-list region).
+                // Reject rather than hand mixed parents to Roslyn (#936).
+                throw new RefactoringException(
+                    ErrorCodes.InvalidRegion,
+                    "Selected statements are not within the same statement list.");
+            }
+        }
 
         if (statements.Count == 0)
         {

--- a/src/RoslynMcp.Core/Query/AnalyzeControlFlowOperation.cs
+++ b/src/RoslynMcp.Core/Query/AnalyzeControlFlowOperation.cs
@@ -125,9 +125,45 @@ public sealed class AnalyzeControlFlowOperation : QueryOperationBase<AnalyzeCont
 
             if (outermostParent != null)
             {
-                statements = listParentCandidates
+                // Direct children of the outermost list among candidates,
+                // ordered by source position.
+                var directChildren = listParentCandidates
                     .Where(s => s.Parent == outermostParent)
+                    .OrderBy(s => s.SpanStart)
                     .ToList();
+
+                // Nested candidates under outermostParent (different
+                // statement lists). Accept outermost only when every
+                // nested candidate falls within the span from the first
+                // to last direct-child candidate — otherwise a middle
+                // outer statement (e.g. Log()) can win while boundary
+                // nested returns are filtered away → silent wrong
+                // analysis of only Log() instead of InvalidRegion.
+                var nestedCandidates = listParentCandidates
+                    .Where(s => s.Parent != outermostParent && outermostParent.Contains(s))
+                    .ToList();
+
+                if (nestedCandidates.Count > 0)
+                {
+                    if (directChildren.Count == 0)
+                    {
+                        throw new RefactoringException(
+                            ErrorCodes.InvalidRegion,
+                            "Selected statements are not within the same statement list.");
+                    }
+
+                    var coverStart = directChildren.First().Span.Start;
+                    var coverEnd = directChildren.Last().Span.End;
+                    if (nestedCandidates.Any(n =>
+                            n.Span.Start < coverStart || n.Span.End > coverEnd))
+                    {
+                        throw new RefactoringException(
+                            ErrorCodes.InvalidRegion,
+                            "Selected statements are not within the same statement list.");
+                    }
+                }
+
+                statements = directChildren;
             }
             else
             {

--- a/tests/RoslynMcp.Core.Tests/Query/AnalyzeControlFlowOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Query/AnalyzeControlFlowOperationTests.cs
@@ -671,7 +671,8 @@ class C
     public async Task AnalyzeControlFlow_WholeMethodWithNestedIfs_StillSucceedsViaOutermostList()
     {
         // Regression: whole-method region keeps outermost method-block
-        // siblings (the two ifs + final return) and Succeeds.
+        // siblings (the two ifs + final return) and Succeeds with all
+        // three returns/exits and expected reachability.
         const string source =
             """
 class C
@@ -712,7 +713,62 @@ class C
 
         Assert.True(result.Success);
         Assert.NotNull(result.Data);
-        Assert.NotEmpty(result.Data.ReturnStatements);
+        Assert.Equal(3, result.Data.ReturnStatements.Count);
+        Assert.Equal(3, result.Data.ExitPoints.Count);
+        Assert.True(result.Data.StartPointReachable);
+        Assert.False(result.Data.EndPointReachable);
+    }
+
+    [SkippableFact]
+    public async Task AnalyzeControlFlow_CrossBlockReturnsWithMiddleOuterStatement_ThrowsInvalidRegion()
+    {
+        // #936 Codex: return1 / Log() / return2 spanning region must not
+        // select outermost method block solely via Log() then silently
+        // analyze only Log(). Nested boundary returns sit outside the
+        // direct-child covered range → InvalidRegion.
+        const string source =
+            """
+class C
+{
+    void Log() { }
+
+    int M(bool a, bool b)
+    {
+        if (a)
+        {
+            return 1;
+        }
+        Log();
+        if (b)
+        {
+            return 2;
+        }
+        return 0;
+    }
+}
+""";
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new AnalyzeControlFlowOperation(workspace.Context);
+
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var root = tree.GetRoot();
+        var returns = root.DescendantNodes().OfType<ReturnStatementSyntax>().ToList();
+        var r1 = returns.Single(r => r.Expression?.ToString() == "1");
+        var r2 = returns.Single(r => r.Expression?.ToString() == "2");
+        var startLine = r1.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+        var endLine = r2.GetLocation().GetLineSpan().EndLinePosition.Line + 1;
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new AnalyzeControlFlowParams
+            {
+                SourceFile = workspace.SourcePath,
+                StartLine = startLine,
+                EndLine = endLine
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidRegion, ex.ErrorCode);
+        Assert.Contains("same statement list", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [SkippableFact]

--- a/tests/RoslynMcp.Core.Tests/Query/AnalyzeControlFlowOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Query/AnalyzeControlFlowOperationTests.cs
@@ -619,6 +619,103 @@ return 2;
     }
 
     [SkippableFact]
+    public async Task AnalyzeControlFlow_CrossBlockNestedReturns_ThrowsInvalidRegionNotRoslynError()
+    {
+        // #936: region spanning return 1 under if (a) and return 2 under
+        // if (b). Kind filter alone keeps both (different Block parents);
+        // outermost-parent policy must InvalidRegion, not RoslynError.
+        const string source =
+            """
+class C
+{
+    int M(bool a, bool b)
+    {
+        if (a)
+        {
+            return 1;
+        }
+        if (b)
+        {
+            return 2;
+        }
+        return 0;
+    }
+}
+""";
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new AnalyzeControlFlowOperation(workspace.Context);
+
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var root = tree.GetRoot();
+        var returns = root.DescendantNodes().OfType<ReturnStatementSyntax>().ToList();
+        var r1 = returns.Single(r => r.Expression?.ToString() == "1");
+        var r2 = returns.Single(r => r.Expression?.ToString() == "2");
+        var startLine = r1.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+        var endLine = r2.GetLocation().GetLineSpan().EndLinePosition.Line + 1;
+
+        var ex = await Assert.ThrowsAsync<RefactoringException>(() =>
+            operation.ExecuteAsync(new AnalyzeControlFlowParams
+            {
+                SourceFile = workspace.SourcePath,
+                StartLine = startLine,
+                EndLine = endLine
+            }));
+
+        Assert.Equal(ErrorCodes.InvalidRegion, ex.ErrorCode);
+        Assert.DoesNotContain("Unexpected", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("same statement list", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [SkippableFact]
+    public async Task AnalyzeControlFlow_WholeMethodWithNestedIfs_StillSucceedsViaOutermostList()
+    {
+        // Regression: whole-method region keeps outermost method-block
+        // siblings (the two ifs + final return) and Succeeds.
+        const string source =
+            """
+class C
+{
+    int M(bool a, bool b)
+    {
+        if (a)
+        {
+            return 1;
+        }
+        if (b)
+        {
+            return 2;
+        }
+        return 0;
+    }
+}
+""";
+
+        await using var workspace = await TempWorkspace.CreateAsync(source);
+        var operation = new AnalyzeControlFlowOperation(workspace.Context);
+
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var root = tree.GetRoot();
+        var method = root.DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .Single(m => m.Identifier.ValueText == "M");
+        var methodSpan = method.GetLocation().GetLineSpan();
+        var startLine = methodSpan.StartLinePosition.Line + 1;
+        var endLine = methodSpan.EndLinePosition.Line + 1;
+
+        var result = await operation.ExecuteAsync(new AnalyzeControlFlowParams
+        {
+            SourceFile = workspace.SourcePath,
+            StartLine = startLine,
+            EndLine = endLine
+        });
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Data);
+        Assert.NotEmpty(result.Data.ReturnStatements);
+    }
+
+    [SkippableFact]
     public async Task AnalyzeControlFlow_UnbracedEmbeddedSingleStatement_AnalyzesAlone()
     {
         // Region = only the unbraced return under if. Parent is


### PR DESCRIPTION
## Summary
- Mirror `AnalyzeDataFlowOperation` outermost statement-list parent selection in `AnalyzeControlFlowOperation` after the Block/SwitchSection kind filter.
- Cross-block nested returns (different Block parents) now throw `InvalidRegion` “same statement list” instead of `RoslynError` / ValidateStatementRange.
- Whole-method region with nested ifs still Succeeds via outermost method-block siblings.

Closes #936

## Test plan
- [x] `dotnet test --filter FullyQualifiedName~AnalyzeControlFlowOperationTests` (32 passed)
- [ ] CI Build & Test + Code Quality green
- [ ] Copilot/Codex review threads resolved