### PR TITLE
refactor: extract shared SpanCoversColumn for Signature ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Changed
 - Extracted shared `SpanCoverage.SpanCoversColumn` and replaced the five identical Signature-family copies (`add_parameter` / `remove_parameter` / `change_signature` / `change_return_type` / `reorder_parameters`); `TypeSymbolResolver.SpanCoversColumn` delegates to the same helper (#955)
+
 ## [0.6.0] - 2026-09-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Changed
+- Extracted shared `SpanCoverage.SpanCoversColumn` and replaced the five identical Signature-family copies (`add_parameter` / `remove_parameter` / `change_signature` / `change_return_type` / `reorder_parameters`); `TypeSymbolResolver.SpanCoversColumn` delegates to the same helper (#955)
 ## [0.6.0] - 2026-09-11
 
 ### Added

--- a/src/RoslynMcp.Core/Refactoring/Generate/AddNullChecksOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/AddNullChecksOperation.cs
@@ -337,7 +337,7 @@ public sealed class AddNullChecksOperation : RefactoringOperationBase<AddNullChe
     /// <paramref name="line"/>, picks the smallest method or constructor
     /// whose identifier or declaration span covers that 1-based column
     /// (same exclusive-end coverage as
-    /// <c>ChangeSignatureOperation.SpanCoversColumn</c>). Prefer the
+    /// <c>SpanCoverage.SpanCoversColumn</c>). Prefer the
     /// identifier hit, then the smallest containing declaration. Do not
     /// require the declaration to start on <paramref name="line"/> when
     /// column is set — a split signature may put the identifier on a
@@ -415,7 +415,7 @@ public sealed class AddNullChecksOperation : RefactoringOperationBase<AddNullChe
     /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
     /// inclusive would let the first character of an adjacent method also
     /// match the previous declaration. Same helper as
-    /// <c>ChangeSignatureOperation.SpanCoversColumn</c>.
+    /// <c>SpanCoverage.SpanCoversColumn</c>.
     /// </summary>
     internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
     {

--- a/src/RoslynMcp.Core/Refactoring/Inline/InlineMethodOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Inline/InlineMethodOperation.cs
@@ -302,11 +302,7 @@ public sealed class InlineMethodOperation : RefactoringOperationBase<InlineMetho
     /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
     /// inclusive would let the first character of an adjacent method also
     /// match the previous declaration. Same helper as
-    /// <c>ChangeReturnTypeOperation.SpanCoversColumn</c> /
-    /// <c>ChangeSignatureOperation.SpanCoversColumn</c> /
-    /// <c>AddParameterOperation.SpanCoversColumn</c> /
-    /// <c>RemoveParameterOperation.SpanCoversColumn</c> /
-    /// <c>ReorderParametersOperation.SpanCoversColumn</c>.
+    /// <c>SpanCoverage.SpanCoversColumn</c>.
     /// </summary>
     internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
     {

--- a/src/RoslynMcp.Core/Refactoring/Rename/RenameNamespaceOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Rename/RenameNamespaceOperation.cs
@@ -574,13 +574,9 @@ public sealed class RenameNamespaceOperation : RefactoringOperationBase<RenameNa
     /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
     /// inclusive would let the first character of an adjacent namespace also
     /// match the previous declaration. Same helper as
+    /// <c>SpanCoverage.SpanCoversColumn</c> /
     /// <c>TypeSymbolResolver.SpanCoversColumn</c> /
-    /// <c>InlineMethodOperation.SpanCoversColumn</c> /
-    /// <c>ChangeReturnTypeOperation.SpanCoversColumn</c> /
-    /// <c>ChangeSignatureOperation.SpanCoversColumn</c> /
-    /// <c>AddParameterOperation.SpanCoversColumn</c> /
-    /// <c>RemoveParameterOperation.SpanCoversColumn</c> /
-    /// <c>ReorderParametersOperation.SpanCoversColumn</c>.
+    /// <c>InlineMethodOperation.SpanCoversColumn</c>.
     /// </summary>
     internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
     {

--- a/src/RoslynMcp.Core/Refactoring/Signature/AddParameterOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Signature/AddParameterOperation.cs
@@ -8,6 +8,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 
 namespace RoslynMcp.Core.Refactoring.Signature;
@@ -334,34 +335,11 @@ public sealed class AddParameterOperation : RefactoringOperationBase<AddParamete
 
     private static bool MethodCoversColumn(MethodDeclarationSyntax method, int line, int column) =>
         IdentifierCoversColumn(method, line, column) ||
-        SpanCoversColumn(method.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(method.GetLocation().GetLineSpan(), line, column);
 
     private static bool IdentifierCoversColumn(MethodDeclarationSyntax method, int line, int column) =>
-        SpanCoversColumn(method.Identifier.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(method.Identifier.GetLocation().GetLineSpan(), line, column);
 
-    /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character of an adjacent method also
-    /// match the previous declaration. Same helper as
-    /// <c>ChangeSignatureOperation.SpanCoversColumn</c>.
-    /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
 
     internal static int ComputeInsertionIndex(ParameterListSyntax list, int position)
     {

--- a/src/RoslynMcp.Core/Refactoring/Signature/ChangeReturnTypeOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Signature/ChangeReturnTypeOperation.cs
@@ -8,6 +8,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 
 namespace RoslynMcp.Core.Refactoring.Signature;
@@ -466,37 +467,11 @@ public sealed class ChangeReturnTypeOperation : RefactoringOperationBase<ChangeR
 
     private static bool MethodCoversColumn(MethodDeclarationSyntax method, int line, int column) =>
         IdentifierCoversColumn(method, line, column) ||
-        SpanCoversColumn(method.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(method.GetLocation().GetLineSpan(), line, column);
 
     private static bool IdentifierCoversColumn(MethodDeclarationSyntax method, int line, int column) =>
-        SpanCoversColumn(method.Identifier.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(method.Identifier.GetLocation().GetLineSpan(), line, column);
 
-    /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character of an adjacent method also
-    /// match the previous declaration. Same helper as
-    /// <c>ChangeSignatureOperation.SpanCoversColumn</c> /
-    /// <c>AddParameterOperation.SpanCoversColumn</c> /
-    /// <c>RemoveParameterOperation.SpanCoversColumn</c> /
-    /// <c>ReorderParametersOperation.SpanCoversColumn</c>.
-    /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
 
     private async Task<List<IMethodSymbol>> GetRelatedMethodsAsync(
         IMethodSymbol method,

--- a/src/RoslynMcp.Core/Refactoring/Signature/ChangeSignatureOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Signature/ChangeSignatureOperation.cs
@@ -7,6 +7,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 
 namespace RoslynMcp.Core.Refactoring.Signature;
@@ -255,33 +256,11 @@ public sealed class ChangeSignatureOperation : RefactoringOperationBase<ChangeSi
 
     private static bool MethodCoversColumn(MethodDeclarationSyntax method, int line, int column) =>
         IdentifierCoversColumn(method, line, column) ||
-        SpanCoversColumn(method.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(method.GetLocation().GetLineSpan(), line, column);
 
     private static bool IdentifierCoversColumn(MethodDeclarationSyntax method, int line, int column) =>
-        SpanCoversColumn(method.Identifier.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(method.Identifier.GetLocation().GetLineSpan(), line, column);
 
-    /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character of an adjacent method also
-    /// match the previous declaration.
-    /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
 
     private static List<NewParameter> BuildNewParameterList(
         List<IParameterSymbol> originalParams,

--- a/src/RoslynMcp.Core/Refactoring/Signature/RemoveParameterOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Signature/RemoveParameterOperation.cs
@@ -8,6 +8,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 
 namespace RoslynMcp.Core.Refactoring.Signature;
@@ -327,35 +328,11 @@ public sealed class RemoveParameterOperation : RefactoringOperationBase<RemovePa
 
     private static bool MethodCoversColumn(MethodDeclarationSyntax method, int line, int column) =>
         IdentifierCoversColumn(method, line, column) ||
-        SpanCoversColumn(method.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(method.GetLocation().GetLineSpan(), line, column);
 
     private static bool IdentifierCoversColumn(MethodDeclarationSyntax method, int line, int column) =>
-        SpanCoversColumn(method.Identifier.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(method.Identifier.GetLocation().GetLineSpan(), line, column);
 
-    /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character of an adjacent method also
-    /// match the previous declaration. Same helper as
-    /// <c>ChangeSignatureOperation.SpanCoversColumn</c> /
-    /// <c>AddParameterOperation.SpanCoversColumn</c>.
-    /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
 
     internal static IParameterSymbol FindParameter(IMethodSymbol method, string name)
     {

--- a/src/RoslynMcp.Core/Refactoring/Signature/ReorderParametersOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Signature/ReorderParametersOperation.cs
@@ -8,6 +8,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 
 namespace RoslynMcp.Core.Refactoring.Signature;
@@ -469,36 +470,11 @@ public sealed class ReorderParametersOperation : RefactoringOperationBase<Reorde
 
     private static bool MethodCoversColumn(MethodDeclarationSyntax method, int line, int column) =>
         IdentifierCoversColumn(method, line, column) ||
-        SpanCoversColumn(method.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(method.GetLocation().GetLineSpan(), line, column);
 
     private static bool IdentifierCoversColumn(MethodDeclarationSyntax method, int line, int column) =>
-        SpanCoversColumn(method.Identifier.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(method.Identifier.GetLocation().GetLineSpan(), line, column);
 
-    /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character of an adjacent method also
-    /// match the previous declaration. Same helper as
-    /// <c>ChangeSignatureOperation.SpanCoversColumn</c> /
-    /// <c>AddParameterOperation.SpanCoversColumn</c> /
-    /// <c>RemoveParameterOperation.SpanCoversColumn</c>.
-    /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
 
     private async Task<List<IMethodSymbol>> GetRelatedMethodsAsync(
         IMethodSymbol method,

--- a/src/RoslynMcp.Core/Resolution/SpanCoverage.cs
+++ b/src/RoslynMcp.Core/Resolution/SpanCoverage.cs
@@ -1,0 +1,32 @@
+using Microsoft.CodeAnalysis;
+
+namespace RoslynMcp.Core.Resolution;
+
+/// <summary>
+/// Shared 1-based exclusive-end coverage helpers for <see cref="FileLinePositionSpan"/>.
+/// </summary>
+internal static class SpanCoverage
+{
+    /// <summary>
+    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
+    /// is exclusive, so <paramref name="column"/> must be strictly before the
+    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
+    /// inclusive would let the first character of an adjacent declaration also
+    /// match the previous one.
+    /// </summary>
+    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
+    {
+        var startLine = span.StartLinePosition.Line + 1;
+        var endLine = span.EndLinePosition.Line + 1;
+        var startCol = span.StartLinePosition.Character + 1;
+        var endCol = span.EndLinePosition.Character + 1;
+
+        if (line < startLine || line > endLine)
+            return false;
+        if (line == startLine && column < startCol)
+            return false;
+        if (line == endLine && column >= endCol)
+            return false;
+        return true;
+    }
+}

--- a/src/RoslynMcp.Core/Resolution/TypeSymbolResolver.cs
+++ b/src/RoslynMcp.Core/Resolution/TypeSymbolResolver.cs
@@ -244,30 +244,10 @@ public sealed class TypeSymbolResolver
         SpanCoversColumn(type.Identifier.GetLocation().GetLineSpan(), line, column);
 
     /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character of an adjacent type also
-    /// match the previous declaration. Same helper as
-    /// <c>UseBaseTypeOperation.SpanCoversColumn</c> /
-    /// <c>EncapsulateFieldOperation.SpanCoversColumn</c> /
-    /// <c>PushMembersDownOperation.SpanCoversColumn</c>.
+    /// 1-based line/column coverage. Delegates to <see cref="SpanCoverage.SpanCoversColumn"/>.
     /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
+    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column) =>
+        SpanCoverage.SpanCoversColumn(span, line, column);
 }
 
 /// <summary>

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Signature/AddParameterOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Signature/AddParameterOperationTests.cs
@@ -6,6 +6,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Signature;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 using Xunit;
 
@@ -883,10 +884,10 @@ public class AddParameterOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(AddParameterOperation.SpanCoversColumn(span, line, startCol));
-        Assert.True(AddParameterOperation.SpanCoversColumn(span, line, endCol - 1));
-        Assert.False(AddParameterOperation.SpanCoversColumn(span, line, endCol));
-        Assert.False(AddParameterOperation.SpanCoversColumn(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, startCol - 1));
     }
 
     [SkippableFact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Signature/ChangeReturnTypeOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Signature/ChangeReturnTypeOperationTests.cs
@@ -6,6 +6,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Signature;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 using Xunit;
 
@@ -1000,10 +1001,10 @@ public class ChangeReturnTypeOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(ChangeReturnTypeOperation.SpanCoversColumn(span, line, startCol));
-        Assert.True(ChangeReturnTypeOperation.SpanCoversColumn(span, line, endCol - 1));
-        Assert.False(ChangeReturnTypeOperation.SpanCoversColumn(span, line, endCol));
-        Assert.False(ChangeReturnTypeOperation.SpanCoversColumn(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, startCol - 1));
     }
 
     [SkippableFact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Signature/ChangeSignatureOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Signature/ChangeSignatureOperationTests.cs
@@ -5,6 +5,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Signature;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 using Xunit;
 
@@ -428,10 +429,10 @@ public class ChangeSignatureOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(ChangeSignatureOperation.SpanCoversColumn(span, line, startCol));
-        Assert.True(ChangeSignatureOperation.SpanCoversColumn(span, line, endCol - 1));
-        Assert.False(ChangeSignatureOperation.SpanCoversColumn(span, line, endCol));
-        Assert.False(ChangeSignatureOperation.SpanCoversColumn(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, startCol - 1));
     }
 
     #endregion

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Signature/RemoveParameterOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Signature/RemoveParameterOperationTests.cs
@@ -6,6 +6,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Signature;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 using Xunit;
 
@@ -731,10 +732,10 @@ public class RemoveParameterOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(RemoveParameterOperation.SpanCoversColumn(span, line, startCol));
-        Assert.True(RemoveParameterOperation.SpanCoversColumn(span, line, endCol - 1));
-        Assert.False(RemoveParameterOperation.SpanCoversColumn(span, line, endCol));
-        Assert.False(RemoveParameterOperation.SpanCoversColumn(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, startCol - 1));
     }
 
     [SkippableFact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Signature/ReorderParametersOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Signature/ReorderParametersOperationTests.cs
@@ -6,6 +6,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Signature;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 using Xunit;
 
@@ -909,10 +910,10 @@ public class ReorderParametersOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(ReorderParametersOperation.SpanCoversColumn(span, line, startCol));
-        Assert.True(ReorderParametersOperation.SpanCoversColumn(span, line, endCol - 1));
-        Assert.False(ReorderParametersOperation.SpanCoversColumn(span, line, endCol));
-        Assert.False(ReorderParametersOperation.SpanCoversColumn(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, startCol - 1));
     }
 
     [SkippableFact]


### PR DESCRIPTION
## Summary
- Add `SpanCoverage.SpanCoversColumn` as the shared exclusive-end coverage helper
- Remove five identical Signature-family copies; call the shared helper
- Delegate `TypeSymbolResolver.SpanCoversColumn` to `SpanCoverage` (MoveType* tests unchanged)
- Retarget Signature exclusive-end unit tests

Closes #955

## Test plan
- [x] `dotnet test` filter `FullyQualifiedName~Signature` — 206 passed
- [ ] CI Build and Test + Code Quality green
- [ ] Copilot/Codex threads resolved (GitHub PM owns squash-merge)