### PR TITLE
refactor: replace Convert SpanCoversColumn with SpanCoverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- Replaced 13 identical Convert-family `SpanCoversColumn` copies with shared `SpanCoverage.SpanCoversColumn` (`add_braces` / `remove_braces` / `convert_*` / `invert_if` / `simplify_name`) (#959)
 - Extracted shared `SpanCoverage.SpanCoversColumn` and replaced the five identical Signature-family copies (`add_parameter` / `remove_parameter` / `change_signature` / `change_return_type` / `reorder_parameters`); `TypeSymbolResolver.SpanCoversColumn` delegates to the same helper (#955)
 
 ## [0.6.0] - 2026-09-11

--- a/src/RoslynMcp.Core/Refactoring/Convert/AddBracesOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/AddBracesOperation.cs
@@ -8,8 +8,8 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
-using RoslynMcp.Core.Workspace;
 using RoslynMcp.Core.Resolution;
+using RoslynMcp.Core.Workspace;
 
 namespace RoslynMcp.Core.Refactoring.Convert;
 

--- a/src/RoslynMcp.Core/Refactoring/Convert/AddBracesOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/AddBracesOperation.cs
@@ -9,6 +9,7 @@ using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
 using RoslynMcp.Core.Workspace;
+using RoslynMcp.Core.Resolution;
 
 namespace RoslynMcp.Core.Refactoring.Convert;
 
@@ -614,36 +615,9 @@ public sealed class AddBracesOperation : RefactoringOperationBase<AddBracesParam
 
     private static bool KeywordCoversColumn(SyntaxToken keyword, int line, int column)
     {
-        return SpanCoversColumn(keyword.GetLocation().GetLineSpan(), line, column);
+        return SpanCoverage.SpanCoversColumn(keyword.GetLocation().GetLineSpan(), line, column);
     }
 
-    /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character after a covered keyword also
-    /// match the previous keyword. Same helper as
-    /// <c>SimplifyNameOperation.SpanCoversColumn</c> /
-    /// <c>InvertIfOperation.SpanCoversColumn</c> /
-    /// <c>TypeSymbolResolver.SpanCoversColumn</c> /
-    /// <c>RenameFileToMatchTypeOperation.SpanCoversColumn</c> /
-    /// <c>InlineMethodOperation.SpanCoversColumn</c>.
-    /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
 
     private static string BuildDescription(string scope, int count, string? typeName)
     {

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertAnonymousToClassOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertAnonymousToClassOperation.cs
@@ -9,6 +9,7 @@ using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
 using RoslynMcp.Core.Workspace;
+using RoslynMcp.Core.Resolution;
 using SymbolKind = RoslynMcp.Contracts.Enums.SymbolKind;
 
 namespace RoslynMcp.Core.Refactoring.Convert;
@@ -215,7 +216,7 @@ public sealed class ConvertAnonymousToClassOperation : RefactoringOperationBase<
         if (@params.Column.HasValue)
         {
             var atColumn = candidates
-                .Where(n => SpanCoversColumn(n.GetLocation().GetLineSpan(), @params.Line, @params.Column.Value))
+                .Where(n => SpanCoverage.SpanCoversColumn(n.GetLocation().GetLineSpan(), @params.Line, @params.Column.Value))
                 .ToList();
             if (atColumn.Count == 1)
                 return atColumn[0];
@@ -804,36 +805,9 @@ public sealed class ConvertAnonymousToClassOperation : RefactoringOperationBase<
         if (!column.HasValue)
             return true;
 
-        return SpanCoversColumn(span, line, column.Value);
+        return SpanCoverage.SpanCoversColumn(span, line, column.Value);
     }
 
-    /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character after a covered anonymous
-    /// creation also match the previous creation. Same helper as
-    /// <c>ConvertForeachLinqOperation.SpanCoversColumn</c> /
-    /// <c>RemoveBracesOperation.SpanCoversColumn</c> /
-    /// <c>AddBracesOperation.SpanCoversColumn</c> /
-    /// <c>SimplifyNameOperation.SpanCoversColumn</c> /
-    /// <c>InvertIfOperation.SpanCoversColumn</c>.
-    /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
 
     private static bool TypeNameBindsToDifferentType(
         string display,

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertAnonymousToClassOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertAnonymousToClassOperation.cs
@@ -8,8 +8,8 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
-using RoslynMcp.Core.Workspace;
 using RoslynMcp.Core.Resolution;
+using RoslynMcp.Core.Workspace;
 using SymbolKind = RoslynMcp.Contracts.Enums.SymbolKind;
 
 namespace RoslynMcp.Core.Refactoring.Convert;

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertExpressionBodyOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertExpressionBodyOperation.cs
@@ -7,8 +7,8 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
-using RoslynMcp.Core.Workspace;
 using RoslynMcp.Core.Resolution;
+using RoslynMcp.Core.Workspace;
 
 namespace RoslynMcp.Core.Refactoring.Convert;
 

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertExpressionBodyOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertExpressionBodyOperation.cs
@@ -8,6 +8,7 @@ using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
 using RoslynMcp.Core.Workspace;
+using RoslynMcp.Core.Resolution;
 
 namespace RoslynMcp.Core.Refactoring.Convert;
 
@@ -290,12 +291,12 @@ public sealed class ConvertExpressionBodyOperation : RefactoringOperationBase<Co
 
     private static bool MemberCoversColumn(MemberDeclarationSyntax member, int line, int column) =>
         IdentifierCoversColumn(member, line, column) ||
-        SpanCoversColumn(member.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(member.GetLocation().GetLineSpan(), line, column);
 
     private static bool IdentifierCoversColumn(MemberDeclarationSyntax member, int line, int column)
     {
         var token = GetIdentifierToken(member);
-        return token != default && SpanCoversColumn(token.GetLocation().GetLineSpan(), line, column);
+        return token != default && SpanCoverage.SpanCoversColumn(token.GetLocation().GetLineSpan(), line, column);
     }
 
     private static SyntaxToken GetIdentifierToken(MemberDeclarationSyntax member) => member switch
@@ -308,28 +309,6 @@ public sealed class ConvertExpressionBodyOperation : RefactoringOperationBase<Co
         _ => default
     };
 
-    /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character of an adjacent member also
-    /// match the previous declaration.
-    /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
 
     private static string? GetMemberName(MemberDeclarationSyntax member) => member switch
     {

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertForeachLinqOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertForeachLinqOperation.cs
@@ -8,6 +8,7 @@ using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
 using RoslynMcp.Core.Workspace;
+using RoslynMcp.Core.Resolution;
 
 namespace RoslynMcp.Core.Refactoring.Convert;
 
@@ -541,38 +542,9 @@ public sealed class ConvertForeachLinqOperation : RefactoringOperationBase<Conve
 
     private static bool KeywordCoversColumn(ForEachStatementSyntax statement, int line, int column)
     {
-        return SpanCoversColumn(statement.ForEachKeyword.GetLocation().GetLineSpan(), line, column);
+        return SpanCoverage.SpanCoversColumn(statement.ForEachKeyword.GetLocation().GetLineSpan(), line, column);
     }
 
-    /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character after a covered <c>foreach</c>
-    /// keyword also match the previous keyword. Same helper as
-    /// <c>RemoveBracesOperation.SpanCoversColumn</c> /
-    /// <c>AddBracesOperation.SpanCoversColumn</c> /
-    /// <c>SimplifyNameOperation.SpanCoversColumn</c> /
-    /// <c>InvertIfOperation.SpanCoversColumn</c> /
-    /// <c>TypeSymbolResolver.SpanCoversColumn</c> /
-    /// <c>RenameFileToMatchTypeOperation.SpanCoversColumn</c> /
-    /// <c>InlineMethodOperation.SpanCoversColumn</c>.
-    /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
 }
 
 /// <summary>

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertForeachLinqOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertForeachLinqOperation.cs
@@ -7,8 +7,8 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
-using RoslynMcp.Core.Workspace;
 using RoslynMcp.Core.Resolution;
+using RoslynMcp.Core.Workspace;
 
 namespace RoslynMcp.Core.Refactoring.Convert;
 

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertPropertyOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertPropertyOperation.cs
@@ -7,6 +7,7 @@ using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
 using RoslynMcp.Core.Workspace;
+using RoslynMcp.Core.Resolution;
 
 namespace RoslynMcp.Core.Refactoring.Convert;
 
@@ -512,33 +513,11 @@ public sealed class ConvertPropertyOperation : RefactoringOperationBase<ConvertP
 
     private static bool PropertyCoversColumn(PropertyDeclarationSyntax property, int line, int column) =>
         IdentifierCoversColumn(property, line, column) ||
-        SpanCoversColumn(property.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(property.GetLocation().GetLineSpan(), line, column);
 
     private static bool IdentifierCoversColumn(PropertyDeclarationSyntax property, int line, int column) =>
-        SpanCoversColumn(property.Identifier.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(property.Identifier.GetLocation().GetLineSpan(), line, column);
 
-    /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character of an adjacent property also
-    /// match the previous declaration.
-    /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
 
     /// <summary>
     /// Visits nested types first, then converts each eligible property in

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertPropertyOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertPropertyOperation.cs
@@ -6,8 +6,8 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
-using RoslynMcp.Core.Workspace;
 using RoslynMcp.Core.Resolution;
+using RoslynMcp.Core.Workspace;
 
 namespace RoslynMcp.Core.Refactoring.Convert;
 

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertToAsyncOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertToAsyncOperation.cs
@@ -8,8 +8,8 @@ using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
 using RoslynMcp.Core.Refactoring.Utilities;
-using RoslynMcp.Core.Workspace;
 using RoslynMcp.Core.Resolution;
+using RoslynMcp.Core.Workspace;
 
 namespace RoslynMcp.Core.Refactoring.Convert;
 

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertToAsyncOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertToAsyncOperation.cs
@@ -9,6 +9,7 @@ using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
 using RoslynMcp.Core.Refactoring.Utilities;
 using RoslynMcp.Core.Workspace;
+using RoslynMcp.Core.Resolution;
 
 namespace RoslynMcp.Core.Refactoring.Convert;
 
@@ -813,33 +814,11 @@ public sealed class ConvertToAsyncOperation : RefactoringOperationBase<ConvertTo
 
     private static bool MethodCoversColumn(MethodDeclarationSyntax method, int line, int column) =>
         IdentifierCoversColumn(method, line, column) ||
-        SpanCoversColumn(method.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(method.GetLocation().GetLineSpan(), line, column);
 
     private static bool IdentifierCoversColumn(MethodDeclarationSyntax method, int line, int column) =>
-        SpanCoversColumn(method.Identifier.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(method.Identifier.GetLocation().GetLineSpan(), line, column);
 
-    /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character of an adjacent method also
-    /// match the previous declaration.
-    /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
 
     private static async Task<List<CallSite>> CollectCallSitesAsync(
         IMethodSymbol methodSymbol,

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertToBlockBodyOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertToBlockBodyOperation.cs
@@ -6,8 +6,8 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
-using RoslynMcp.Core.Workspace;
 using RoslynMcp.Core.Resolution;
+using RoslynMcp.Core.Workspace;
 
 namespace RoslynMcp.Core.Refactoring.Convert;
 

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertToBlockBodyOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertToBlockBodyOperation.cs
@@ -7,6 +7,7 @@ using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
 using RoslynMcp.Core.Workspace;
+using RoslynMcp.Core.Resolution;
 
 namespace RoslynMcp.Core.Refactoring.Convert;
 
@@ -202,12 +203,12 @@ public sealed class ConvertToBlockBodyOperation : RefactoringOperationBase<Conve
 
     private static bool MemberCoversColumn(SyntaxNode member, int line, int column) =>
         IdentifierCoversColumn(member, line, column) ||
-        SpanCoversColumn(member.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(member.GetLocation().GetLineSpan(), line, column);
 
     private static bool IdentifierCoversColumn(SyntaxNode member, int line, int column)
     {
         var token = GetIdentifierToken(member);
-        return token != default && SpanCoversColumn(token.GetLocation().GetLineSpan(), line, column);
+        return token != default && SpanCoverage.SpanCoversColumn(token.GetLocation().GetLineSpan(), line, column);
     }
 
     private static SyntaxToken GetIdentifierToken(SyntaxNode member) => member switch
@@ -227,28 +228,6 @@ public sealed class ConvertToBlockBodyOperation : RefactoringOperationBase<Conve
         _ => default
     };
 
-    /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character of an adjacent member also
-    /// match the previous declaration.
-    /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
 
     /// <summary>
     /// 1-based line coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertToInterpolatedStringOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertToInterpolatedStringOperation.cs
@@ -7,8 +7,8 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
-using RoslynMcp.Core.Workspace;
 using RoslynMcp.Core.Resolution;
+using RoslynMcp.Core.Workspace;
 
 namespace RoslynMcp.Core.Refactoring.Convert;
 

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertToInterpolatedStringOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertToInterpolatedStringOperation.cs
@@ -8,6 +8,7 @@ using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
 using RoslynMcp.Core.Workspace;
+using RoslynMcp.Core.Resolution;
 
 namespace RoslynMcp.Core.Refactoring.Convert;
 
@@ -284,7 +285,7 @@ public sealed class ConvertToInterpolatedStringOperation : RefactoringOperationB
         }
 
         var formatAtColumn = formats
-            .Where(invocation => SpanCoversColumn(invocation.GetLocation().GetLineSpan(), line, column.Value))
+            .Where(invocation => SpanCoverage.SpanCoversColumn(invocation.GetLocation().GetLineSpan(), line, column.Value))
             .OrderBy(invocation => invocation.Span.Length)
             .FirstOrDefault();
         if (formatAtColumn != null)
@@ -296,7 +297,7 @@ public sealed class ConvertToInterpolatedStringOperation : RefactoringOperationB
         // operands. Adjacent independent concatenations still do not share a
         // span, so column continues to distinguish them.
         var concatAtColumn = concats
-            .Where(binary => SpanCoversColumn(binary.GetLocation().GetLineSpan(), line, column.Value))
+            .Where(binary => SpanCoverage.SpanCoversColumn(binary.GetLocation().GetLineSpan(), line, column.Value))
             .OrderByDescending(binary => binary.Span.Length)
             .FirstOrDefault();
         return concatAtColumn == null ? null : OuterConcatenation(concatAtColumn);
@@ -367,28 +368,6 @@ public sealed class ConvertToInterpolatedStringOperation : RefactoringOperationB
     private static bool StartsOnLine(SyntaxNode node, int line) =>
         node.GetLocation().GetLineSpan().StartLinePosition.Line + 1 == line;
 
-    /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character of an adjacent expression also
-    /// match the previous Format invocation or concatenation.
-    /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
 
     private static bool IsStringFormatCall(InvocationExpressionSyntax invocation, SemanticModel model)
     {

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertToPatternMatchingOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertToPatternMatchingOperation.cs
@@ -7,8 +7,8 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
-using RoslynMcp.Core.Workspace;
 using RoslynMcp.Core.Resolution;
+using RoslynMcp.Core.Workspace;
 
 namespace RoslynMcp.Core.Refactoring.Convert;
 

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertToPatternMatchingOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertToPatternMatchingOperation.cs
@@ -8,6 +8,7 @@ using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
 using RoslynMcp.Core.Workspace;
+using RoslynMcp.Core.Resolution;
 
 namespace RoslynMcp.Core.Refactoring.Convert;
 
@@ -276,7 +277,7 @@ public sealed class ConvertToPatternMatchingOperation : RefactoringOperationBase
 
         return switches.Cast<StatementSyntax>()
             .Concat(ifs)
-            .Where(statement => SpanCoversColumn(statement.GetLocation().GetLineSpan(), line, column.Value))
+            .Where(statement => SpanCoverage.SpanCoversColumn(statement.GetLocation().GetLineSpan(), line, column.Value))
             .OrderBy(statement => statement.Span.Length)
             .FirstOrDefault();
     }
@@ -284,28 +285,6 @@ public sealed class ConvertToPatternMatchingOperation : RefactoringOperationBase
     private static bool StartsOnLine(SyntaxNode node, int line) =>
         node.GetLocation().GetLineSpan().StartLinePosition.Line + 1 == line;
 
-    /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character of an adjacent statement also
-    /// match the previous switch or if.
-    /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
 
     private async Task<RefactoringResult> ConvertSwitchToExpression(
         Guid operationId, Document document, SyntaxNode root,

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertTupleToStructOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertTupleToStructOperation.cs
@@ -8,6 +8,7 @@ using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
 using RoslynMcp.Core.Workspace;
+using RoslynMcp.Core.Resolution;
 using SymbolKind = RoslynMcp.Contracts.Enums.SymbolKind;
 
 namespace RoslynMcp.Core.Refactoring.Convert;
@@ -220,7 +221,7 @@ public sealed class ConvertTupleToStructOperation : RefactoringOperationBase<Con
         if (@params.Column.HasValue)
         {
             var atColumn = candidates
-                .Where(n => SpanCoversColumn(n.GetLocation().GetLineSpan(), @params.Line, @params.Column.Value))
+                .Where(n => SpanCoverage.SpanCoversColumn(n.GetLocation().GetLineSpan(), @params.Line, @params.Column.Value))
                 .ToList();
             if (atColumn.Count == 1)
                 return (ExpressionSyntax)atColumn[0];
@@ -1039,37 +1040,9 @@ public sealed class ConvertTupleToStructOperation : RefactoringOperationBase<Con
         if (!column.HasValue)
             return true;
 
-        return SpanCoversColumn(span, line, column.Value);
+        return SpanCoverage.SpanCoversColumn(span, line, column.Value);
     }
 
-    /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character after a covered tuple
-    /// creation also match the previous creation. Same helper as
-    /// <c>ConvertAnonymousToClassOperation.SpanCoversColumn</c> /
-    /// <c>ConvertForeachLinqOperation.SpanCoversColumn</c> /
-    /// <c>RemoveBracesOperation.SpanCoversColumn</c> /
-    /// <c>AddBracesOperation.SpanCoversColumn</c> /
-    /// <c>SimplifyNameOperation.SpanCoversColumn</c> /
-    /// <c>InvertIfOperation.SpanCoversColumn</c>.
-    /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
 
     private static bool TypeNameBindsToDifferentType(
         string display,

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertTupleToStructOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertTupleToStructOperation.cs
@@ -7,8 +7,8 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
-using RoslynMcp.Core.Workspace;
 using RoslynMcp.Core.Resolution;
+using RoslynMcp.Core.Workspace;
 using SymbolKind = RoslynMcp.Contracts.Enums.SymbolKind;
 
 namespace RoslynMcp.Core.Refactoring.Convert;

--- a/src/RoslynMcp.Core/Refactoring/Convert/InvertIfOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/InvertIfOperation.cs
@@ -7,8 +7,8 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
-using RoslynMcp.Core.Workspace;
 using RoslynMcp.Core.Resolution;
+using RoslynMcp.Core.Workspace;
 
 namespace RoslynMcp.Core.Refactoring.Convert;
 

--- a/src/RoslynMcp.Core/Refactoring/Convert/InvertIfOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/InvertIfOperation.cs
@@ -8,6 +8,7 @@ using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
 using RoslynMcp.Core.Workspace;
+using RoslynMcp.Core.Resolution;
 
 namespace RoslynMcp.Core.Refactoring.Convert;
 
@@ -369,34 +370,9 @@ public sealed class InvertIfOperation : RefactoringOperationBase<InvertIfParams>
     private static bool KeywordCoversColumn(IfStatementSyntax statement, int line, int column)
     {
         var span = statement.IfKeyword.GetLocation().GetLineSpan();
-        return SpanCoversColumn(span, line, column);
+        return SpanCoverage.SpanCoversColumn(span, line, column);
     }
 
-    /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character after an <c>if</c> keyword also
-    /// match the previous keyword. Same helper as
-    /// <c>TypeSymbolResolver.SpanCoversColumn</c> /
-    /// <c>RenameFileToMatchTypeOperation.SpanCoversColumn</c> /
-    /// <c>InlineMethodOperation.SpanCoversColumn</c>.
-    /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
 
     internal static ExpressionSyntax InvertCondition(ExpressionSyntax condition, SemanticModel? model)
     {

--- a/src/RoslynMcp.Core/Refactoring/Convert/RemoveBracesOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/RemoveBracesOperation.cs
@@ -8,8 +8,8 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
-using RoslynMcp.Core.Workspace;
 using RoslynMcp.Core.Resolution;
+using RoslynMcp.Core.Workspace;
 
 namespace RoslynMcp.Core.Refactoring.Convert;
 

--- a/src/RoslynMcp.Core/Refactoring/Convert/RemoveBracesOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/RemoveBracesOperation.cs
@@ -9,6 +9,7 @@ using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
 using RoslynMcp.Core.Workspace;
+using RoslynMcp.Core.Resolution;
 
 namespace RoslynMcp.Core.Refactoring.Convert;
 
@@ -714,37 +715,9 @@ public sealed class RemoveBracesOperation : RefactoringOperationBase<RemoveBrace
 
     private static bool KeywordCoversColumn(SyntaxToken keyword, int line, int column)
     {
-        return SpanCoversColumn(keyword.GetLocation().GetLineSpan(), line, column);
+        return SpanCoverage.SpanCoversColumn(keyword.GetLocation().GetLineSpan(), line, column);
     }
 
-    /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character after a covered keyword also
-    /// match the previous keyword. Same helper as
-    /// <c>AddBracesOperation.SpanCoversColumn</c> /
-    /// <c>SimplifyNameOperation.SpanCoversColumn</c> /
-    /// <c>InvertIfOperation.SpanCoversColumn</c> /
-    /// <c>TypeSymbolResolver.SpanCoversColumn</c> /
-    /// <c>RenameFileToMatchTypeOperation.SpanCoversColumn</c> /
-    /// <c>InlineMethodOperation.SpanCoversColumn</c>.
-    /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
 
     private static string BuildDescription(string scope, int count, string? typeName)
     {

--- a/src/RoslynMcp.Core/Refactoring/Convert/SimplifyNameOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/SimplifyNameOperation.cs
@@ -9,8 +9,8 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
-using RoslynMcp.Core.Workspace;
 using RoslynMcp.Core.Resolution;
+using RoslynMcp.Core.Workspace;
 
 namespace RoslynMcp.Core.Refactoring.Convert;
 

--- a/src/RoslynMcp.Core/Refactoring/Convert/SimplifyNameOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/SimplifyNameOperation.cs
@@ -10,6 +10,7 @@ using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
 using RoslynMcp.Core.Workspace;
+using RoslynMcp.Core.Resolution;
 
 namespace RoslynMcp.Core.Refactoring.Convert;
 
@@ -412,7 +413,7 @@ public sealed class SimplifyNameOperation : RefactoringOperationBase<SimplifyNam
         if (column.HasValue)
         {
             var covering = onLine
-                .Where(node => SpanCoversColumn(node.GetLocation().GetLineSpan(), line, column.Value))
+                .Where(node => SpanCoverage.SpanCoversColumn(node.GetLocation().GetLineSpan(), line, column.Value))
                 .OrderBy(node => node.Span.Length)
                 .ToList();
             return covering.FirstOrDefault();
@@ -1034,32 +1035,6 @@ public sealed class SimplifyNameOperation : RefactoringOperationBase<SimplifyNam
         return true;
     }
 
-    /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character after a covered name also
-    /// match the previous name. Same helper as
-    /// <c>InvertIfOperation.SpanCoversColumn</c> /
-    /// <c>TypeSymbolResolver.SpanCoversColumn</c> /
-    /// <c>RenameFileToMatchTypeOperation.SpanCoversColumn</c> /
-    /// <c>InlineMethodOperation.SpanCoversColumn</c>.
-    /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
 
     private static string BuildDescription(string scope, int applied, int skipped)
     {

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/AddBracesOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/AddBracesOperationTests.cs
@@ -6,8 +6,8 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Convert;
-using RoslynMcp.Core.Workspace;
 using RoslynMcp.Core.Resolution;
+using RoslynMcp.Core.Workspace;
 using Xunit;
 
 namespace RoslynMcp.Core.Tests.Refactoring;

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/AddBracesOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/AddBracesOperationTests.cs
@@ -7,6 +7,7 @@ using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Convert;
 using RoslynMcp.Core.Workspace;
+using RoslynMcp.Core.Resolution;
 using Xunit;
 
 namespace RoslynMcp.Core.Tests.Refactoring;
@@ -1353,7 +1354,7 @@ public class AddBracesOperationTests
         var atExclusiveEnd = AddBracesOperation.FindControlTarget(root, line, firstKeywordEndCol);
         var atSecond = AddBracesOperation.FindControlTarget(root, line, secondKeyword);
 
-        Assert.False(AddBracesOperation.SpanCoversColumn(
+        Assert.False(SpanCoverage.SpanCoversColumn(
             first.IfKeyword.GetLocation().GetLineSpan(), line, firstKeywordEndCol));
         Assert.True(atExclusiveEnd == null
             || ((IfStatementSyntax)atExclusiveEnd.Value.Owner).Condition.ToString() != "a");
@@ -1373,10 +1374,10 @@ public class AddBracesOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(AddBracesOperation.SpanCoversColumn(span, line, startCol));
-        Assert.True(AddBracesOperation.SpanCoversColumn(span, line, endCol - 1));
-        Assert.False(AddBracesOperation.SpanCoversColumn(span, line, endCol));
-        Assert.False(AddBracesOperation.SpanCoversColumn(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, startCol - 1));
     }
 
     #endregion

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertAnonymousToClassOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertAnonymousToClassOperationTests.cs
@@ -6,8 +6,8 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Convert;
-using RoslynMcp.Core.Workspace;
 using RoslynMcp.Core.Resolution;
+using RoslynMcp.Core.Workspace;
 using Xunit;
 
 namespace RoslynMcp.Core.Tests.Refactoring;

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertAnonymousToClassOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertAnonymousToClassOperationTests.cs
@@ -7,6 +7,7 @@ using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Convert;
 using RoslynMcp.Core.Workspace;
+using RoslynMcp.Core.Resolution;
 using Xunit;
 
 namespace RoslynMcp.Core.Tests.Refactoring;
@@ -522,7 +523,7 @@ public class ConvertAnonymousToClassOperationTests
         var firstCreationEndCol = first.GetLocation().GetLineSpan().EndLinePosition.Character + 1;
         var secondColumn = ColumnOf(SameLineAnonymousSource, "new { Age = 1 }");
 
-        Assert.False(ConvertAnonymousToClassOperation.SpanCoversColumn(
+        Assert.False(SpanCoverage.SpanCoversColumn(
             first.GetLocation().GetLineSpan(), line, firstCreationEndCol));
 
         var exclusiveEnd = Assert.Throws<RefactoringException>(() =>
@@ -560,10 +561,10 @@ public class ConvertAnonymousToClassOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(ConvertAnonymousToClassOperation.SpanCoversColumn(span, line, startCol));
-        Assert.True(ConvertAnonymousToClassOperation.SpanCoversColumn(span, line, endCol - 1));
-        Assert.False(ConvertAnonymousToClassOperation.SpanCoversColumn(span, line, endCol));
-        Assert.False(ConvertAnonymousToClassOperation.SpanCoversColumn(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, startCol - 1));
     }
 
     [Fact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertExpressionBodyOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertExpressionBodyOperationTests.cs
@@ -6,6 +6,7 @@ using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Convert;
 using RoslynMcp.Core.Workspace;
+using RoslynMcp.Core.Resolution;
 using Xunit;
 
 namespace RoslynMcp.Core.Tests.Refactoring;
@@ -1034,10 +1035,10 @@ public class ConvertExpressionBodyOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(ConvertExpressionBodyOperation.SpanCoversColumn(span, line, startCol));
-        Assert.True(ConvertExpressionBodyOperation.SpanCoversColumn(span, line, endCol - 1));
-        Assert.False(ConvertExpressionBodyOperation.SpanCoversColumn(span, line, endCol));
-        Assert.False(ConvertExpressionBodyOperation.SpanCoversColumn(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, startCol - 1));
     }
 
     #endregion

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertExpressionBodyOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertExpressionBodyOperationTests.cs
@@ -5,8 +5,8 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Convert;
-using RoslynMcp.Core.Workspace;
 using RoslynMcp.Core.Resolution;
+using RoslynMcp.Core.Workspace;
 using Xunit;
 
 namespace RoslynMcp.Core.Tests.Refactoring;

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertForeachLinqOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertForeachLinqOperationTests.cs
@@ -6,6 +6,7 @@ using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Convert;
 using RoslynMcp.Core.Workspace;
+using RoslynMcp.Core.Resolution;
 using Xunit;
 
 namespace RoslynMcp.Core.Tests.Refactoring;
@@ -831,7 +832,7 @@ public class ConvertForeachLinqOperationTests
         var atExclusiveEnd = ConvertForeachLinqOperation.FindForeachStatement(root, line, firstKeywordEndCol);
         var atSecond = ConvertForeachLinqOperation.FindForeachStatement(root, line, secondKeyword);
 
-        Assert.False(ConvertForeachLinqOperation.SpanCoversColumn(
+        Assert.False(SpanCoverage.SpanCoversColumn(
             first.ForEachKeyword.GetLocation().GetLineSpan(), line, firstKeywordEndCol));
         Assert.True(atExclusiveEnd == null || atExclusiveEnd.Identifier.Text != "x");
         Assert.NotNull(atSecond);
@@ -849,10 +850,10 @@ public class ConvertForeachLinqOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(ConvertForeachLinqOperation.SpanCoversColumn(span, line, startCol));
-        Assert.True(ConvertForeachLinqOperation.SpanCoversColumn(span, line, endCol - 1));
-        Assert.False(ConvertForeachLinqOperation.SpanCoversColumn(span, line, endCol));
-        Assert.False(ConvertForeachLinqOperation.SpanCoversColumn(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, startCol - 1));
     }
 
     #endregion

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertForeachLinqOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertForeachLinqOperationTests.cs
@@ -5,8 +5,8 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Convert;
-using RoslynMcp.Core.Workspace;
 using RoslynMcp.Core.Resolution;
+using RoslynMcp.Core.Workspace;
 using Xunit;
 
 namespace RoslynMcp.Core.Tests.Refactoring;

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertPropertyOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertPropertyOperationTests.cs
@@ -6,8 +6,8 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Convert;
-using RoslynMcp.Core.Workspace;
 using RoslynMcp.Core.Resolution;
+using RoslynMcp.Core.Workspace;
 using Xunit;
 
 namespace RoslynMcp.Core.Tests.Refactoring;

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertPropertyOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertPropertyOperationTests.cs
@@ -7,6 +7,7 @@ using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Convert;
 using RoslynMcp.Core.Workspace;
+using RoslynMcp.Core.Resolution;
 using Xunit;
 
 namespace RoslynMcp.Core.Tests.Refactoring;
@@ -534,7 +535,7 @@ public class ConvertPropertyOperationTests
         var atExclusiveEnd = ConvertPropertyOperation.FindProperty(root, null, line, firstEndCol);
         var atSecondId = ConvertPropertyOperation.FindProperty(root, null, line, secondId);
 
-        Assert.False(ConvertPropertyOperation.SpanCoversColumn(
+        Assert.False(SpanCoverage.SpanCoversColumn(
             first.GetLocation().GetLineSpan(), line, firstEndCol));
         Assert.True(atExclusiveEnd == null || atExclusiveEnd.Identifier.Text != "Foo");
         Assert.NotNull(atSecondId);
@@ -585,10 +586,10 @@ public class ConvertPropertyOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(ConvertPropertyOperation.SpanCoversColumn(span, line, startCol));
-        Assert.True(ConvertPropertyOperation.SpanCoversColumn(span, line, endCol - 1));
-        Assert.False(ConvertPropertyOperation.SpanCoversColumn(span, line, endCol));
-        Assert.False(ConvertPropertyOperation.SpanCoversColumn(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, startCol - 1));
     }
 
     #endregion

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertToAsyncOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertToAsyncOperationTests.cs
@@ -6,6 +6,7 @@ using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Convert;
 using RoslynMcp.Core.Workspace;
+using RoslynMcp.Core.Resolution;
 using Xunit;
 
 namespace RoslynMcp.Core.Tests.Refactoring;
@@ -1722,10 +1723,10 @@ public class ConvertToAsyncOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(ConvertToAsyncOperation.SpanCoversColumn(span, line, startCol));
-        Assert.True(ConvertToAsyncOperation.SpanCoversColumn(span, line, endCol - 1));
-        Assert.False(ConvertToAsyncOperation.SpanCoversColumn(span, line, endCol));
-        Assert.False(ConvertToAsyncOperation.SpanCoversColumn(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, startCol - 1));
     }
 
     #endregion

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertToAsyncOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertToAsyncOperationTests.cs
@@ -5,8 +5,8 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Convert;
-using RoslynMcp.Core.Workspace;
 using RoslynMcp.Core.Resolution;
+using RoslynMcp.Core.Workspace;
 using Xunit;
 
 namespace RoslynMcp.Core.Tests.Refactoring;

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertToBlockBodyOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertToBlockBodyOperationTests.cs
@@ -6,8 +6,8 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Convert;
-using RoslynMcp.Core.Workspace;
 using RoslynMcp.Core.Resolution;
+using RoslynMcp.Core.Workspace;
 using Xunit;
 
 namespace RoslynMcp.Core.Tests.Refactoring;

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertToBlockBodyOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertToBlockBodyOperationTests.cs
@@ -7,6 +7,7 @@ using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Convert;
 using RoslynMcp.Core.Workspace;
+using RoslynMcp.Core.Resolution;
 using Xunit;
 
 namespace RoslynMcp.Core.Tests.Refactoring;
@@ -660,10 +661,10 @@ public class ConvertToBlockBodyOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(ConvertToBlockBodyOperation.SpanCoversColumn(span, line, startCol));
-        Assert.True(ConvertToBlockBodyOperation.SpanCoversColumn(span, line, endCol - 1));
-        Assert.False(ConvertToBlockBodyOperation.SpanCoversColumn(span, line, endCol));
-        Assert.False(ConvertToBlockBodyOperation.SpanCoversColumn(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, startCol - 1));
     }
 
     [Fact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertToInterpolatedStringOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertToInterpolatedStringOperationTests.cs
@@ -6,6 +6,7 @@ using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Convert;
 using RoslynMcp.Core.Workspace;
+using RoslynMcp.Core.Resolution;
 using Xunit;
 
 namespace RoslynMcp.Core.Tests.Refactoring;
@@ -528,7 +529,7 @@ public class ConvertToInterpolatedStringOperationTests
         var atSecondId = ConvertToInterpolatedStringOperation.FindConvertibleExpression(
             root, model, line, secondId);
 
-        Assert.False(ConvertToInterpolatedStringOperation.SpanCoversColumn(
+        Assert.False(SpanCoverage.SpanCoversColumn(
             first.GetLocation().GetLineSpan(), line, firstEndCol));
         Assert.True(atExclusiveEnd == null || !atExclusiveEnd.ToString().Contains("first", StringComparison.Ordinal));
         Assert.NotNull(atSecondId);
@@ -547,10 +548,10 @@ public class ConvertToInterpolatedStringOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(ConvertToInterpolatedStringOperation.SpanCoversColumn(span, line, startCol));
-        Assert.True(ConvertToInterpolatedStringOperation.SpanCoversColumn(span, line, endCol - 1));
-        Assert.False(ConvertToInterpolatedStringOperation.SpanCoversColumn(span, line, endCol));
-        Assert.False(ConvertToInterpolatedStringOperation.SpanCoversColumn(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, startCol - 1));
     }
 
     #endregion

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertToInterpolatedStringOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertToInterpolatedStringOperationTests.cs
@@ -5,8 +5,8 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Convert;
-using RoslynMcp.Core.Workspace;
 using RoslynMcp.Core.Resolution;
+using RoslynMcp.Core.Workspace;
 using Xunit;
 
 namespace RoslynMcp.Core.Tests.Refactoring;

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertToPatternMatchingOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertToPatternMatchingOperationTests.cs
@@ -6,6 +6,7 @@ using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Convert;
 using RoslynMcp.Core.Workspace;
+using RoslynMcp.Core.Resolution;
 using Xunit;
 
 namespace RoslynMcp.Core.Tests.Refactoring;
@@ -496,7 +497,7 @@ public class ConvertToPatternMatchingOperationTests
         var atExclusiveEnd = ConvertToPatternMatchingOperation.FindConvertibleStatement(root, line, firstEndCol);
         var atSecondKeyword = ConvertToPatternMatchingOperation.FindConvertibleStatement(root, line, secondKeyword);
 
-        Assert.False(ConvertToPatternMatchingOperation.SpanCoversColumn(
+        Assert.False(SpanCoverage.SpanCoversColumn(
             first.GetLocation().GetLineSpan(), line, firstEndCol));
         Assert.True(atExclusiveEnd == null || !atExclusiveEnd.ToString().Contains("intA", StringComparison.Ordinal));
         Assert.IsType<IfStatementSyntax>(atSecondKeyword);
@@ -515,10 +516,10 @@ public class ConvertToPatternMatchingOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(ConvertToPatternMatchingOperation.SpanCoversColumn(span, line, startCol));
-        Assert.True(ConvertToPatternMatchingOperation.SpanCoversColumn(span, line, endCol - 1));
-        Assert.False(ConvertToPatternMatchingOperation.SpanCoversColumn(span, line, endCol));
-        Assert.False(ConvertToPatternMatchingOperation.SpanCoversColumn(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, startCol - 1));
     }
 
     #endregion

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertToPatternMatchingOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertToPatternMatchingOperationTests.cs
@@ -5,8 +5,8 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Convert;
-using RoslynMcp.Core.Workspace;
 using RoslynMcp.Core.Resolution;
+using RoslynMcp.Core.Workspace;
 using Xunit;
 
 namespace RoslynMcp.Core.Tests.Refactoring;

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertTupleToStructOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertTupleToStructOperationTests.cs
@@ -7,6 +7,7 @@ using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Convert;
 using RoslynMcp.Core.Workspace;
+using RoslynMcp.Core.Resolution;
 using Xunit;
 
 namespace RoslynMcp.Core.Tests.Refactoring;
@@ -525,7 +526,7 @@ public class ConvertTupleToStructOperationTests
         var firstCreationEndCol = first.GetLocation().GetLineSpan().EndLinePosition.Character + 1;
         var secondColumn = ColumnOf(SameLineTupleSource, "(A: 3, B: 4)");
 
-        Assert.False(ConvertTupleToStructOperation.SpanCoversColumn(
+        Assert.False(SpanCoverage.SpanCoversColumn(
             first.GetLocation().GetLineSpan(), line, firstCreationEndCol));
 
         var exclusiveEnd = Assert.Throws<RefactoringException>(() =>
@@ -565,10 +566,10 @@ public class ConvertTupleToStructOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(ConvertTupleToStructOperation.SpanCoversColumn(span, line, startCol));
-        Assert.True(ConvertTupleToStructOperation.SpanCoversColumn(span, line, endCol - 1));
-        Assert.False(ConvertTupleToStructOperation.SpanCoversColumn(span, line, endCol));
-        Assert.False(ConvertTupleToStructOperation.SpanCoversColumn(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, startCol - 1));
     }
 
     [Fact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertTupleToStructOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertTupleToStructOperationTests.cs
@@ -6,8 +6,8 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Convert;
-using RoslynMcp.Core.Workspace;
 using RoslynMcp.Core.Resolution;
+using RoslynMcp.Core.Workspace;
 using Xunit;
 
 namespace RoslynMcp.Core.Tests.Refactoring;

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/InvertIfOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/InvertIfOperationTests.cs
@@ -7,6 +7,7 @@ using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Convert;
 using RoslynMcp.Core.Workspace;
+using RoslynMcp.Core.Resolution;
 using Xunit;
 
 namespace RoslynMcp.Core.Tests.Refactoring;
@@ -1359,7 +1360,7 @@ public class InvertIfOperationTests
         var atExclusiveEnd = InvertIfOperation.FindIfStatement(root, line, firstKeywordEndCol);
         var atSecond = InvertIfOperation.FindIfStatement(root, line, secondKeyword);
 
-        Assert.False(InvertIfOperation.SpanCoversColumn(
+        Assert.False(SpanCoverage.SpanCoversColumn(
             first.IfKeyword.GetLocation().GetLineSpan(), line, firstKeywordEndCol));
         Assert.True(atExclusiveEnd == null || atExclusiveEnd.Condition.ToString() != "a");
         Assert.NotNull(atSecond);
@@ -1377,10 +1378,10 @@ public class InvertIfOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(InvertIfOperation.SpanCoversColumn(span, line, startCol));
-        Assert.True(InvertIfOperation.SpanCoversColumn(span, line, endCol - 1));
-        Assert.False(InvertIfOperation.SpanCoversColumn(span, line, endCol));
-        Assert.False(InvertIfOperation.SpanCoversColumn(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, startCol - 1));
     }
 
     #endregion

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/InvertIfOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/InvertIfOperationTests.cs
@@ -6,8 +6,8 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Convert;
-using RoslynMcp.Core.Workspace;
 using RoslynMcp.Core.Resolution;
+using RoslynMcp.Core.Workspace;
 using Xunit;
 
 namespace RoslynMcp.Core.Tests.Refactoring;

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/RemoveBracesOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/RemoveBracesOperationTests.cs
@@ -6,8 +6,8 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Convert;
-using RoslynMcp.Core.Workspace;
 using RoslynMcp.Core.Resolution;
+using RoslynMcp.Core.Workspace;
 using Xunit;
 
 namespace RoslynMcp.Core.Tests.Refactoring;

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/RemoveBracesOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/RemoveBracesOperationTests.cs
@@ -7,6 +7,7 @@ using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Convert;
 using RoslynMcp.Core.Workspace;
+using RoslynMcp.Core.Resolution;
 using Xunit;
 
 namespace RoslynMcp.Core.Tests.Refactoring;
@@ -1934,7 +1935,7 @@ public class RemoveBracesOperationTests
         var atExclusiveEnd = RemoveBracesOperation.FindControlTarget(root, line, firstKeywordEndCol);
         var atSecond = RemoveBracesOperation.FindControlTarget(root, line, secondKeyword);
 
-        Assert.False(RemoveBracesOperation.SpanCoversColumn(
+        Assert.False(SpanCoverage.SpanCoversColumn(
             first.IfKeyword.GetLocation().GetLineSpan(), line, firstKeywordEndCol));
         Assert.True(atExclusiveEnd == null
             || ((IfStatementSyntax)atExclusiveEnd.Value.Owner).Condition.ToString() != "a");
@@ -1954,10 +1955,10 @@ public class RemoveBracesOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(RemoveBracesOperation.SpanCoversColumn(span, line, startCol));
-        Assert.True(RemoveBracesOperation.SpanCoversColumn(span, line, endCol - 1));
-        Assert.False(RemoveBracesOperation.SpanCoversColumn(span, line, endCol));
-        Assert.False(RemoveBracesOperation.SpanCoversColumn(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, startCol - 1));
     }
 
     #endregion

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/SimplifyNameOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/SimplifyNameOperationTests.cs
@@ -6,8 +6,8 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Convert;
-using RoslynMcp.Core.Workspace;
 using RoslynMcp.Core.Resolution;
+using RoslynMcp.Core.Workspace;
 using Xunit;
 
 namespace RoslynMcp.Core.Tests.Refactoring;

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/SimplifyNameOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/SimplifyNameOperationTests.cs
@@ -7,6 +7,7 @@ using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Convert;
 using RoslynMcp.Core.Workspace;
+using RoslynMcp.Core.Resolution;
 using Xunit;
 
 namespace RoslynMcp.Core.Tests.Refactoring;
@@ -259,7 +260,7 @@ public class SimplifyNameOperationTests
         var atExclusiveEnd = SimplifyNameOperation.FindNameAtLocation(names, line, firstNameEndCol);
         var atSecond = SimplifyNameOperation.FindNameAtLocation(names, line, secondColumn);
 
-        Assert.False(SimplifyNameOperation.SpanCoversColumn(
+        Assert.False(SpanCoverage.SpanCoversColumn(
             first.GetLocation().GetLineSpan(), line, firstNameEndCol));
         Assert.True(atExclusiveEnd == null
             || !atExclusiveEnd.ToString().Contains("StringBuilder", StringComparison.Ordinal));
@@ -278,10 +279,10 @@ public class SimplifyNameOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(SimplifyNameOperation.SpanCoversColumn(span, line, startCol));
-        Assert.True(SimplifyNameOperation.SpanCoversColumn(span, line, endCol - 1));
-        Assert.False(SimplifyNameOperation.SpanCoversColumn(span, line, endCol));
-        Assert.False(SimplifyNameOperation.SpanCoversColumn(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, startCol - 1));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Continues #955: remove 13 byte-identical Convert-family `SpanCoversColumn` copies in favor of shared `SpanCoverage.SpanCoversColumn`.
- Retargets Convert exclusive-end unit tests to the shared helper.
- Unreleased CHANGELOG hygiene line. No behavior change.

Closes #959

## Test plan
- [x] `dotnet test` filter `FullyQualifiedName~SpanCoversColumn` — 40 passed locally
- [ ] CI Build and Test + Code Quality on this PR
- [ ] Copilot/Codex review; GitHub PM squash-merges. Leave Dependabot.