### PR TITLE
refactor: replace Generate SpanCoversColumn with SpanCoverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- Replaced 7 identical Generate-family `SpanCoversColumn` copies with shared `SpanCoverage.SpanCoversColumn` (`generate_constructor` / `generate_equals_hashcode` / `generate_overrides` / `generate_property` / `generate_tostring` / `implement_abstract` / `implement_interface`) (#962)
 - Replaced 13 identical Convert-family `SpanCoversColumn` copies with shared `SpanCoverage.SpanCoversColumn` (`add_braces` / `remove_braces` / `convert_*` / `invert_if` / `simplify_name`) (#959)
 - Extracted shared `SpanCoverage.SpanCoversColumn` and replaced the five identical Signature-family copies (`add_parameter` / `remove_parameter` / `change_signature` / `change_return_type` / `reorder_parameters`); `TypeSymbolResolver.SpanCoversColumn` delegates to the same helper (#955)
 

--- a/src/RoslynMcp.Core/Refactoring/Generate/GenerateConstructorOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GenerateConstructorOperation.cs
@@ -7,6 +7,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 
 namespace RoslynMcp.Core.Refactoring.Generate;
@@ -1311,35 +1312,11 @@ public sealed class GenerateConstructorOperation : RefactoringOperationBase<Gene
 
     private static bool TypeCoversColumn(TypeDeclarationSyntax type, int line, int column) =>
         IdentifierCoversColumn(type, line, column) ||
-        SpanCoversColumn(type.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(type.GetLocation().GetLineSpan(), line, column);
 
     private static bool IdentifierCoversColumn(TypeDeclarationSyntax type, int line, int column) =>
-        SpanCoversColumn(type.Identifier.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(type.Identifier.GetLocation().GetLineSpan(), line, column);
 
-    /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character of an adjacent type also
-    /// match the previous declaration. Same helper as
-    /// <c>GenerateEqualsHashCodeOperation.SpanCoversColumn</c> /
-    /// <c>GenerateOverridesOperation.SpanCoversColumn</c>.
-    /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
 
     /// <summary>
     /// 1-based line coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>

--- a/src/RoslynMcp.Core/Refactoring/Generate/GenerateEqualsHashCodeOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GenerateEqualsHashCodeOperation.cs
@@ -8,6 +8,7 @@ using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
 using RoslynMcp.Core.Refactoring.Utilities;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 
 namespace RoslynMcp.Core.Refactoring.Generate;
@@ -1009,34 +1010,11 @@ public sealed class GenerateEqualsHashCodeOperation : RefactoringOperationBase<G
 
     private static bool TypeCoversColumn(TypeDeclarationSyntax type, int line, int column) =>
         IdentifierCoversColumn(type, line, column) ||
-        SpanCoversColumn(type.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(type.GetLocation().GetLineSpan(), line, column);
 
     private static bool IdentifierCoversColumn(TypeDeclarationSyntax type, int line, int column) =>
-        SpanCoversColumn(type.Identifier.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(type.Identifier.GetLocation().GetLineSpan(), line, column);
 
-    /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character of an adjacent type also
-    /// match the previous declaration. Same helper as
-    /// <c>GenerateOverridesOperation.SpanCoversColumn</c>.
-    /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
 
     /// <summary>
     /// 1-based line coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>

--- a/src/RoslynMcp.Core/Refactoring/Generate/GenerateOverridesOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GenerateOverridesOperation.cs
@@ -1293,34 +1293,11 @@ public sealed class GenerateOverridesOperation : RefactoringOperationBase<Genera
 
     private static bool TypeCoversColumn(TypeDeclarationSyntax type, int line, int column) =>
         IdentifierCoversColumn(type, line, column) ||
-        SpanCoversColumn(type.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(type.GetLocation().GetLineSpan(), line, column);
 
     private static bool IdentifierCoversColumn(TypeDeclarationSyntax type, int line, int column) =>
-        SpanCoversColumn(type.Identifier.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(type.Identifier.GetLocation().GetLineSpan(), line, column);
 
-    /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character of an adjacent type also
-    /// match the previous declaration. Same helper as
-    /// <c>AddNullChecksOperation.SpanCoversColumn</c>.
-    /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
 
     /// <summary>
     /// 1-based line coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>

--- a/src/RoslynMcp.Core/Refactoring/Generate/GeneratePropertyOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GeneratePropertyOperation.cs
@@ -7,6 +7,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 
 namespace RoslynMcp.Core.Refactoring.Generate;
@@ -819,35 +820,11 @@ public sealed class GeneratePropertyOperation : RefactoringOperationBase<Generat
 
     private static bool TypeCoversColumn(BaseTypeDeclarationSyntax type, int line, int column) =>
         IdentifierCoversColumn(type, line, column) ||
-        SpanCoversColumn(type.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(type.GetLocation().GetLineSpan(), line, column);
 
     private static bool IdentifierCoversColumn(BaseTypeDeclarationSyntax type, int line, int column) =>
-        SpanCoversColumn(type.Identifier.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(type.Identifier.GetLocation().GetLineSpan(), line, column);
 
-    /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character of an adjacent type also
-    /// match the previous declaration. Same helper as
-    /// <c>GenerateConstructorOperation.SpanCoversColumn</c> /
-    /// <c>GenerateOverridesOperation.SpanCoversColumn</c>.
-    /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
 
     /// <summary>
     /// 1-based line coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>

--- a/src/RoslynMcp.Core/Refactoring/Generate/GenerateToStringOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GenerateToStringOperation.cs
@@ -8,6 +8,7 @@ using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
 using RoslynMcp.Core.Refactoring.Utilities;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 
 namespace RoslynMcp.Core.Refactoring.Generate;
@@ -907,13 +908,13 @@ public sealed class GenerateToStringOperation : RefactoringOperationBase<Generat
 
     private static bool TypeCoversColumn(MemberDeclarationSyntax type, int line, int column) =>
         IdentifierCoversColumn(type, line, column) ||
-        SpanCoversColumn(type.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(type.GetLocation().GetLineSpan(), line, column);
 
     private static bool IdentifierCoversColumn(MemberDeclarationSyntax type, int line, int column)
     {
         var identifier = GetTypeIdentifier(type);
         return identifier != default
-            && SpanCoversColumn(identifier.GetLocation().GetLineSpan(), line, column);
+            && SpanCoverage.SpanCoversColumn(identifier.GetLocation().GetLineSpan(), line, column);
     }
 
     private static SyntaxToken GetTypeIdentifier(MemberDeclarationSyntax type) => type switch
@@ -923,31 +924,6 @@ public sealed class GenerateToStringOperation : RefactoringOperationBase<Generat
         _ => default
     };
 
-    /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character of an adjacent type also
-    /// match the previous declaration. Same helper as
-    /// <c>GenerateConstructorOperation.SpanCoversColumn</c> /
-    /// <c>ImplementAbstractOperation.SpanCoversColumn</c> /
-    /// <c>GenerateOverridesOperation.SpanCoversColumn</c>.
-    /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
 
     /// <summary>
     /// 1-based line coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>

--- a/src/RoslynMcp.Core/Refactoring/Generate/ImplementAbstractOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/ImplementAbstractOperation.cs
@@ -1756,13 +1756,13 @@ public sealed class ImplementAbstractOperation : RefactoringOperationBase<Implem
 
     private static bool TypeCoversColumn(MemberDeclarationSyntax type, int line, int column) =>
         IdentifierCoversColumn(type, line, column) ||
-        SpanCoversColumn(type.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(type.GetLocation().GetLineSpan(), line, column);
 
     private static bool IdentifierCoversColumn(MemberDeclarationSyntax type, int line, int column)
     {
         var identifier = GetTypeIdentifier(type);
         return identifier != default
-            && SpanCoversColumn(identifier.GetLocation().GetLineSpan(), line, column);
+            && SpanCoverage.SpanCoversColumn(identifier.GetLocation().GetLineSpan(), line, column);
     }
 
     private static SyntaxToken GetTypeIdentifier(MemberDeclarationSyntax type) => type switch
@@ -1772,30 +1772,6 @@ public sealed class ImplementAbstractOperation : RefactoringOperationBase<Implem
         _ => default
     };
 
-    /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character of an adjacent type also
-    /// match the previous declaration. Same helper as
-    /// <c>GeneratePropertyOperation.SpanCoversColumn</c> /
-    /// <c>GenerateOverridesOperation.SpanCoversColumn</c>.
-    /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
 
     /// <summary>
     /// 1-based line coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>

--- a/src/RoslynMcp.Core/Refactoring/Generate/ImplementInterfaceOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/ImplementInterfaceOperation.cs
@@ -1453,34 +1453,11 @@ public sealed class ImplementInterfaceOperation : RefactoringOperationBase<Imple
 
     private static bool TypeCoversColumn(TypeDeclarationSyntax type, int line, int column) =>
         IdentifierCoversColumn(type, line, column) ||
-        SpanCoversColumn(type.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(type.GetLocation().GetLineSpan(), line, column);
 
     private static bool IdentifierCoversColumn(TypeDeclarationSyntax type, int line, int column) =>
-        SpanCoversColumn(type.Identifier.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(type.Identifier.GetLocation().GetLineSpan(), line, column);
 
-    /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character of an adjacent type also
-    /// match the previous declaration. Same helper as
-    /// <c>GenerateOverridesOperation.SpanCoversColumn</c>.
-    /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
 
     /// <summary>
     /// 1-based line coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GenerateConstructorOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GenerateConstructorOperationTests.cs
@@ -6,6 +6,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Generate;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 using Xunit;
 
@@ -735,10 +736,10 @@ public class GenerateConstructorOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(GenerateConstructorOperation.SpanCoversColumn(span, line, startCol));
-        Assert.True(GenerateConstructorOperation.SpanCoversColumn(span, line, endCol - 1));
-        Assert.False(GenerateConstructorOperation.SpanCoversColumn(span, line, endCol));
-        Assert.False(GenerateConstructorOperation.SpanCoversColumn(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, startCol - 1));
     }
 
     [SkippableFact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GenerateEqualsHashCodeOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GenerateEqualsHashCodeOperationTests.cs
@@ -6,6 +6,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Generate;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 using Xunit;
 
@@ -729,10 +730,10 @@ public class GenerateEqualsHashCodeOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(GenerateEqualsHashCodeOperation.SpanCoversColumn(span, line, startCol));
-        Assert.True(GenerateEqualsHashCodeOperation.SpanCoversColumn(span, line, endCol - 1));
-        Assert.False(GenerateEqualsHashCodeOperation.SpanCoversColumn(span, line, endCol));
-        Assert.False(GenerateEqualsHashCodeOperation.SpanCoversColumn(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, startCol - 1));
     }
 
     [SkippableFact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GenerateOverridesOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GenerateOverridesOperationTests.cs
@@ -6,6 +6,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Generate;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 using Xunit;
 
@@ -781,10 +782,10 @@ public class GenerateOverridesOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(GenerateOverridesOperation.SpanCoversColumn(span, line, startCol));
-        Assert.True(GenerateOverridesOperation.SpanCoversColumn(span, line, endCol - 1));
-        Assert.False(GenerateOverridesOperation.SpanCoversColumn(span, line, endCol));
-        Assert.False(GenerateOverridesOperation.SpanCoversColumn(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, startCol - 1));
     }
 
     #endregion

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GeneratePropertyOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GeneratePropertyOperationTests.cs
@@ -7,6 +7,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Generate;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 using Xunit;
 
@@ -1157,10 +1158,10 @@ public class GeneratePropertyOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(GeneratePropertyOperation.SpanCoversColumn(span, line, startCol));
-        Assert.True(GeneratePropertyOperation.SpanCoversColumn(span, line, endCol - 1));
-        Assert.False(GeneratePropertyOperation.SpanCoversColumn(span, line, endCol));
-        Assert.False(GeneratePropertyOperation.SpanCoversColumn(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, startCol - 1));
     }
 
     [SkippableFact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GenerateToStringOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GenerateToStringOperationTests.cs
@@ -6,6 +6,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Generate;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 using Xunit;
 
@@ -1132,10 +1133,10 @@ public class GenerateToStringOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(GenerateToStringOperation.SpanCoversColumn(span, line, startCol));
-        Assert.True(GenerateToStringOperation.SpanCoversColumn(span, line, endCol - 1));
-        Assert.False(GenerateToStringOperation.SpanCoversColumn(span, line, endCol));
-        Assert.False(GenerateToStringOperation.SpanCoversColumn(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, startCol - 1));
     }
 
     [SkippableFact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Generate/ImplementAbstractOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Generate/ImplementAbstractOperationTests.cs
@@ -7,6 +7,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Generate;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 using Xunit;
 
@@ -1206,10 +1207,10 @@ public class ImplementAbstractOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(ImplementAbstractOperation.SpanCoversColumn(span, line, startCol));
-        Assert.True(ImplementAbstractOperation.SpanCoversColumn(span, line, endCol - 1));
-        Assert.False(ImplementAbstractOperation.SpanCoversColumn(span, line, endCol));
-        Assert.False(ImplementAbstractOperation.SpanCoversColumn(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, startCol - 1));
     }
 
     [SkippableFact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Generate/ImplementInterfaceOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Generate/ImplementInterfaceOperationTests.cs
@@ -7,6 +7,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Generate;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 using Xunit;
 
@@ -770,10 +771,10 @@ public class ImplementInterfaceOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(ImplementInterfaceOperation.SpanCoversColumn(span, line, startCol));
-        Assert.True(ImplementInterfaceOperation.SpanCoversColumn(span, line, endCol - 1));
-        Assert.False(ImplementInterfaceOperation.SpanCoversColumn(span, line, endCol));
-        Assert.False(ImplementInterfaceOperation.SpanCoversColumn(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, startCol - 1));
     }
 
     [SkippableFact]


### PR DESCRIPTION
## Summary
- Continues #955/#959: remove 7 byte-identical Generate-family `SpanCoversColumn` copies in favor of shared `SpanCoverage.SpanCoversColumn`.
- Retargets Generate exclusive-end unit tests to the shared helper.
- Leaves `AddNullChecksOperation` alone (already on shared path / out of this ticket's listed set).
- Unreleased CHANGELOG hygiene line. No behavior change.

Closes #962

## Test plan
- [x] `dotnet test` filter `FullyQualifiedName~SpanCoversColumn` — 40 passed locally
- [ ] CI Build and Test + Code Quality on this PR
- [ ] Copilot/Codex review; squash-merge after threads resolved. Leave Dependabot.