### PR TITLE
refactor: replace Encapsulate/Extract SpanCoversColumn with SpanCoverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- Replaced 4 identical Encapsulate/Extract `SpanCoversColumn` copies with shared `SpanCoverage.SpanCoversColumn` (`encapsulate_field` / `introduce_parameter` / `extract_base_class` / `extract_interface`) (#965)
 - Replaced 7 identical Generate-family `SpanCoversColumn` copies with shared `SpanCoverage.SpanCoversColumn` (`generate_constructor` / `generate_equals_hashcode` / `generate_overrides` / `generate_property` / `generate_tostring` / `implement_abstract` / `implement_interface`) (#962)
 - Replaced 13 identical Convert-family `SpanCoversColumn` copies with shared `SpanCoverage.SpanCoversColumn` (`add_braces` / `remove_braces` / `convert_*` / `invert_if` / `simplify_name`) (#959)
 - Extracted shared `SpanCoverage.SpanCoversColumn` and replaced the five identical Signature-family copies (`add_parameter` / `remove_parameter` / `change_signature` / `change_return_type` / `reorder_parameters`); `TypeSymbolResolver.SpanCoversColumn` delegates to the same helper (#955)

--- a/src/RoslynMcp.Core/Refactoring/Encapsulate/EncapsulateFieldOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Encapsulate/EncapsulateFieldOperation.cs
@@ -8,6 +8,7 @@ using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
 using RoslynMcp.Core.Refactoring.Utilities;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 
 namespace RoslynMcp.Core.Refactoring.Encapsulate;
@@ -746,12 +747,12 @@ public sealed class EncapsulateFieldOperation : RefactoringOperationBase<Encapsu
 
     private static bool FieldCoversColumn(VariableDeclaratorSyntax declarator, int line, int column) =>
         IdentifierCoversColumn(declarator, line, column) ||
-        SpanCoversColumn(declarator.GetLocation().GetLineSpan(), line, column) ||
+        SpanCoverage.SpanCoversColumn(declarator.GetLocation().GetLineSpan(), line, column) ||
         (GetFieldDeclaration(declarator) is { } field &&
-         SpanCoversColumn(field.GetLocation().GetLineSpan(), line, column));
+         SpanCoverage.SpanCoversColumn(field.GetLocation().GetLineSpan(), line, column));
 
     private static bool IdentifierCoversColumn(VariableDeclaratorSyntax declarator, int line, int column) =>
-        SpanCoversColumn(declarator.Identifier.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(declarator.Identifier.GetLocation().GetLineSpan(), line, column);
 
     private static int SmallestCoveringSpanLength(VariableDeclaratorSyntax declarator, int line)
     {
@@ -771,11 +772,11 @@ public sealed class EncapsulateFieldOperation : RefactoringOperationBase<Encapsu
     private static int SmallestCoveringSpanLength(VariableDeclaratorSyntax declarator, int line, int column)
     {
         var smallest = int.MaxValue;
-        if (SpanCoversColumn(declarator.GetLocation().GetLineSpan(), line, column))
+        if (SpanCoverage.SpanCoversColumn(declarator.GetLocation().GetLineSpan(), line, column))
             smallest = Math.Min(smallest, declarator.Span.Length);
 
         if (GetFieldDeclaration(declarator) is { } field &&
-            SpanCoversColumn(field.GetLocation().GetLineSpan(), line, column))
+            SpanCoverage.SpanCoversColumn(field.GetLocation().GetLineSpan(), line, column))
         {
             smallest = Math.Min(smallest, field.Span.Length);
         }
@@ -785,32 +786,6 @@ public sealed class EncapsulateFieldOperation : RefactoringOperationBase<Encapsu
 
     private static FieldDeclarationSyntax? GetFieldDeclaration(VariableDeclaratorSyntax declarator) =>
         declarator.Parent?.Parent as FieldDeclarationSyntax;
-
-    /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character of an adjacent field also
-    /// match the previous declaration. Same helper as
-    /// <c>UseBaseTypeOperation.SpanCoversColumn</c> /
-    /// <c>PushMembersDownOperation.SpanCoversColumn</c> /
-    /// <c>PullMembersUpOperation.SpanCoversColumn</c>.
-    /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
 
     /// <summary>
     /// 1-based line coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>

--- a/src/RoslynMcp.Core/Refactoring/Extract/ExtractBaseClassOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/ExtractBaseClassOperation.cs
@@ -12,6 +12,7 @@ using RoslynMcp.Core.Refactoring.Base;
 using RoslynMcp.Core.Refactoring.Generate;
 using RoslynMcp.Core.Refactoring.Hierarchy;
 using RoslynMcp.Core.Refactoring.Rename;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 
 namespace RoslynMcp.Core.Refactoring.Extract;
@@ -1201,13 +1202,13 @@ public sealed class ExtractBaseClassOperation : RefactoringOperationBase<Extract
 
     private static bool TypeCoversColumn(MemberDeclarationSyntax type, int line, int column) =>
         IdentifierCoversColumn(type, line, column) ||
-        SpanCoversColumn(type.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(type.GetLocation().GetLineSpan(), line, column);
 
     private static bool IdentifierCoversColumn(MemberDeclarationSyntax type, int line, int column)
     {
         var identifier = GetTypeIdentifier(type);
         return identifier != default
-            && SpanCoversColumn(identifier.GetLocation().GetLineSpan(), line, column);
+            && SpanCoverage.SpanCoversColumn(identifier.GetLocation().GetLineSpan(), line, column);
     }
 
     private static SyntaxToken GetTypeIdentifier(MemberDeclarationSyntax type) => type switch
@@ -1216,31 +1217,6 @@ public sealed class ExtractBaseClassOperation : RefactoringOperationBase<Extract
         DelegateDeclarationSyntax del => del.Identifier,
         _ => default
     };
-
-    /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character of an adjacent type also
-    /// match the previous declaration. Same helper as
-    /// <c>ExtractInterfaceOperation.SpanCoversColumn</c> /
-    /// <c>GenerateToStringOperation.SpanCoversColumn</c>.
-    /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
 
     /// <summary>
     /// 1-based line coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>

--- a/src/RoslynMcp.Core/Refactoring/Extract/ExtractInterfaceOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/ExtractInterfaceOperation.cs
@@ -635,13 +635,13 @@ public sealed class ExtractInterfaceOperation : RefactoringOperationBase<Extract
 
     private static bool TypeCoversColumn(MemberDeclarationSyntax type, int line, int column) =>
         IdentifierCoversColumn(type, line, column) ||
-        SpanCoversColumn(type.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(type.GetLocation().GetLineSpan(), line, column);
 
     private static bool IdentifierCoversColumn(MemberDeclarationSyntax type, int line, int column)
     {
         var identifier = GetTypeIdentifier(type);
         return identifier != default
-            && SpanCoversColumn(identifier.GetLocation().GetLineSpan(), line, column);
+            && SpanCoverage.SpanCoversColumn(identifier.GetLocation().GetLineSpan(), line, column);
     }
 
     private static SyntaxToken GetTypeIdentifier(MemberDeclarationSyntax type) => type switch
@@ -650,31 +650,6 @@ public sealed class ExtractInterfaceOperation : RefactoringOperationBase<Extract
         DelegateDeclarationSyntax del => del.Identifier,
         _ => default
     };
-
-    /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character of an adjacent type also
-    /// match the previous declaration. Same helper as
-    /// <c>GenerateToStringOperation.SpanCoversColumn</c> /
-    /// <c>ImplementAbstractOperation.SpanCoversColumn</c>.
-    /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
 
     /// <summary>
     /// 1-based line coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>

--- a/src/RoslynMcp.Core/Refactoring/Extract/IntroduceParameterOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/IntroduceParameterOperation.cs
@@ -7,6 +7,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 
 namespace RoslynMcp.Core.Refactoring.Extract;
@@ -266,21 +267,21 @@ public sealed class IntroduceParameterOperation : RefactoringOperationBase<Intro
 
     private static bool DeclaratorCoversColumn(VariableDeclaratorSyntax declarator, int line, int column) =>
         IdentifierCoversColumn(declarator, line, column) ||
-        SpanCoversColumn(declarator.GetLocation().GetLineSpan(), line, column) ||
+        SpanCoverage.SpanCoversColumn(declarator.GetLocation().GetLineSpan(), line, column) ||
         (GetLocalDeclaration(declarator) is { } local &&
-         SpanCoversColumn(local.GetLocation().GetLineSpan(), line, column));
+         SpanCoverage.SpanCoversColumn(local.GetLocation().GetLineSpan(), line, column));
 
     private static bool IdentifierCoversColumn(VariableDeclaratorSyntax declarator, int line, int column) =>
-        SpanCoversColumn(declarator.Identifier.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(declarator.Identifier.GetLocation().GetLineSpan(), line, column);
 
     private static int SmallestCoveringSpanLength(VariableDeclaratorSyntax declarator, int line, int column)
     {
         var smallest = int.MaxValue;
-        if (SpanCoversColumn(declarator.GetLocation().GetLineSpan(), line, column))
+        if (SpanCoverage.SpanCoversColumn(declarator.GetLocation().GetLineSpan(), line, column))
             smallest = Math.Min(smallest, declarator.Span.Length);
 
         if (GetLocalDeclaration(declarator) is { } local &&
-            SpanCoversColumn(local.GetLocation().GetLineSpan(), line, column))
+            SpanCoverage.SpanCoversColumn(local.GetLocation().GetLineSpan(), line, column))
         {
             smallest = Math.Min(smallest, local.Span.Length);
         }
@@ -291,27 +292,4 @@ public sealed class IntroduceParameterOperation : RefactoringOperationBase<Intro
     private static LocalDeclarationStatementSyntax? GetLocalDeclaration(VariableDeclaratorSyntax declarator) =>
         declarator.Parent?.Parent as LocalDeclarationStatementSyntax;
 
-    /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character of an adjacent declarator also
-    /// match the previous one. Same helper as
-    /// <c>EncapsulateFieldOperation.SpanCoversColumn</c>.
-    /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
 }

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Encapsulate/EncapsulateFieldOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Encapsulate/EncapsulateFieldOperationTests.cs
@@ -6,6 +6,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Encapsulate;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 using Xunit;
 
@@ -1194,10 +1195,10 @@ public class EncapsulateFieldOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(EncapsulateFieldOperation.SpanCoversColumn(span, line, startCol));
-        Assert.True(EncapsulateFieldOperation.SpanCoversColumn(span, line, endCol - 1));
-        Assert.False(EncapsulateFieldOperation.SpanCoversColumn(span, line, endCol));
-        Assert.False(EncapsulateFieldOperation.SpanCoversColumn(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, startCol - 1));
     }
 
     [SkippableFact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Extract/ExtractBaseClassOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Extract/ExtractBaseClassOperationTests.cs
@@ -7,6 +7,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Extract;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 using Xunit;
 
@@ -1087,10 +1088,10 @@ public class ExtractBaseClassOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(ExtractBaseClassOperation.SpanCoversColumn(span, line, startCol));
-        Assert.True(ExtractBaseClassOperation.SpanCoversColumn(span, line, endCol - 1));
-        Assert.False(ExtractBaseClassOperation.SpanCoversColumn(span, line, endCol));
-        Assert.False(ExtractBaseClassOperation.SpanCoversColumn(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, startCol - 1));
     }
 
     [SkippableFact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Extract/ExtractInterfaceOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Extract/ExtractInterfaceOperationTests.cs
@@ -7,6 +7,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Extract;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 using Xunit;
 
@@ -1047,10 +1048,10 @@ public class ExtractInterfaceOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(ExtractInterfaceOperation.SpanCoversColumn(span, line, startCol));
-        Assert.True(ExtractInterfaceOperation.SpanCoversColumn(span, line, endCol - 1));
-        Assert.False(ExtractInterfaceOperation.SpanCoversColumn(span, line, endCol));
-        Assert.False(ExtractInterfaceOperation.SpanCoversColumn(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, startCol - 1));
     }
 
     [SkippableFact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Extract/IntroduceParameterOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Extract/IntroduceParameterOperationTests.cs
@@ -5,6 +5,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Extract;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 using Xunit;
 
@@ -302,9 +303,9 @@ public class IntroduceParameterOperationTests
         var atFirstId = IntroduceParameterOperation.FindLocalDeclarator(
             root, "a", line, ColumnOf(MultiDeclaratorSource, "a = 1"));
 
-        Assert.False(IntroduceParameterOperation.SpanCoversColumn(
+        Assert.False(SpanCoverage.SpanCoversColumn(
             first.GetLocation().GetLineSpan(), line, firstEndCol));
-        Assert.False(IntroduceParameterOperation.SpanCoversColumn(
+        Assert.False(SpanCoverage.SpanCoversColumn(
             first.GetLocation().GetLineSpan(), line, secondId));
         Assert.Null(atBAskingForA);
         Assert.NotNull(atSecondId);
@@ -333,10 +334,10 @@ public class IntroduceParameterOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(IntroduceParameterOperation.SpanCoversColumn(span, line, startCol));
-        Assert.True(IntroduceParameterOperation.SpanCoversColumn(span, line, endCol - 1));
-        Assert.False(IntroduceParameterOperation.SpanCoversColumn(span, line, endCol));
-        Assert.False(IntroduceParameterOperation.SpanCoversColumn(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, startCol - 1));
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- Continues #955/#959/#962: remove 4 byte-identical Encapsulate/Extract `SpanCoversColumn` copies in favor of shared `SpanCoverage.SpanCoversColumn`.
- Retargets Encapsulate/Extract exclusive-end unit tests to the shared helper.
- Leaves Hierarchy / Inline / Rename duplicates for a Separate follow-up.
- Unreleased CHANGELOG hygiene line. No behavior change.

Closes #965

## Test plan
- [x] `dotnet test` filter `FullyQualifiedName~SpanCoversColumn` — 40 passed locally
- [ ] CI Build and Test + Code Quality on this PR
- [ ] Copilot/Codex review; squash-merge after threads resolved (GitHub PM). Leave Dependabot.