### PR TITLE
refactor: replace Hierarchy SpanCoversColumn with SpanCoverage (#967)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- Replaced 3 identical Hierarchy `SpanCoversColumn` copies with shared `SpanCoverage.SpanCoversColumn` (`pull_members_up` / `push_members_down` / `use_base_type`) (#967)
 - Replaced 4 identical Encapsulate/Extract `SpanCoversColumn` copies with shared `SpanCoverage.SpanCoversColumn` (`encapsulate_field` / `introduce_parameter` / `extract_base_class` / `extract_interface`) (#965)
 - Replaced 7 identical Generate-family `SpanCoversColumn` copies with shared `SpanCoverage.SpanCoversColumn` (`generate_constructor` / `generate_equals_hashcode` / `generate_overrides` / `generate_property` / `generate_tostring` / `implement_abstract` / `implement_interface`) (#962)
 - Replaced 13 identical Convert-family `SpanCoversColumn` copies with shared `SpanCoverage.SpanCoversColumn` (`add_braces` / `remove_braces` / `convert_*` / `invert_if` / `simplify_name`) (#959)

--- a/src/RoslynMcp.Core/Refactoring/Hierarchy/PullMembersUpOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Hierarchy/PullMembersUpOperation.cs
@@ -8,6 +8,7 @@ using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
 using RoslynMcp.Core.Refactoring.Generate;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 
 namespace RoslynMcp.Core.Refactoring.Hierarchy;
@@ -213,9 +214,7 @@ public sealed class PullMembersUpOperation : RefactoringOperationBase<PullMember
     /// substituting each candidate's own start line. When column is set
     /// with line, picks the type whose identifier or declaration span
     /// covers that 1-based column (same exclusive-end coverage as
-    /// <c>ExtractInterfaceOperation.SpanCoversColumn</c> /
-    /// <c>ExtractBaseClassOperation.SpanCoversColumn</c> /
-    /// <c>GenerateToStringOperation.SpanCoversColumn</c>). Prefer the
+    /// <c>SpanCoverage.SpanCoversColumn</c>). Prefer the
     /// identifier hit, then the smallest containing type. Nested types,
     /// enums, and <c>DelegateDeclarationSyntax</c> participate when line
     /// is set so a covering enum or delegate still reaches
@@ -325,13 +324,13 @@ public sealed class PullMembersUpOperation : RefactoringOperationBase<PullMember
 
     private static bool TypeCoversColumn(MemberDeclarationSyntax type, int line, int column) =>
         IdentifierCoversColumn(type, line, column) ||
-        SpanCoversColumn(type.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(type.GetLocation().GetLineSpan(), line, column);
 
     private static bool IdentifierCoversColumn(MemberDeclarationSyntax type, int line, int column)
     {
         var identifier = GetTypeIdentifier(type);
         return identifier != default
-            && SpanCoversColumn(identifier.GetLocation().GetLineSpan(), line, column);
+            && SpanCoverage.SpanCoversColumn(identifier.GetLocation().GetLineSpan(), line, column);
     }
 
     private static SyntaxToken GetTypeIdentifier(MemberDeclarationSyntax type) => type switch
@@ -341,31 +340,6 @@ public sealed class PullMembersUpOperation : RefactoringOperationBase<PullMember
         _ => default
     };
 
-    /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character of an adjacent type also
-    /// match the previous declaration. Same helper as
-    /// <c>ExtractInterfaceOperation.SpanCoversColumn</c> /
-    /// <c>ExtractBaseClassOperation.SpanCoversColumn</c> /
-    /// <c>GenerateToStringOperation.SpanCoversColumn</c>.
-    /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
 
     /// <summary>
     /// 1-based line coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>

--- a/src/RoslynMcp.Core/Refactoring/Hierarchy/PushMembersDownOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Hierarchy/PushMembersDownOperation.cs
@@ -9,6 +9,7 @@ using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
 using RoslynMcp.Core.Refactoring.Generate;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 
 namespace RoslynMcp.Core.Refactoring.Hierarchy;
@@ -235,10 +236,7 @@ public sealed class PushMembersDownOperation : RefactoringOperationBase<PushMemb
     /// substituting each candidate's own start line. When column is set
     /// with line, picks the type whose identifier or declaration span
     /// covers that 1-based column (same exclusive-end coverage as
-    /// <c>ExtractInterfaceOperation.SpanCoversColumn</c> /
-    /// <c>ExtractBaseClassOperation.SpanCoversColumn</c> /
-    /// <c>GenerateToStringOperation.SpanCoversColumn</c> /
-    /// <c>PullMembersUpOperation.SpanCoversColumn</c>). Prefer the
+    /// <c>SpanCoverage.SpanCoversColumn</c>). Prefer the
     /// identifier hit, then the smallest containing type. Nested types,
     /// enums, and <c>DelegateDeclarationSyntax</c> participate when line
     /// is set so a covering enum or delegate still reaches
@@ -348,13 +346,13 @@ public sealed class PushMembersDownOperation : RefactoringOperationBase<PushMemb
 
     private static bool TypeCoversColumn(MemberDeclarationSyntax type, int line, int column) =>
         IdentifierCoversColumn(type, line, column) ||
-        SpanCoversColumn(type.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(type.GetLocation().GetLineSpan(), line, column);
 
     private static bool IdentifierCoversColumn(MemberDeclarationSyntax type, int line, int column)
     {
         var identifier = GetTypeIdentifier(type);
         return identifier != default
-            && SpanCoversColumn(identifier.GetLocation().GetLineSpan(), line, column);
+            && SpanCoverage.SpanCoversColumn(identifier.GetLocation().GetLineSpan(), line, column);
     }
 
     private static SyntaxToken GetTypeIdentifier(MemberDeclarationSyntax type) => type switch
@@ -364,32 +362,6 @@ public sealed class PushMembersDownOperation : RefactoringOperationBase<PushMemb
         _ => default
     };
 
-    /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character of an adjacent type also
-    /// match the previous declaration. Same helper as
-    /// <c>ExtractInterfaceOperation.SpanCoversColumn</c> /
-    /// <c>ExtractBaseClassOperation.SpanCoversColumn</c> /
-    /// <c>GenerateToStringOperation.SpanCoversColumn</c> /
-    /// <c>PullMembersUpOperation.SpanCoversColumn</c>.
-    /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
 
     /// <summary>
     /// 1-based line coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>

--- a/src/RoslynMcp.Core/Refactoring/Hierarchy/UseBaseTypeOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Hierarchy/UseBaseTypeOperation.cs
@@ -8,6 +8,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 
 namespace RoslynMcp.Core.Refactoring.Hierarchy;
@@ -513,8 +514,7 @@ public sealed class UseBaseTypeOperation : RefactoringOperationBase<UseBaseTypeP
     /// candidate's own start line. When column is set with line, picks
     /// the type whose identifier or declaration span covers that 1-based
     /// column (same exclusive-end coverage as
-    /// <c>PushMembersDownOperation.SpanCoversColumn</c> /
-    /// <c>PullMembersUpOperation.SpanCoversColumn</c>). Prefer the
+    /// <c>SpanCoverage.SpanCoversColumn</c>). Prefer the
     /// identifier hit, then the smallest containing type. Nested types,
     /// enums, and <c>DelegateDeclarationSyntax</c> participate when line
     /// is set so a covering enum or delegate still reaches
@@ -651,13 +651,13 @@ public sealed class UseBaseTypeOperation : RefactoringOperationBase<UseBaseTypeP
 
     private static bool TypeCoversColumn(MemberDeclarationSyntax type, int line, int column) =>
         IdentifierCoversColumn(type, line, column) ||
-        SpanCoversColumn(type.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(type.GetLocation().GetLineSpan(), line, column);
 
     private static bool IdentifierCoversColumn(MemberDeclarationSyntax type, int line, int column)
     {
         var identifier = GetTypeIdentifier(type);
         return identifier != default
-            && SpanCoversColumn(identifier.GetLocation().GetLineSpan(), line, column);
+            && SpanCoverage.SpanCoversColumn(identifier.GetLocation().GetLineSpan(), line, column);
     }
 
     private static SyntaxToken GetTypeIdentifier(MemberDeclarationSyntax type) => type switch
@@ -667,31 +667,6 @@ public sealed class UseBaseTypeOperation : RefactoringOperationBase<UseBaseTypeP
         _ => default
     };
 
-    /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character of an adjacent type also
-    /// match the previous declaration. Same helper as
-    /// <c>PushMembersDownOperation.SpanCoversColumn</c> /
-    /// <c>PullMembersUpOperation.SpanCoversColumn</c> /
-    /// <c>ExtractBaseClassOperation.SpanCoversColumn</c>.
-    /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
 
     /// <summary>
     /// 1-based line coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Hierarchy/PullMembersUpOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Hierarchy/PullMembersUpOperationTests.cs
@@ -6,6 +6,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Hierarchy;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 using Xunit;
 
@@ -1145,10 +1146,10 @@ public class PullMembersUpOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(PullMembersUpOperation.SpanCoversColumn(span, line, startCol));
-        Assert.True(PullMembersUpOperation.SpanCoversColumn(span, line, endCol - 1));
-        Assert.False(PullMembersUpOperation.SpanCoversColumn(span, line, endCol));
-        Assert.False(PullMembersUpOperation.SpanCoversColumn(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, startCol - 1));
     }
 
     [SkippableFact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Hierarchy/PushMembersDownOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Hierarchy/PushMembersDownOperationTests.cs
@@ -6,6 +6,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Hierarchy;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 using Xunit;
 
@@ -1182,10 +1183,10 @@ public class PushMembersDownOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(PushMembersDownOperation.SpanCoversColumn(span, line, startCol));
-        Assert.True(PushMembersDownOperation.SpanCoversColumn(span, line, endCol - 1));
-        Assert.False(PushMembersDownOperation.SpanCoversColumn(span, line, endCol));
-        Assert.False(PushMembersDownOperation.SpanCoversColumn(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, startCol - 1));
     }
 
     [SkippableFact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Hierarchy/UseBaseTypeOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Hierarchy/UseBaseTypeOperationTests.cs
@@ -6,6 +6,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Hierarchy;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 using Xunit;
 
@@ -1306,10 +1307,10 @@ public class UseBaseTypeOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(UseBaseTypeOperation.SpanCoversColumn(span, line, startCol));
-        Assert.True(UseBaseTypeOperation.SpanCoversColumn(span, line, endCol - 1));
-        Assert.False(UseBaseTypeOperation.SpanCoversColumn(span, line, endCol));
-        Assert.False(UseBaseTypeOperation.SpanCoversColumn(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, startCol - 1));
     }
 
     [SkippableFact]


### PR DESCRIPTION
## Summary
- Delete the three identical Hierarchy `SpanCoversColumn` helpers (`PullMembersUp` / `PushMembersDown` / `UseBaseType`) and call shared `SpanCoverage.SpanCoversColumn`.
- Retarget exclusive-end unit tests; refresh FindTypeDeclaration XML docs that named deleted Extract/Generate helpers.
- CHANGELOG Unreleased one-liner. Behavior-preserving only.

Closes #967

## Test plan
- [x] Local `SpanCoversColumn_TreatsEndAsExclusive` — 40 passed
- [x] Local Hierarchy PullMembersUp / PushMembersDown / UseBaseType suites — 356 passed
- [ ] CI green on this PR