### PR TITLE
refactor: replace Inline SpanCoversColumn with SpanCoverage (#970)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- Replaced 3 identical Inline `SpanCoversColumn` copies with shared `SpanCoverage.SpanCoversColumn` (`inline_method` / `inline_constant` / `inline_variable`) (#970)
 - Replaced 3 identical Hierarchy `SpanCoversColumn` copies with shared `SpanCoverage.SpanCoversColumn` (`pull_members_up` / `push_members_down` / `use_base_type`) (#967)
 - Replaced 4 identical Encapsulate/Extract `SpanCoversColumn` copies with shared `SpanCoverage.SpanCoversColumn` (`encapsulate_field` / `introduce_parameter` / `extract_base_class` / `extract_interface`) (#965)
 - Replaced 7 identical Generate-family `SpanCoversColumn` copies with shared `SpanCoverage.SpanCoversColumn` (`generate_constructor` / `generate_equals_hashcode` / `generate_overrides` / `generate_property` / `generate_tostring` / `implement_abstract` / `implement_interface`) (#962)

--- a/src/RoslynMcp.Core/Refactoring/Inline/InlineConstantOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Inline/InlineConstantOperation.cs
@@ -497,7 +497,7 @@ public sealed class InlineConstantOperation : RefactoringOperationBase<InlineCon
     /// declarator/field — same exclusive-end coverage as
     /// <c>EncapsulateFieldOperation.FindFieldDeclarator</c> /
     /// <see cref="SpanCoversLine"/>). When column is set with line, same
-    /// covering-span rules as encapsulate_field (<see cref="SpanCoversColumn"/>,
+    /// covering-span rules as encapsulate_field (<c>SpanCoverage.SpanCoversColumn</c>,
     /// exclusive end). Nested types participate. Do not require the
     /// declaration to start on line — a split declaration may put the
     /// identifier on a continuation line. If line is set (with or without
@@ -610,12 +610,12 @@ public sealed class InlineConstantOperation : RefactoringOperationBase<InlineCon
 
     private static bool FieldCoversColumn(VariableDeclaratorSyntax declarator, int line, int column) =>
         IdentifierCoversColumn(declarator, line, column) ||
-        SpanCoversColumn(declarator.GetLocation().GetLineSpan(), line, column) ||
+        SpanCoverage.SpanCoversColumn(declarator.GetLocation().GetLineSpan(), line, column) ||
         (GetFieldDeclaration(declarator) is { } field &&
-         SpanCoversColumn(field.GetLocation().GetLineSpan(), line, column));
+         SpanCoverage.SpanCoversColumn(field.GetLocation().GetLineSpan(), line, column));
 
     private static bool IdentifierCoversColumn(VariableDeclaratorSyntax declarator, int line, int column) =>
-        SpanCoversColumn(declarator.Identifier.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(declarator.Identifier.GetLocation().GetLineSpan(), line, column);
 
     private static int SmallestCoveringSpanLength(VariableDeclaratorSyntax declarator, int line)
     {
@@ -635,11 +635,11 @@ public sealed class InlineConstantOperation : RefactoringOperationBase<InlineCon
     private static int SmallestCoveringSpanLength(VariableDeclaratorSyntax declarator, int line, int column)
     {
         var smallest = int.MaxValue;
-        if (SpanCoversColumn(declarator.GetLocation().GetLineSpan(), line, column))
+        if (SpanCoverage.SpanCoversColumn(declarator.GetLocation().GetLineSpan(), line, column))
             smallest = Math.Min(smallest, declarator.Span.Length);
 
         if (GetFieldDeclaration(declarator) is { } field &&
-            SpanCoversColumn(field.GetLocation().GetLineSpan(), line, column))
+            SpanCoverage.SpanCoversColumn(field.GetLocation().GetLineSpan(), line, column))
         {
             smallest = Math.Min(smallest, field.Span.Length);
         }
@@ -650,29 +650,6 @@ public sealed class InlineConstantOperation : RefactoringOperationBase<InlineCon
     private static FieldDeclarationSyntax? GetFieldDeclaration(VariableDeclaratorSyntax declarator) =>
         declarator.Parent?.Parent as FieldDeclarationSyntax;
 
-    /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character of an adjacent field also
-    /// match the previous declaration. Same helper as
-    /// <c>EncapsulateFieldOperation.SpanCoversColumn</c>.
-    /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
 
     /// <summary>
     /// 1-based line coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>

--- a/src/RoslynMcp.Core/Refactoring/Inline/InlineMethodOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Inline/InlineMethodOperation.cs
@@ -291,34 +291,11 @@ public sealed class InlineMethodOperation : RefactoringOperationBase<InlineMetho
 
     private static bool MethodCoversColumn(MethodDeclarationSyntax method, int line, int column) =>
         IdentifierCoversColumn(method, line, column) ||
-        SpanCoversColumn(method.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(method.GetLocation().GetLineSpan(), line, column);
 
     private static bool IdentifierCoversColumn(MethodDeclarationSyntax method, int line, int column) =>
-        SpanCoversColumn(method.Identifier.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(method.Identifier.GetLocation().GetLineSpan(), line, column);
 
-    /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character of an adjacent method also
-    /// match the previous declaration. Same helper as
-    /// <c>SpanCoverage.SpanCoversColumn</c>.
-    /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
 
     private static void ValidateInlineable(
         MethodDeclarationSyntax methodSyntax,
@@ -544,7 +521,7 @@ public sealed class InlineMethodOperation : RefactoringOperationBase<InlineMetho
             return false;
 
         var span = invocation.GetLocation().GetLineSpan();
-        return SpanCoversColumn(span, location.Line, location.Column);
+        return SpanCoverage.SpanCoversColumn(span, location.Line, location.Column);
     }
 
     private static async Task ValidateCallSitesAsync(

--- a/src/RoslynMcp.Core/Refactoring/Inline/InlineVariableOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Inline/InlineVariableOperation.cs
@@ -324,38 +324,16 @@ public sealed class InlineVariableOperation : RefactoringOperationBase<InlineVar
 
     private static bool DeclaratorCoversColumn(VariableDeclaratorSyntax declarator, int line, int column) =>
         IdentifierCoversColumn(declarator, line, column) ||
-        SpanCoversColumn(DeclarationSpan(declarator), line, column);
+        SpanCoverage.SpanCoversColumn(DeclarationSpan(declarator), line, column);
 
     private static bool IdentifierCoversColumn(VariableDeclaratorSyntax declarator, int line, int column) =>
-        SpanCoversColumn(declarator.Identifier.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(declarator.Identifier.GetLocation().GetLineSpan(), line, column);
 
     private static FileLinePositionSpan DeclarationSpan(VariableDeclaratorSyntax declarator) =>
         declarator.Parent is VariableDeclarationSyntax declaration
             ? declaration.GetLocation().GetLineSpan()
             : declarator.GetLocation().GetLineSpan();
 
-    /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character of an adjacent declaration also
-    /// match the previous one.
-    /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
 
     private sealed class InlineRewriter : CSharpSyntaxRewriter
     {

--- a/src/RoslynMcp.Core/Refactoring/Rename/RenameFileToMatchTypeOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Rename/RenameFileToMatchTypeOperation.cs
@@ -744,7 +744,7 @@ public sealed class RenameFileToMatchTypeOperation : RefactoringOperationBase<Re
     /// match the previous declaration. Same helper as
     /// <c>TypeSymbolResolver.SpanCoversColumn</c> /
     /// <c>RenameNamespaceOperation.SpanCoversColumn</c> /
-    /// <c>InlineMethodOperation.SpanCoversColumn</c>.
+    /// <c>SpanCoverage.SpanCoversColumn</c>.
     /// </summary>
     internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
     {

--- a/src/RoslynMcp.Core/Refactoring/Rename/RenameNamespaceOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Rename/RenameNamespaceOperation.cs
@@ -575,8 +575,7 @@ public sealed class RenameNamespaceOperation : RefactoringOperationBase<RenameNa
     /// inclusive would let the first character of an adjacent namespace also
     /// match the previous declaration. Same helper as
     /// <c>SpanCoverage.SpanCoversColumn</c> /
-    /// <c>TypeSymbolResolver.SpanCoversColumn</c> /
-    /// <c>InlineMethodOperation.SpanCoversColumn</c>.
+    /// <c>TypeSymbolResolver.SpanCoversColumn</c>.
     /// </summary>
     internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
     {

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Inline/InlineConstantOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Inline/InlineConstantOperationTests.cs
@@ -6,6 +6,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Inline;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 using Xunit;
 
@@ -1539,10 +1540,10 @@ public class InlineConstantOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(InlineConstantOperation.SpanCoversColumn(span, line, startCol));
-        Assert.True(InlineConstantOperation.SpanCoversColumn(span, line, endCol - 1));
-        Assert.False(InlineConstantOperation.SpanCoversColumn(span, line, endCol));
-        Assert.False(InlineConstantOperation.SpanCoversColumn(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, startCol - 1));
     }
 
     #endregion

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Inline/InlineMethodOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Inline/InlineMethodOperationTests.cs
@@ -5,6 +5,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Inline;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 using Xunit;
 
@@ -900,10 +901,10 @@ public class InlineMethodOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(InlineMethodOperation.SpanCoversColumn(span, line, startCol));
-        Assert.True(InlineMethodOperation.SpanCoversColumn(span, line, endCol - 1));
-        Assert.False(InlineMethodOperation.SpanCoversColumn(span, line, endCol));
-        Assert.False(InlineMethodOperation.SpanCoversColumn(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, startCol - 1));
     }
 
     [Fact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Inline/InlineVariableOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Inline/InlineVariableOperationTests.cs
@@ -5,6 +5,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Inline;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 using Xunit;
 
@@ -393,7 +394,7 @@ public class InlineVariableOperationTests
         var atFirstId = InlineVariableOperation.FindDeclarator(
             root, "value", line, ColumnOf(SameLineLocalsSource, "value = 1"));
 
-        Assert.False(InlineVariableOperation.SpanCoversColumn(
+        Assert.False(SpanCoverage.SpanCoversColumn(
             firstDecl.GetLocation().GetLineSpan(), line, firstEndCol));
         Assert.True(atExclusiveEnd == null || atExclusiveEnd.Initializer!.Value.ToString() != "1");
         Assert.NotNull(atSecondId);
@@ -413,10 +414,10 @@ public class InlineVariableOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(InlineVariableOperation.SpanCoversColumn(span, line, startCol));
-        Assert.True(InlineVariableOperation.SpanCoversColumn(span, line, endCol - 1));
-        Assert.False(InlineVariableOperation.SpanCoversColumn(span, line, endCol));
-        Assert.False(InlineVariableOperation.SpanCoversColumn(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, startCol - 1));
     }
 
     [SkippableFact]


### PR DESCRIPTION
## Summary
- Delete the three identical Inline `SpanCoversColumn` helpers (`InlineMethod` / `InlineConstant` / `InlineVariable`) and call shared `SpanCoverage.SpanCoversColumn`.
- Retarget exclusive-end unit tests; refresh FindConstantDeclarator XML doc that named the deleted type-local helper / EncapsulateField `SpanCoversColumn`.
- CHANGELOG Unreleased one-liner. Behavior-preserving only. Leave Rename / SpanCoversLine / AddNullChecks alone.

Closes #970

## Test plan
- [x] Local `SpanCoversColumn_TreatsEndAsExclusive` (+ related exclusive-end) — 36 passed
- [x] Local Inline suite (`Refactoring.Inline`) — 138 passed
- [ ] CI green on this PR