### PR TITLE
refactor: replace Rename SpanCoversColumn with SpanCoverage (#973)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- Replaced 2 identical Rename `SpanCoversColumn` copies with shared `SpanCoverage.SpanCoversColumn` (`rename_namespace` / `rename_file_to_match_type`) (#973)
 - Replaced 3 identical Inline `SpanCoversColumn` copies with shared `SpanCoverage.SpanCoversColumn` (`inline_method` / `inline_constant` / `inline_variable`) (#970)
 - Replaced 3 identical Hierarchy `SpanCoversColumn` copies with shared `SpanCoverage.SpanCoversColumn` (`pull_members_up` / `push_members_down` / `use_base_type`) (#967)
 - Replaced 4 identical Encapsulate/Extract `SpanCoversColumn` copies with shared `SpanCoverage.SpanCoversColumn` (`encapsulate_field` / `introduce_parameter` / `extract_base_class` / `extract_interface`) (#965)

--- a/src/RoslynMcp.Core/Refactoring/Rename/RenameFileToMatchTypeOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Rename/RenameFileToMatchTypeOperation.cs
@@ -6,6 +6,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 
 namespace RoslynMcp.Core.Refactoring.Rename;
@@ -467,7 +468,7 @@ public sealed class RenameFileToMatchTypeOperation : RefactoringOperationBase<Re
                     .Select(t => (
                         Target: t,
                         IdentifierHit: IdentifierCoversColumn(t.Node, @params.Line.Value, @params.Column.Value),
-                        DeclarationHit: SpanCoversColumn(
+                        DeclarationHit: SpanCoverage.SpanCoversColumn(
                             t.Node.GetLocation().GetLineSpan(), @params.Line.Value, @params.Column.Value)))
                     .Where(t => t.IdentifierHit || t.DeclarationHit)
                     .OrderBy(t => t.IdentifierHit ? 0 : 1)
@@ -733,40 +734,15 @@ public sealed class RenameFileToMatchTypeOperation : RefactoringOperationBase<Re
         if (!column.HasValue)
             return true;
 
-        return SpanCoversColumn(span, line, column.Value);
+        return SpanCoverage.SpanCoversColumn(span, line, column.Value);
     }
 
-    /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character of an adjacent type also
-    /// match the previous declaration. Same helper as
-    /// <c>TypeSymbolResolver.SpanCoversColumn</c> /
-    /// <c>RenameNamespaceOperation.SpanCoversColumn</c> /
-    /// <c>SpanCoverage.SpanCoversColumn</c>.
-    /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
 
     private static bool IdentifierCoversColumn(SyntaxNode node, int line, int column)
     {
         var identifier = GetTypeIdentifier(node);
         return identifier != default
-               && SpanCoversColumn(identifier.GetLocation().GetLineSpan(), line, column);
+               && SpanCoverage.SpanCoversColumn(identifier.GetLocation().GetLineSpan(), line, column);
     }
 
     internal static SyntaxToken GetTypeIdentifier(SyntaxNode node) => node switch

--- a/src/RoslynMcp.Core/Refactoring/Rename/RenameNamespaceOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Rename/RenameNamespaceOperation.cs
@@ -10,6 +10,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 
 namespace RoslynMcp.Core.Refactoring.Rename;
@@ -294,7 +295,7 @@ public sealed class RenameNamespaceOperation : RefactoringOperationBase<RenameNa
                         m.Declared,
                         m.Declaration,
                         NameHit: NameCoversColumn(m.Symbol, m.Declared, m.Declaration, line.Value, column.Value),
-                        DeclarationHit: SpanCoversColumn(
+                        DeclarationHit: SpanCoverage.SpanCoversColumn(
                             m.Declaration.GetLocation().GetLineSpan(), line.Value, column.Value)))
                     .Where(m => m.NameHit || m.DeclarationHit)
                     .OrderBy(m => m.NameHit ? 0 : 1)
@@ -493,7 +494,7 @@ public sealed class RenameNamespaceOperation : RefactoringOperationBase<RenameNa
         if (!column.HasValue)
             return true;
 
-        return SpanCoversColumn(span, line, column.Value);
+        return SpanCoverage.SpanCoversColumn(span, line, column.Value);
     }
 
     /// <summary>
@@ -512,7 +513,7 @@ public sealed class RenameNamespaceOperation : RefactoringOperationBase<RenameNa
     {
         var token = FindNameToken(candidate, declared, declaration);
         return token.HasValue
-               && SpanCoversColumn(token.Value.GetLocation().GetLineSpan(), line, column);
+               && SpanCoverage.SpanCoversColumn(token.Value.GetLocation().GetLineSpan(), line, column);
     }
 
     private static SyntaxToken? FindNameToken(
@@ -568,30 +569,6 @@ public sealed class RenameNamespaceOperation : RefactoringOperationBase<RenameNa
         }
     }
 
-    /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character of an adjacent namespace also
-    /// match the previous declaration. Same helper as
-    /// <c>SpanCoverage.SpanCoversColumn</c> /
-    /// <c>TypeSymbolResolver.SpanCoversColumn</c>.
-    /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
 
     private static IEnumerable<INamespaceSymbol> EnumerateNamespaceChain(INamespaceSymbol symbol)
     {

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Rename/RenameFileToMatchTypeOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Rename/RenameFileToMatchTypeOperationTests.cs
@@ -7,8 +7,8 @@ using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Rename;
-using RoslynMcp.Core.Workspace;
 using RoslynMcp.Core.Resolution;
+using RoslynMcp.Core.Workspace;
 using Xunit;
 
 namespace RoslynMcp.Core.Tests.Refactoring.Rename;

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Rename/RenameFileToMatchTypeOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Rename/RenameFileToMatchTypeOperationTests.cs
@@ -8,6 +8,7 @@ using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Rename;
 using RoslynMcp.Core.Workspace;
+using RoslynMcp.Core.Resolution;
 using Xunit;
 
 namespace RoslynMcp.Core.Tests.Refactoring.Rename;
@@ -449,10 +450,10 @@ public class RenameFileToMatchTypeOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(RenameFileToMatchTypeOperation.SpanCoversColumn(span, line, startCol));
-        Assert.True(RenameFileToMatchTypeOperation.SpanCoversColumn(span, line, endCol - 1));
-        Assert.False(RenameFileToMatchTypeOperation.SpanCoversColumn(span, line, endCol));
-        Assert.False(RenameFileToMatchTypeOperation.SpanCoversColumn(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, startCol - 1));
     }
 
     [SkippableFact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Rename/RenameNamespaceOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Rename/RenameNamespaceOperationTests.cs
@@ -8,6 +8,7 @@ using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Rename;
 using RoslynMcp.Core.Workspace;
+using RoslynMcp.Core.Resolution;
 using Xunit;
 
 namespace RoslynMcp.Core.Tests.Refactoring.Rename;
@@ -1405,10 +1406,10 @@ public class RenameNamespaceOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(RenameNamespaceOperation.SpanCoversColumn(span, line, startCol));
-        Assert.True(RenameNamespaceOperation.SpanCoversColumn(span, line, endCol - 1));
-        Assert.False(RenameNamespaceOperation.SpanCoversColumn(span, line, endCol));
-        Assert.False(RenameNamespaceOperation.SpanCoversColumn(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, startCol - 1));
     }
 
     [Fact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Rename/RenameNamespaceOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Rename/RenameNamespaceOperationTests.cs
@@ -7,8 +7,8 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Rename;
-using RoslynMcp.Core.Workspace;
 using RoslynMcp.Core.Resolution;
+using RoslynMcp.Core.Workspace;
 using Xunit;
 
 namespace RoslynMcp.Core.Tests.Refactoring.Rename;


### PR DESCRIPTION
## Summary
- Delete the two identical Rename `SpanCoversColumn` helpers (`RenameNamespace` / `RenameFileToMatchType`) and call shared `SpanCoverage.SpanCoversColumn`.
- Retarget exclusive-end unit tests; refresh XML peers that named the deleted helpers.
- CHANGELOG Unreleased one-liner. Behavior-preserving only. Leave AddNullChecks / SpanCoversLine alone.

Closes #973

## Test plan
- [x] Local Rename suite filter — 181 passed
- [x] Local `SpanCoversColumn_TreatsEndAsExclusive` retargeted
- [ ] CI green on this PR