### PR TITLE
refactor: extract SpanCoversLine; replace Generate duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- Extracted shared `SpanCoverage.SpanCoversLine` and replaced 7 identical Generate-family copies (`generate_constructor` / `generate_equals_hashcode` / `generate_overrides` / `generate_property` / `generate_tostring` / `implement_abstract` / `implement_interface`) (#975)
 - Replaced 2 identical Rename `SpanCoversColumn` copies with shared `SpanCoverage.SpanCoversColumn` (`rename_namespace` / `rename_file_to_match_type`) (#973)
 - Replaced 3 identical Inline `SpanCoversColumn` copies with shared `SpanCoverage.SpanCoversColumn` (`inline_method` / `inline_constant` / `inline_variable`) (#970)
 - Replaced 3 identical Hierarchy `SpanCoversColumn` copies with shared `SpanCoverage.SpanCoversColumn` (`pull_members_up` / `push_members_down` / `use_base_type`) (#967)

--- a/src/RoslynMcp.Core/Refactoring/Extract/ExtractInterfaceOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/ExtractInterfaceOperation.cs
@@ -656,7 +656,7 @@ public sealed class ExtractInterfaceOperation : RefactoringOperationBase<Extract
     /// is exclusive, so a span that ends at the start of a line does not
     /// cover that line. Treating the end as inclusive would let the first
     /// line of an adjacent type also match the previous declaration. Same
-    /// exclusive-end idea as <c>GenerateToStringOperation.SpanCoversLine</c>.
+    /// exclusive-end idea as <c>SpanCoverage.SpanCoversLine</c>.
     /// </summary>
     internal static bool SpanCoversLine(FileLinePositionSpan span, int line)
     {

--- a/src/RoslynMcp.Core/Refactoring/Generate/GenerateConstructorOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GenerateConstructorOperation.cs
@@ -1230,7 +1230,7 @@ public sealed class GenerateConstructorOperation : RefactoringOperationBase<Gene
     /// <paramref name="column"/> keeps today's typeName + optional
     /// <paramref name="line"/> pick, including omitted-line
     /// <c>FirstOrDefault</c> and line-only exclusive-end coverage
-    /// (<see cref="SpanCoversLine"/>). Do not force column 1 when omitted.
+    /// (<see cref="SpanCoverage.SpanCoversLine"/>). Do not force column 1 when omitted.
     /// Column without line keeps today's first-match after the typeName
     /// filter rather than substituting each candidate's own start line.
     /// When column is set with line, picks the type whose identifier or
@@ -1305,10 +1305,10 @@ public sealed class GenerateConstructorOperation : RefactoringOperationBase<Gene
 
     private static bool TypeCoversLine(TypeDeclarationSyntax type, int line) =>
         IdentifierCoversLine(type, line) ||
-        SpanCoversLine(type.GetLocation().GetLineSpan(), line);
+        SpanCoverage.SpanCoversLine(type.GetLocation().GetLineSpan(), line);
 
     private static bool IdentifierCoversLine(TypeDeclarationSyntax type, int line) =>
-        SpanCoversLine(type.Identifier.GetLocation().GetLineSpan(), line);
+        SpanCoverage.SpanCoversLine(type.Identifier.GetLocation().GetLineSpan(), line);
 
     private static bool TypeCoversColumn(TypeDeclarationSyntax type, int line, int column) =>
         IdentifierCoversColumn(type, line, column) ||
@@ -1316,26 +1316,6 @@ public sealed class GenerateConstructorOperation : RefactoringOperationBase<Gene
 
     private static bool IdentifierCoversColumn(TypeDeclarationSyntax type, int line, int column) =>
         SpanCoverage.SpanCoversColumn(type.Identifier.GetLocation().GetLineSpan(), line, column);
-
-
-    /// <summary>
-    /// 1-based line coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so a span that ends at the start of a line does not
-    /// cover that line. Treating the end as inclusive would let the first
-    /// line of an adjacent type also match the previous declaration. Same
-    /// exclusive-end idea as <c>GenerateEqualsHashCodeOperation.SpanCoversLine</c>.
-    /// </summary>
-    internal static bool SpanCoversLine(FileLinePositionSpan span, int line)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == endLine && span.EndLinePosition.Character == 0)
-            return false;
-        return true;
-    }
 
     private static ITypeSymbol GetMemberType(ISymbol member)
     {

--- a/src/RoslynMcp.Core/Refactoring/Generate/GenerateEqualsHashCodeOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GenerateEqualsHashCodeOperation.cs
@@ -929,7 +929,7 @@ public sealed class GenerateEqualsHashCodeOperation : RefactoringOperationBase<G
     /// <paramref name="column"/> keeps today's typeName + optional
     /// <paramref name="line"/> pick, including omitted-line
     /// <c>FirstOrDefault</c> and line-only exclusive-end coverage
-    /// (<see cref="SpanCoversLine"/>). Do not force column 1 when omitted.
+    /// (<see cref="SpanCoverage.SpanCoversLine"/>). Do not force column 1 when omitted.
     /// Column without line keeps today's first-match after the typeName
     /// filter rather than substituting each candidate's own start line.
     /// When column is set with line, picks the type whose identifier or
@@ -1003,10 +1003,10 @@ public sealed class GenerateEqualsHashCodeOperation : RefactoringOperationBase<G
 
     private static bool TypeCoversLine(TypeDeclarationSyntax type, int line) =>
         IdentifierCoversLine(type, line) ||
-        SpanCoversLine(type.GetLocation().GetLineSpan(), line);
+        SpanCoverage.SpanCoversLine(type.GetLocation().GetLineSpan(), line);
 
     private static bool IdentifierCoversLine(TypeDeclarationSyntax type, int line) =>
-        SpanCoversLine(type.Identifier.GetLocation().GetLineSpan(), line);
+        SpanCoverage.SpanCoversLine(type.Identifier.GetLocation().GetLineSpan(), line);
 
     private static bool TypeCoversColumn(TypeDeclarationSyntax type, int line, int column) =>
         IdentifierCoversColumn(type, line, column) ||
@@ -1014,26 +1014,6 @@ public sealed class GenerateEqualsHashCodeOperation : RefactoringOperationBase<G
 
     private static bool IdentifierCoversColumn(TypeDeclarationSyntax type, int line, int column) =>
         SpanCoverage.SpanCoversColumn(type.Identifier.GetLocation().GetLineSpan(), line, column);
-
-
-    /// <summary>
-    /// 1-based line coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so a span that ends at the start of a line does not
-    /// cover that line. Treating the end as inclusive would let the first
-    /// line of an adjacent type also match the previous declaration. Same
-    /// exclusive-end idea as <c>GenerateOverridesOperation.SpanCoversLine</c>.
-    /// </summary>
-    internal static bool SpanCoversLine(FileLinePositionSpan span, int line)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == endLine && span.EndLinePosition.Character == 0)
-            return false;
-        return true;
-    }
 
     private static TypeDeclarationSyntax StripIEquatableInterface(
         TypeDeclarationSyntax original,

--- a/src/RoslynMcp.Core/Refactoring/Generate/GenerateOverridesOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GenerateOverridesOperation.cs
@@ -1212,7 +1212,7 @@ public sealed class GenerateOverridesOperation : RefactoringOperationBase<Genera
     /// <paramref name="column"/> keeps today's typeName + optional
     /// <paramref name="line"/> pick, including omitted-line
     /// <c>FirstOrDefault</c> and line-only exclusive-end coverage
-    /// (<see cref="SpanCoversLine"/>). Do not force column 1 when omitted.
+    /// (<see cref="SpanCoverage.SpanCoversLine"/>). Do not force column 1 when omitted.
     /// Column without line keeps today's first-match after the typeName
     /// filter rather than substituting each candidate's own start line.
     /// When column is set with line, picks the type whose identifier or
@@ -1286,10 +1286,10 @@ public sealed class GenerateOverridesOperation : RefactoringOperationBase<Genera
 
     private static bool TypeCoversLine(TypeDeclarationSyntax type, int line) =>
         IdentifierCoversLine(type, line) ||
-        SpanCoversLine(type.GetLocation().GetLineSpan(), line);
+        SpanCoverage.SpanCoversLine(type.GetLocation().GetLineSpan(), line);
 
     private static bool IdentifierCoversLine(TypeDeclarationSyntax type, int line) =>
-        SpanCoversLine(type.Identifier.GetLocation().GetLineSpan(), line);
+        SpanCoverage.SpanCoversLine(type.Identifier.GetLocation().GetLineSpan(), line);
 
     private static bool TypeCoversColumn(TypeDeclarationSyntax type, int line, int column) =>
         IdentifierCoversColumn(type, line, column) ||
@@ -1297,26 +1297,6 @@ public sealed class GenerateOverridesOperation : RefactoringOperationBase<Genera
 
     private static bool IdentifierCoversColumn(TypeDeclarationSyntax type, int line, int column) =>
         SpanCoverage.SpanCoversColumn(type.Identifier.GetLocation().GetLineSpan(), line, column);
-
-
-    /// <summary>
-    /// 1-based line coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so a span that ends at the start of a line does not
-    /// cover that line. Treating the end as inclusive would let the first
-    /// line of an adjacent type also match the previous declaration. Same
-    /// exclusive-end idea as <c>AddNullChecksOperation.SpanCoversColumn</c>.
-    /// </summary>
-    internal static bool SpanCoversLine(FileLinePositionSpan span, int line)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == endLine && span.EndLinePosition.Character == 0)
-            return false;
-        return true;
-    }
 
     private static RefactoringResult CreatePreviewResult(
         Guid operationId,

--- a/src/RoslynMcp.Core/Refactoring/Generate/GeneratePropertyOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GeneratePropertyOperation.cs
@@ -719,7 +719,7 @@ public sealed class GeneratePropertyOperation : RefactoringOperationBase<Generat
     /// <paramref name="line"/> pick, including omitted-line
     /// <c>BaseTypeDeclarationSyntax</c> <c>FirstOrDefault</c> (enum
     /// participates) and line-only exclusive-end coverage
-    /// (<see cref="SpanCoversLine"/>). Do not force column 1 when omitted.
+    /// (<see cref="SpanCoverage.SpanCoversLine"/>). Do not force column 1 when omitted.
     /// Do not change omitted-line/omitted-column to
     /// <c>TypeDeclarationSyntax</c> / <c>ClassDeclarationSyntax</c>
     /// FirstOrDefault. Column without line keeps today's first-match after
@@ -813,10 +813,10 @@ public sealed class GeneratePropertyOperation : RefactoringOperationBase<Generat
 
     private static bool TypeCoversLine(BaseTypeDeclarationSyntax type, int line) =>
         IdentifierCoversLine(type, line) ||
-        SpanCoversLine(type.GetLocation().GetLineSpan(), line);
+        SpanCoverage.SpanCoversLine(type.GetLocation().GetLineSpan(), line);
 
     private static bool IdentifierCoversLine(BaseTypeDeclarationSyntax type, int line) =>
-        SpanCoversLine(type.Identifier.GetLocation().GetLineSpan(), line);
+        SpanCoverage.SpanCoversLine(type.Identifier.GetLocation().GetLineSpan(), line);
 
     private static bool TypeCoversColumn(BaseTypeDeclarationSyntax type, int line, int column) =>
         IdentifierCoversColumn(type, line, column) ||
@@ -824,26 +824,6 @@ public sealed class GeneratePropertyOperation : RefactoringOperationBase<Generat
 
     private static bool IdentifierCoversColumn(BaseTypeDeclarationSyntax type, int line, int column) =>
         SpanCoverage.SpanCoversColumn(type.Identifier.GetLocation().GetLineSpan(), line, column);
-
-
-    /// <summary>
-    /// 1-based line coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so a span that ends at the start of a line does not
-    /// cover that line. Treating the end as inclusive would let the first
-    /// line of an adjacent type also match the previous declaration. Same
-    /// exclusive-end idea as <c>GenerateConstructorOperation.SpanCoversLine</c>.
-    /// </summary>
-    internal static bool SpanCoversLine(FileLinePositionSpan span, int line)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == endLine && span.EndLinePosition.Character == 0)
-            return false;
-        return true;
-    }
 
     /// <summary>
     /// Creates a preview result with the generated property code.

--- a/src/RoslynMcp.Core/Refactoring/Generate/GenerateToStringOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GenerateToStringOperation.cs
@@ -790,7 +790,7 @@ public sealed class GenerateToStringOperation : RefactoringOperationBase<Generat
     /// <paramref name="line"/> pick, including omitted-line
     /// <c>TypeDeclarationSyntax</c> <c>FirstOrDefault</c> (enum and
     /// <c>DelegateDeclarationSyntax</c> do not participate) and
-    /// line-only exclusive-end coverage (<see cref="SpanCoversLine"/>).
+    /// line-only exclusive-end coverage (<see cref="SpanCoverage.SpanCoversLine"/>).
     /// Do not force column 1 when omitted. Do not change
     /// omitted-line/omitted-column to <c>BaseTypeDeclarationSyntax</c>
     /// FirstOrDefault. Do not add enums or delegates to the omitted-line
@@ -897,13 +897,13 @@ public sealed class GenerateToStringOperation : RefactoringOperationBase<Generat
 
     private static bool TypeCoversLine(MemberDeclarationSyntax type, int line) =>
         IdentifierCoversLine(type, line) ||
-        SpanCoversLine(type.GetLocation().GetLineSpan(), line);
+        SpanCoverage.SpanCoversLine(type.GetLocation().GetLineSpan(), line);
 
     private static bool IdentifierCoversLine(MemberDeclarationSyntax type, int line)
     {
         var identifier = GetTypeIdentifier(type);
         return identifier != default
-            && SpanCoversLine(identifier.GetLocation().GetLineSpan(), line);
+            && SpanCoverage.SpanCoversLine(identifier.GetLocation().GetLineSpan(), line);
     }
 
     private static bool TypeCoversColumn(MemberDeclarationSyntax type, int line, int column) =>
@@ -923,26 +923,6 @@ public sealed class GenerateToStringOperation : RefactoringOperationBase<Generat
         DelegateDeclarationSyntax del => del.Identifier,
         _ => default
     };
-
-
-    /// <summary>
-    /// 1-based line coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so a span that ends at the start of a line does not
-    /// cover that line. Treating the end as inclusive would let the first
-    /// line of an adjacent type also match the previous declaration. Same
-    /// exclusive-end idea as <c>GeneratePropertyOperation.SpanCoversLine</c>.
-    /// </summary>
-    internal static bool SpanCoversLine(FileLinePositionSpan span, int line)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == endLine && span.EndLinePosition.Character == 0)
-            return false;
-        return true;
-    }
 
     private static MethodDeclarationSyntax GenerateToString(
         string typeName,

--- a/src/RoslynMcp.Core/Refactoring/Generate/ImplementAbstractOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/ImplementAbstractOperation.cs
@@ -1627,7 +1627,7 @@ public sealed class ImplementAbstractOperation : RefactoringOperationBase<Implem
     /// <paramref name="line"/> pick, including omitted-line
     /// <c>BaseTypeDeclarationSyntax</c> <c>FirstOrDefault</c> (enum
     /// participates; <c>DelegateDeclarationSyntax</c> does not) and
-    /// line-only exclusive-end coverage (<see cref="SpanCoversLine"/>).
+    /// line-only exclusive-end coverage (<see cref="SpanCoverage.SpanCoversLine"/>).
     /// Do not force column 1 when omitted. Do not change
     /// omitted-line/omitted-column to <c>TypeDeclarationSyntax</c> /
     /// <c>ClassDeclarationSyntax</c> FirstOrDefault. Do not add delegates
@@ -1745,13 +1745,13 @@ public sealed class ImplementAbstractOperation : RefactoringOperationBase<Implem
 
     private static bool TypeCoversLine(MemberDeclarationSyntax type, int line) =>
         IdentifierCoversLine(type, line) ||
-        SpanCoversLine(type.GetLocation().GetLineSpan(), line);
+        SpanCoverage.SpanCoversLine(type.GetLocation().GetLineSpan(), line);
 
     private static bool IdentifierCoversLine(MemberDeclarationSyntax type, int line)
     {
         var identifier = GetTypeIdentifier(type);
         return identifier != default
-            && SpanCoversLine(identifier.GetLocation().GetLineSpan(), line);
+            && SpanCoverage.SpanCoversLine(identifier.GetLocation().GetLineSpan(), line);
     }
 
     private static bool TypeCoversColumn(MemberDeclarationSyntax type, int line, int column) =>
@@ -1771,26 +1771,6 @@ public sealed class ImplementAbstractOperation : RefactoringOperationBase<Implem
         DelegateDeclarationSyntax del => del.Identifier,
         _ => default
     };
-
-
-    /// <summary>
-    /// 1-based line coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so a span that ends at the start of a line does not
-    /// cover that line. Treating the end as inclusive would let the first
-    /// line of an adjacent type also match the previous declaration. Same
-    /// exclusive-end idea as <c>GeneratePropertyOperation.SpanCoversLine</c>.
-    /// </summary>
-    internal static bool SpanCoversLine(FileLinePositionSpan span, int line)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == endLine && span.EndLinePosition.Character == 0)
-            return false;
-        return true;
-    }
 
     /// <summary>
     /// Creates a preview result describing generate vs replace.

--- a/src/RoslynMcp.Core/Refactoring/Generate/ImplementInterfaceOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/ImplementInterfaceOperation.cs
@@ -1372,7 +1372,7 @@ public sealed class ImplementInterfaceOperation : RefactoringOperationBase<Imple
     /// <paramref name="column"/> keeps today's typeName + optional
     /// <paramref name="line"/> pick, including omitted-line
     /// <c>FirstOrDefault</c> and line-only exclusive-end coverage
-    /// (<see cref="SpanCoversLine"/>). Do not force column 1 when omitted.
+    /// (<see cref="SpanCoverage.SpanCoversLine"/>). Do not force column 1 when omitted.
     /// Column without line keeps today's first-match after the typeName
     /// filter rather than substituting each candidate's own start line.
     /// When column is set with line, picks the type whose identifier or
@@ -1446,10 +1446,10 @@ public sealed class ImplementInterfaceOperation : RefactoringOperationBase<Imple
 
     private static bool TypeCoversLine(TypeDeclarationSyntax type, int line) =>
         IdentifierCoversLine(type, line) ||
-        SpanCoversLine(type.GetLocation().GetLineSpan(), line);
+        SpanCoverage.SpanCoversLine(type.GetLocation().GetLineSpan(), line);
 
     private static bool IdentifierCoversLine(TypeDeclarationSyntax type, int line) =>
-        SpanCoversLine(type.Identifier.GetLocation().GetLineSpan(), line);
+        SpanCoverage.SpanCoversLine(type.Identifier.GetLocation().GetLineSpan(), line);
 
     private static bool TypeCoversColumn(TypeDeclarationSyntax type, int line, int column) =>
         IdentifierCoversColumn(type, line, column) ||
@@ -1457,26 +1457,6 @@ public sealed class ImplementInterfaceOperation : RefactoringOperationBase<Imple
 
     private static bool IdentifierCoversColumn(TypeDeclarationSyntax type, int line, int column) =>
         SpanCoverage.SpanCoversColumn(type.Identifier.GetLocation().GetLineSpan(), line, column);
-
-
-    /// <summary>
-    /// 1-based line coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so a span that ends at the start of a line does not
-    /// cover that line. Treating the end as inclusive would let the first
-    /// line of an adjacent type also match the previous declaration. Same
-    /// exclusive-end idea as <c>GenerateOverridesOperation.SpanCoversLine</c>.
-    /// </summary>
-    internal static bool SpanCoversLine(FileLinePositionSpan span, int line)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == endLine && span.EndLinePosition.Character == 0)
-            return false;
-        return true;
-    }
 
     /// <summary>
     /// Creates a preview result describing generate vs replace.

--- a/src/RoslynMcp.Core/Resolution/SpanCoverage.cs
+++ b/src/RoslynMcp.Core/Resolution/SpanCoverage.cs
@@ -29,4 +29,25 @@ internal static class SpanCoverage
             return false;
         return true;
     }
+
+    /// <summary>
+    /// 1-based line coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
+    /// is exclusive, so a span that ends at the start of a line does not
+    /// cover that line (reject when <paramref name="line"/> equals the
+    /// exclusive end line and <c>EndLinePosition.Character == 0</c>).
+    /// Treating the end as inclusive would let the first line of an
+    /// adjacent type also match the previous declaration.
+    /// </summary>
+    internal static bool SpanCoversLine(FileLinePositionSpan span, int line)
+    {
+        var startLine = span.StartLinePosition.Line + 1;
+        var endLine = span.EndLinePosition.Line + 1;
+
+        if (line < startLine || line > endLine)
+            return false;
+        if (line == endLine && span.EndLinePosition.Character == 0)
+            return false;
+        return true;
+    }
 }
+

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GenerateConstructorOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GenerateConstructorOperationTests.cs
@@ -278,10 +278,10 @@ public class GenerateConstructorOperationTests
             new LinePosition(0, 0),
             new LinePosition(2, 0));
 
-        Assert.True(GenerateConstructorOperation.SpanCoversLine(span, 1));
-        Assert.True(GenerateConstructorOperation.SpanCoversLine(span, 2));
-        Assert.False(GenerateConstructorOperation.SpanCoversLine(span, 3));
-        Assert.False(GenerateConstructorOperation.SpanCoversLine(span, 0));
+        Assert.True(SpanCoverage.SpanCoversLine(span, 1));
+        Assert.True(SpanCoverage.SpanCoversLine(span, 2));
+        Assert.False(SpanCoverage.SpanCoversLine(span, 3));
+        Assert.False(SpanCoverage.SpanCoversLine(span, 0));
     }
 
     [SkippableFact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GenerateEqualsHashCodeOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GenerateEqualsHashCodeOperationTests.cs
@@ -273,10 +273,10 @@ public class GenerateEqualsHashCodeOperationTests
             new LinePosition(0, 0),
             new LinePosition(2, 0));
 
-        Assert.True(GenerateEqualsHashCodeOperation.SpanCoversLine(span, 1));
-        Assert.True(GenerateEqualsHashCodeOperation.SpanCoversLine(span, 2));
-        Assert.False(GenerateEqualsHashCodeOperation.SpanCoversLine(span, 3));
-        Assert.False(GenerateEqualsHashCodeOperation.SpanCoversLine(span, 0));
+        Assert.True(SpanCoverage.SpanCoversLine(span, 1));
+        Assert.True(SpanCoverage.SpanCoversLine(span, 2));
+        Assert.False(SpanCoverage.SpanCoversLine(span, 3));
+        Assert.False(SpanCoverage.SpanCoversLine(span, 0));
     }
 
     [SkippableFact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GenerateOverridesOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GenerateOverridesOperationTests.cs
@@ -434,10 +434,10 @@ public class GenerateOverridesOperationTests
             new LinePosition(0, 0),
             new LinePosition(2, 0));
 
-        Assert.True(GenerateOverridesOperation.SpanCoversLine(span, 1));
-        Assert.True(GenerateOverridesOperation.SpanCoversLine(span, 2));
-        Assert.False(GenerateOverridesOperation.SpanCoversLine(span, 3));
-        Assert.False(GenerateOverridesOperation.SpanCoversLine(span, 0));
+        Assert.True(SpanCoverage.SpanCoversLine(span, 1));
+        Assert.True(SpanCoverage.SpanCoversLine(span, 2));
+        Assert.False(SpanCoverage.SpanCoversLine(span, 3));
+        Assert.False(SpanCoverage.SpanCoversLine(span, 0));
     }
 
     [SkippableFact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GeneratePropertyOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GeneratePropertyOperationTests.cs
@@ -636,10 +636,10 @@ public class GeneratePropertyOperationTests
             new LinePosition(0, 0),
             new LinePosition(2, 0));
 
-        Assert.True(GeneratePropertyOperation.SpanCoversLine(span, 1));
-        Assert.True(GeneratePropertyOperation.SpanCoversLine(span, 2));
-        Assert.False(GeneratePropertyOperation.SpanCoversLine(span, 3));
-        Assert.False(GeneratePropertyOperation.SpanCoversLine(span, 0));
+        Assert.True(SpanCoverage.SpanCoversLine(span, 1));
+        Assert.True(SpanCoverage.SpanCoversLine(span, 2));
+        Assert.False(SpanCoverage.SpanCoversLine(span, 3));
+        Assert.False(SpanCoverage.SpanCoversLine(span, 0));
     }
 
     [SkippableFact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GenerateToStringOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GenerateToStringOperationTests.cs
@@ -590,10 +590,10 @@ public class GenerateToStringOperationTests
             new LinePosition(0, 0),
             new LinePosition(2, 0));
 
-        Assert.True(GenerateToStringOperation.SpanCoversLine(span, 1));
-        Assert.True(GenerateToStringOperation.SpanCoversLine(span, 2));
-        Assert.False(GenerateToStringOperation.SpanCoversLine(span, 3));
-        Assert.False(GenerateToStringOperation.SpanCoversLine(span, 0));
+        Assert.True(SpanCoverage.SpanCoversLine(span, 1));
+        Assert.True(SpanCoverage.SpanCoversLine(span, 2));
+        Assert.False(SpanCoverage.SpanCoversLine(span, 3));
+        Assert.False(SpanCoverage.SpanCoversLine(span, 0));
     }
 
     [SkippableFact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Generate/ImplementAbstractOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Generate/ImplementAbstractOperationTests.cs
@@ -625,10 +625,10 @@ public class ImplementAbstractOperationTests
             new LinePosition(0, 0),
             new LinePosition(2, 0));
 
-        Assert.True(ImplementAbstractOperation.SpanCoversLine(span, 1));
-        Assert.True(ImplementAbstractOperation.SpanCoversLine(span, 2));
-        Assert.False(ImplementAbstractOperation.SpanCoversLine(span, 3));
-        Assert.False(ImplementAbstractOperation.SpanCoversLine(span, 0));
+        Assert.True(SpanCoverage.SpanCoversLine(span, 1));
+        Assert.True(SpanCoverage.SpanCoversLine(span, 2));
+        Assert.False(SpanCoverage.SpanCoversLine(span, 3));
+        Assert.False(SpanCoverage.SpanCoversLine(span, 0));
     }
 
     [SkippableFact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Generate/ImplementInterfaceOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Generate/ImplementInterfaceOperationTests.cs
@@ -362,10 +362,10 @@ public class ImplementInterfaceOperationTests
             new LinePosition(0, 0),
             new LinePosition(2, 0));
 
-        Assert.True(ImplementInterfaceOperation.SpanCoversLine(span, 1));
-        Assert.True(ImplementInterfaceOperation.SpanCoversLine(span, 2));
-        Assert.False(ImplementInterfaceOperation.SpanCoversLine(span, 3));
-        Assert.False(ImplementInterfaceOperation.SpanCoversLine(span, 0));
+        Assert.True(SpanCoverage.SpanCoversLine(span, 1));
+        Assert.True(SpanCoverage.SpanCoversLine(span, 2));
+        Assert.False(SpanCoverage.SpanCoversLine(span, 3));
+        Assert.False(SpanCoverage.SpanCoversLine(span, 0));
     }
 
     [SkippableFact]


### PR DESCRIPTION
## Summary
- Continues the SpanCoverage extract series after SpanCoversColumn (#955–#974): add shared `SpanCoverage.SpanCoversLine` (exclusive-end: reject end line when `Character == 0`).
- Removes 7 byte-identical Generate-family type-local copies (`generate_constructor` / `generate_equals_hashcode` / `generate_overrides` / `generate_property` / `generate_tostring` / `implement_abstract` / `implement_interface`).
- Retargets Generate exclusive-end unit tests to the shared helper (tests kept).
- Does **not** replace Hierarchy/Encapsulate/Extract/Inline/Convert/Rename `SpanCoversLine`; does not fold optional-column overload; leaves `AddNullChecksOperation` alone.
- Unreleased CHANGELOG hygiene line. Behavior-preserving only.

Closes #975

## Test plan
- [x] `dotnet test` filter `FullyQualifiedName~SpanCoversLine|FullyQualifiedName~SpanCoverage` — 23 passed locally
- [ ] CI Build and Test + Code Quality on this PR
- [ ] Copilot/Codex review; squash-merge after threads resolved. Leave Dependabot.