### PR TITLE
refactor: extract SpanCoversLine; replace Hierarchy/Encapsulate/Extract/Inline duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- Replaced 7 identical Hierarchy/Encapsulate/Extract/Inline `SpanCoversLine` copies with shared `SpanCoverage.SpanCoversLine` (`pull_members_up` / `push_members_down` / `use_base_type` / `encapsulate_field` / `inline_constant` / `extract_interface` / `extract_base_class`) (#978)
 - Extracted shared `SpanCoverage.SpanCoversLine` and replaced 7 identical Generate-family copies (`generate_constructor` / `generate_equals_hashcode` / `generate_overrides` / `generate_property` / `generate_tostring` / `implement_abstract` / `implement_interface`) (#975)
 - Replaced 2 identical Rename `SpanCoversColumn` copies with shared `SpanCoverage.SpanCoversColumn` (`rename_namespace` / `rename_file_to_match_type`) (#973)
 - Replaced 3 identical Inline `SpanCoversColumn` copies with shared `SpanCoverage.SpanCoversColumn` (`inline_method` / `inline_constant` / `inline_variable`) (#970)

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertToBlockBodyOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertToBlockBodyOperation.cs
@@ -234,7 +234,7 @@ public sealed class ConvertToBlockBodyOperation : RefactoringOperationBase<Conve
     /// is exclusive, so a span that ends at the start of a line does not
     /// cover that line. Treating the end as inclusive would let the first
     /// line of an adjacent member also match the previous declaration. Same
-    /// exclusive-end idea as <c>EncapsulateFieldOperation.SpanCoversLine</c>.
+    /// exclusive-end idea as <c>SpanCoverage.SpanCoversLine</c>.
     /// </summary>
     internal static bool ContainsLine(SyntaxNode node, int line)
     {

--- a/src/RoslynMcp.Core/Refactoring/Convert/SimplifyNameOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/SimplifyNameOperation.cs
@@ -1020,7 +1020,7 @@ public sealed class SimplifyNameOperation : RefactoringOperationBase<SimplifyNam
     /// is exclusive, so a span that ends at the start of a line does not
     /// cover that line. Treating the end as inclusive would let the first
     /// line of an adjacent name also match the previous name. Same
-    /// exclusive-end idea as <c>EncapsulateFieldOperation.SpanCoversLine</c>.
+    /// exclusive-end idea as <c>SpanCoverage.SpanCoversLine</c>.
     /// </summary>
     internal static bool SpanTouchesLine(SyntaxNode node, int line)
     {

--- a/src/RoslynMcp.Core/Refactoring/Encapsulate/EncapsulateFieldOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Encapsulate/EncapsulateFieldOperation.cs
@@ -666,7 +666,7 @@ public sealed class EncapsulateFieldOperation : RefactoringOperationBase<Encapsu
     /// <paramref name="column"/> keeps today's fieldName + optional
     /// <paramref name="line"/> pick, including omitted-line field
     /// <c>VariableDeclaratorSyntax</c> <c>FirstOrDefault</c> and
-    /// line-only exclusive-end coverage (<see cref="SpanCoversLine"/>).
+    /// line-only exclusive-end coverage (<see cref="SpanCoverage.SpanCoversLine"/>).
     /// Do not force column 1 when omitted. Locals and other non-field
     /// declarators stay excluded. Column without line keeps today's
     /// <c>FirstOrDefault</c> after the fieldName filter rather than
@@ -738,12 +738,12 @@ public sealed class EncapsulateFieldOperation : RefactoringOperationBase<Encapsu
 
     private static bool FieldCoversLine(VariableDeclaratorSyntax declarator, int line) =>
         IdentifierCoversLine(declarator, line) ||
-        SpanCoversLine(declarator.GetLocation().GetLineSpan(), line) ||
+        SpanCoverage.SpanCoversLine(declarator.GetLocation().GetLineSpan(), line) ||
         (GetFieldDeclaration(declarator) is { } field &&
-         SpanCoversLine(field.GetLocation().GetLineSpan(), line));
+         SpanCoverage.SpanCoversLine(field.GetLocation().GetLineSpan(), line));
 
     private static bool IdentifierCoversLine(VariableDeclaratorSyntax declarator, int line) =>
-        SpanCoversLine(declarator.Identifier.GetLocation().GetLineSpan(), line);
+        SpanCoverage.SpanCoversLine(declarator.Identifier.GetLocation().GetLineSpan(), line);
 
     private static bool FieldCoversColumn(VariableDeclaratorSyntax declarator, int line, int column) =>
         IdentifierCoversColumn(declarator, line, column) ||
@@ -757,11 +757,11 @@ public sealed class EncapsulateFieldOperation : RefactoringOperationBase<Encapsu
     private static int SmallestCoveringSpanLength(VariableDeclaratorSyntax declarator, int line)
     {
         var smallest = int.MaxValue;
-        if (SpanCoversLine(declarator.GetLocation().GetLineSpan(), line))
+        if (SpanCoverage.SpanCoversLine(declarator.GetLocation().GetLineSpan(), line))
             smallest = Math.Min(smallest, declarator.Span.Length);
 
         if (GetFieldDeclaration(declarator) is { } field &&
-            SpanCoversLine(field.GetLocation().GetLineSpan(), line))
+            SpanCoverage.SpanCoversLine(field.GetLocation().GetLineSpan(), line))
         {
             smallest = Math.Min(smallest, field.Span.Length);
         }
@@ -787,24 +787,6 @@ public sealed class EncapsulateFieldOperation : RefactoringOperationBase<Encapsu
     private static FieldDeclarationSyntax? GetFieldDeclaration(VariableDeclaratorSyntax declarator) =>
         declarator.Parent?.Parent as FieldDeclarationSyntax;
 
-    /// <summary>
-    /// 1-based line coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so a span that ends at the start of a line does not
-    /// cover that line. Treating the end as inclusive would let the first
-    /// line of an adjacent field also match the previous declaration. Same
-    /// exclusive-end idea as <c>UseBaseTypeOperation.SpanCoversLine</c>.
-    /// </summary>
-    internal static bool SpanCoversLine(FileLinePositionSpan span, int line)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == endLine && span.EndLinePosition.Character == 0)
-            return false;
-        return true;
-    }
 
     /// <summary>
     /// True when the reference lives in the selected field's containing

--- a/src/RoslynMcp.Core/Refactoring/Extract/ExtractBaseClassOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/ExtractBaseClassOperation.cs
@@ -1084,7 +1084,7 @@ public sealed class ExtractBaseClassOperation : RefactoringOperationBase<Extract
     /// <paramref name="line"/> pick, including omitted-line
     /// <c>ClassDeclarationSyntax</c> <c>FirstOrDefault</c> (enum, struct,
     /// interface, and <c>DelegateDeclarationSyntax</c> do not participate)
-    /// and line-only exclusive-end coverage (<see cref="SpanCoversLine"/>).
+    /// and line-only exclusive-end coverage (<see cref="SpanCoverage.SpanCoversLine"/>).
     /// Do not force column 1 when omitted. Do not change
     /// omitted-line/omitted-column to <c>BaseTypeDeclarationSyntax</c> or
     /// <c>TypeDeclarationSyntax</c> FirstOrDefault. Do not add enums,
@@ -1191,13 +1191,13 @@ public sealed class ExtractBaseClassOperation : RefactoringOperationBase<Extract
 
     private static bool TypeCoversLine(MemberDeclarationSyntax type, int line) =>
         IdentifierCoversLine(type, line) ||
-        SpanCoversLine(type.GetLocation().GetLineSpan(), line);
+        SpanCoverage.SpanCoversLine(type.GetLocation().GetLineSpan(), line);
 
     private static bool IdentifierCoversLine(MemberDeclarationSyntax type, int line)
     {
         var identifier = GetTypeIdentifier(type);
         return identifier != default
-            && SpanCoversLine(identifier.GetLocation().GetLineSpan(), line);
+            && SpanCoverage.SpanCoversLine(identifier.GetLocation().GetLineSpan(), line);
     }
 
     private static bool TypeCoversColumn(MemberDeclarationSyntax type, int line, int column) =>
@@ -1218,24 +1218,6 @@ public sealed class ExtractBaseClassOperation : RefactoringOperationBase<Extract
         _ => default
     };
 
-    /// <summary>
-    /// 1-based line coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so a span that ends at the start of a line does not
-    /// cover that line. Treating the end as inclusive would let the first
-    /// line of an adjacent type also match the previous declaration. Same
-    /// exclusive-end idea as <c>ExtractInterfaceOperation.SpanCoversLine</c>.
-    /// </summary>
-    internal static bool SpanCoversLine(FileLinePositionSpan span, int line)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == endLine && span.EndLinePosition.Character == 0)
-            return false;
-        return true;
-    }
 
     private static ClassDeclarationSyntax RecoverAnnotatedClass(
         SyntaxNode root,

--- a/src/RoslynMcp.Core/Refactoring/Extract/ExtractBaseClassOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/ExtractBaseClassOperation.cs
@@ -3,7 +3,6 @@ using System.Xml.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 using RoslynMcp.Contracts.Enums;
 using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;

--- a/src/RoslynMcp.Core/Refactoring/Extract/ExtractInterfaceOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/ExtractInterfaceOperation.cs
@@ -1,7 +1,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 using RoslynMcp.Contracts.Enums;
 using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;

--- a/src/RoslynMcp.Core/Refactoring/Extract/ExtractInterfaceOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/ExtractInterfaceOperation.cs
@@ -518,7 +518,7 @@ public sealed class ExtractInterfaceOperation : RefactoringOperationBase<Extract
     /// <paramref name="line"/> pick, including omitted-line
     /// <c>TypeDeclarationSyntax</c> <c>FirstOrDefault</c> (enum and
     /// <c>DelegateDeclarationSyntax</c> do not participate) and
-    /// line-only exclusive-end coverage (<see cref="SpanCoversLine"/>).
+    /// line-only exclusive-end coverage (<see cref="SpanCoverage.SpanCoversLine"/>).
     /// Do not force column 1 when omitted. Do not change
     /// omitted-line/omitted-column to <c>BaseTypeDeclarationSyntax</c>
     /// FirstOrDefault. Do not add enums or delegates to the omitted-line
@@ -624,13 +624,13 @@ public sealed class ExtractInterfaceOperation : RefactoringOperationBase<Extract
 
     private static bool TypeCoversLine(MemberDeclarationSyntax type, int line) =>
         IdentifierCoversLine(type, line) ||
-        SpanCoversLine(type.GetLocation().GetLineSpan(), line);
+        SpanCoverage.SpanCoversLine(type.GetLocation().GetLineSpan(), line);
 
     private static bool IdentifierCoversLine(MemberDeclarationSyntax type, int line)
     {
         var identifier = GetTypeIdentifier(type);
         return identifier != default
-            && SpanCoversLine(identifier.GetLocation().GetLineSpan(), line);
+            && SpanCoverage.SpanCoversLine(identifier.GetLocation().GetLineSpan(), line);
     }
 
     private static bool TypeCoversColumn(MemberDeclarationSyntax type, int line, int column) =>
@@ -651,22 +651,4 @@ public sealed class ExtractInterfaceOperation : RefactoringOperationBase<Extract
         _ => default
     };
 
-    /// <summary>
-    /// 1-based line coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so a span that ends at the start of a line does not
-    /// cover that line. Treating the end as inclusive would let the first
-    /// line of an adjacent type also match the previous declaration. Same
-    /// exclusive-end idea as <c>SpanCoverage.SpanCoversLine</c>.
-    /// </summary>
-    internal static bool SpanCoversLine(FileLinePositionSpan span, int line)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == endLine && span.EndLinePosition.Character == 0)
-            return false;
-        return true;
-    }
 }

--- a/src/RoslynMcp.Core/Refactoring/Hierarchy/PullMembersUpOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Hierarchy/PullMembersUpOperation.cs
@@ -205,7 +205,7 @@ public sealed class PullMembersUpOperation : RefactoringOperationBase<PullMember
     /// <paramref name="line"/> pick, including omitted-line
     /// <c>TypeDeclarationSyntax</c> <c>FirstOrDefault</c> (enum and
     /// <c>DelegateDeclarationSyntax</c> do not participate) and
-    /// line-only exclusive-end coverage (<see cref="SpanCoversLine"/>).
+    /// line-only exclusive-end coverage (<see cref="SpanCoverage.SpanCoversLine"/>).
     /// Do not force column 1 when omitted. Do not change
     /// omitted-line/omitted-column to <c>BaseTypeDeclarationSyntax</c>
     /// FirstOrDefault. Do not add enums or delegates to the omitted-line
@@ -313,13 +313,13 @@ public sealed class PullMembersUpOperation : RefactoringOperationBase<PullMember
 
     private static bool TypeCoversLine(MemberDeclarationSyntax type, int line) =>
         IdentifierCoversLine(type, line) ||
-        SpanCoversLine(type.GetLocation().GetLineSpan(), line);
+        SpanCoverage.SpanCoversLine(type.GetLocation().GetLineSpan(), line);
 
     private static bool IdentifierCoversLine(MemberDeclarationSyntax type, int line)
     {
         var identifier = GetTypeIdentifier(type);
         return identifier != default
-            && SpanCoversLine(identifier.GetLocation().GetLineSpan(), line);
+            && SpanCoverage.SpanCoversLine(identifier.GetLocation().GetLineSpan(), line);
     }
 
     private static bool TypeCoversColumn(MemberDeclarationSyntax type, int line, int column) =>
@@ -341,24 +341,6 @@ public sealed class PullMembersUpOperation : RefactoringOperationBase<PullMember
     };
 
 
-    /// <summary>
-    /// 1-based line coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so a span that ends at the start of a line does not
-    /// cover that line. Treating the end as inclusive would let the first
-    /// line of an adjacent type also match the previous declaration. Same
-    /// exclusive-end idea as <c>ExtractInterfaceOperation.SpanCoversLine</c>.
-    /// </summary>
-    internal static bool SpanCoversLine(FileLinePositionSpan span, int line)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == endLine && span.EndLinePosition.Character == 0)
-            return false;
-        return true;
-    }
 
     private static TypeDeclarationSyntax RecoverAnnotatedType(
         SyntaxNode root,

--- a/src/RoslynMcp.Core/Refactoring/Hierarchy/PullMembersUpOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Hierarchy/PullMembersUpOperation.cs
@@ -1,7 +1,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 using RoslynMcp.Contracts.Enums;
 using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;

--- a/src/RoslynMcp.Core/Refactoring/Hierarchy/PushMembersDownOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Hierarchy/PushMembersDownOperation.cs
@@ -227,7 +227,7 @@ public sealed class PushMembersDownOperation : RefactoringOperationBase<PushMemb
     /// <paramref name="line"/> pick, including omitted-line
     /// <c>TypeDeclarationSyntax</c> <c>FirstOrDefault</c> (enum and
     /// <c>DelegateDeclarationSyntax</c> do not participate) and
-    /// line-only exclusive-end coverage (<see cref="SpanCoversLine"/>).
+    /// line-only exclusive-end coverage (<see cref="SpanCoverage.SpanCoversLine"/>).
     /// Do not force column 1 when omitted. Do not change
     /// omitted-line/omitted-column to <c>BaseTypeDeclarationSyntax</c>
     /// FirstOrDefault. Do not add enums or delegates to the omitted-line
@@ -335,13 +335,13 @@ public sealed class PushMembersDownOperation : RefactoringOperationBase<PushMemb
 
     private static bool TypeCoversLine(MemberDeclarationSyntax type, int line) =>
         IdentifierCoversLine(type, line) ||
-        SpanCoversLine(type.GetLocation().GetLineSpan(), line);
+        SpanCoverage.SpanCoversLine(type.GetLocation().GetLineSpan(), line);
 
     private static bool IdentifierCoversLine(MemberDeclarationSyntax type, int line)
     {
         var identifier = GetTypeIdentifier(type);
         return identifier != default
-            && SpanCoversLine(identifier.GetLocation().GetLineSpan(), line);
+            && SpanCoverage.SpanCoversLine(identifier.GetLocation().GetLineSpan(), line);
     }
 
     private static bool TypeCoversColumn(MemberDeclarationSyntax type, int line, int column) =>
@@ -363,24 +363,6 @@ public sealed class PushMembersDownOperation : RefactoringOperationBase<PushMemb
     };
 
 
-    /// <summary>
-    /// 1-based line coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so a span that ends at the start of a line does not
-    /// cover that line. Treating the end as inclusive would let the first
-    /// line of an adjacent type also match the previous declaration. Same
-    /// exclusive-end idea as <c>ExtractInterfaceOperation.SpanCoversLine</c>.
-    /// </summary>
-    internal static bool SpanCoversLine(FileLinePositionSpan span, int line)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == endLine && span.EndLinePosition.Character == 0)
-            return false;
-        return true;
-    }
 
     private static TypeDeclarationSyntax RecoverAnnotatedType(
         SyntaxNode root,

--- a/src/RoslynMcp.Core/Refactoring/Hierarchy/PushMembersDownOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Hierarchy/PushMembersDownOperation.cs
@@ -2,7 +2,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.FindSymbols;
-using Microsoft.CodeAnalysis.Text;
 using RoslynMcp.Contracts.Enums;
 using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;

--- a/src/RoslynMcp.Core/Refactoring/Hierarchy/UseBaseTypeOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Hierarchy/UseBaseTypeOperation.cs
@@ -505,7 +505,7 @@ public sealed class UseBaseTypeOperation : RefactoringOperationBase<UseBaseTypeP
     /// <paramref name="line"/> pick, including omitted-line
     /// <c>TypeDeclarationSyntax</c> <c>PickOmittedLineMatch</c> (enum and
     /// <c>DelegateDeclarationSyntax</c> do not participate) and line-only
-    /// exclusive-end coverage (<see cref="SpanCoversLine"/>). Do not force
+    /// exclusive-end coverage (<see cref="SpanCoverage.SpanCoversLine"/>). Do not force
     /// column 1 when omitted. Do not change omitted-line/omitted-column to
     /// <c>BaseTypeDeclarationSyntax</c> FirstOrDefault. Do not add enums
     /// or delegates to the omitted-line set. Column without line keeps
@@ -640,13 +640,13 @@ public sealed class UseBaseTypeOperation : RefactoringOperationBase<UseBaseTypeP
 
     private static bool TypeCoversLine(MemberDeclarationSyntax type, int line) =>
         IdentifierCoversLine(type, line) ||
-        SpanCoversLine(type.GetLocation().GetLineSpan(), line);
+        SpanCoverage.SpanCoversLine(type.GetLocation().GetLineSpan(), line);
 
     private static bool IdentifierCoversLine(MemberDeclarationSyntax type, int line)
     {
         var identifier = GetTypeIdentifier(type);
         return identifier != default
-            && SpanCoversLine(identifier.GetLocation().GetLineSpan(), line);
+            && SpanCoverage.SpanCoversLine(identifier.GetLocation().GetLineSpan(), line);
     }
 
     private static bool TypeCoversColumn(MemberDeclarationSyntax type, int line, int column) =>
@@ -668,24 +668,6 @@ public sealed class UseBaseTypeOperation : RefactoringOperationBase<UseBaseTypeP
     };
 
 
-    /// <summary>
-    /// 1-based line coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so a span that ends at the start of a line does not
-    /// cover that line. Treating the end as inclusive would let the first
-    /// line of an adjacent type also match the previous declaration. Same
-    /// exclusive-end idea as <c>PushMembersDownOperation.SpanCoversLine</c>.
-    /// </summary>
-    internal static bool SpanCoversLine(FileLinePositionSpan span, int line)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == endLine && span.EndLinePosition.Character == 0)
-            return false;
-        return true;
-    }
 
     internal static bool TypeNameMatches(INamedTypeSymbol symbol, string typeName)
     {

--- a/src/RoslynMcp.Core/Refactoring/Hierarchy/UseBaseTypeOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Hierarchy/UseBaseTypeOperation.cs
@@ -2,7 +2,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.FindSymbols;
-using Microsoft.CodeAnalysis.Text;
 using RoslynMcp.Contracts.Enums;
 using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;

--- a/src/RoslynMcp.Core/Refactoring/Inline/InlineConstantOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Inline/InlineConstantOperation.cs
@@ -496,7 +496,7 @@ public sealed class InlineConstantOperation : RefactoringOperationBase<InlineCon
     /// that 1-based line (identifier preferred, then smallest covering
     /// declarator/field — same exclusive-end coverage as
     /// <c>EncapsulateFieldOperation.FindFieldDeclarator</c> /
-    /// <see cref="SpanCoversLine"/>). When column is set with line, same
+    /// <see cref="SpanCoverage.SpanCoversLine"/>). When column is set with line, same
     /// covering-span rules as encapsulate_field (<c>SpanCoverage.SpanCoversColumn</c>,
     /// exclusive end). Nested types participate. Do not require the
     /// declaration to start on line — a split declaration may put the
@@ -601,12 +601,12 @@ public sealed class InlineConstantOperation : RefactoringOperationBase<InlineCon
 
     private static bool FieldCoversLine(VariableDeclaratorSyntax declarator, int line) =>
         IdentifierCoversLine(declarator, line) ||
-        SpanCoversLine(declarator.GetLocation().GetLineSpan(), line) ||
+        SpanCoverage.SpanCoversLine(declarator.GetLocation().GetLineSpan(), line) ||
         (GetFieldDeclaration(declarator) is { } field &&
-         SpanCoversLine(field.GetLocation().GetLineSpan(), line));
+         SpanCoverage.SpanCoversLine(field.GetLocation().GetLineSpan(), line));
 
     private static bool IdentifierCoversLine(VariableDeclaratorSyntax declarator, int line) =>
-        SpanCoversLine(declarator.Identifier.GetLocation().GetLineSpan(), line);
+        SpanCoverage.SpanCoversLine(declarator.Identifier.GetLocation().GetLineSpan(), line);
 
     private static bool FieldCoversColumn(VariableDeclaratorSyntax declarator, int line, int column) =>
         IdentifierCoversColumn(declarator, line, column) ||
@@ -620,11 +620,11 @@ public sealed class InlineConstantOperation : RefactoringOperationBase<InlineCon
     private static int SmallestCoveringSpanLength(VariableDeclaratorSyntax declarator, int line)
     {
         var smallest = int.MaxValue;
-        if (SpanCoversLine(declarator.GetLocation().GetLineSpan(), line))
+        if (SpanCoverage.SpanCoversLine(declarator.GetLocation().GetLineSpan(), line))
             smallest = Math.Min(smallest, declarator.Span.Length);
 
         if (GetFieldDeclaration(declarator) is { } field &&
-            SpanCoversLine(field.GetLocation().GetLineSpan(), line))
+            SpanCoverage.SpanCoversLine(field.GetLocation().GetLineSpan(), line))
         {
             smallest = Math.Min(smallest, field.Span.Length);
         }
@@ -651,24 +651,6 @@ public sealed class InlineConstantOperation : RefactoringOperationBase<InlineCon
         declarator.Parent?.Parent as FieldDeclarationSyntax;
 
 
-    /// <summary>
-    /// 1-based line coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so a span that ends at the start of a line does not
-    /// cover that line. Treating the end as inclusive would let the first
-    /// line of an adjacent field also match the previous declaration. Same
-    /// exclusive-end idea as <c>EncapsulateFieldOperation.SpanCoversLine</c>.
-    /// </summary>
-    internal static bool SpanCoversLine(FileLinePositionSpan span, int line)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == endLine && span.EndLinePosition.Character == 0)
-            return false;
-        return true;
-    }
 
     private static bool MatchesTypeName(IFieldSymbol? field, string typeName)
     {

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Encapsulate/EncapsulateFieldOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Encapsulate/EncapsulateFieldOperationTests.cs
@@ -738,9 +738,9 @@ public class EncapsulateFieldOperationTests
             new LinePosition(0, 0),
             new LinePosition(2, 0));
 
-        Assert.True(EncapsulateFieldOperation.SpanCoversLine(span, 1));
-        Assert.True(EncapsulateFieldOperation.SpanCoversLine(span, 2));
-        Assert.False(EncapsulateFieldOperation.SpanCoversLine(span, 3));
+        Assert.True(SpanCoverage.SpanCoversLine(span, 1));
+        Assert.True(SpanCoverage.SpanCoversLine(span, 2));
+        Assert.False(SpanCoverage.SpanCoversLine(span, 3));
     }
 
     #endregion

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Extract/ExtractBaseClassOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Extract/ExtractBaseClassOperationTests.cs
@@ -508,10 +508,10 @@ public class ExtractBaseClassOperationTests
             new LinePosition(0, 0),
             new LinePosition(2, 0));
 
-        Assert.True(ExtractBaseClassOperation.SpanCoversLine(span, 1));
-        Assert.True(ExtractBaseClassOperation.SpanCoversLine(span, 2));
-        Assert.False(ExtractBaseClassOperation.SpanCoversLine(span, 3));
-        Assert.False(ExtractBaseClassOperation.SpanCoversLine(span, 0));
+        Assert.True(SpanCoverage.SpanCoversLine(span, 1));
+        Assert.True(SpanCoverage.SpanCoversLine(span, 2));
+        Assert.False(SpanCoverage.SpanCoversLine(span, 3));
+        Assert.False(SpanCoverage.SpanCoversLine(span, 0));
     }
 
     [SkippableFact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Extract/ExtractInterfaceOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Extract/ExtractInterfaceOperationTests.cs
@@ -582,10 +582,10 @@ public class ExtractInterfaceOperationTests
             new LinePosition(0, 0),
             new LinePosition(2, 0));
 
-        Assert.True(ExtractInterfaceOperation.SpanCoversLine(span, 1));
-        Assert.True(ExtractInterfaceOperation.SpanCoversLine(span, 2));
-        Assert.False(ExtractInterfaceOperation.SpanCoversLine(span, 3));
-        Assert.False(ExtractInterfaceOperation.SpanCoversLine(span, 0));
+        Assert.True(SpanCoverage.SpanCoversLine(span, 1));
+        Assert.True(SpanCoverage.SpanCoversLine(span, 2));
+        Assert.False(SpanCoverage.SpanCoversLine(span, 3));
+        Assert.False(SpanCoverage.SpanCoversLine(span, 0));
     }
 
     [SkippableFact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Hierarchy/PullMembersUpOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Hierarchy/PullMembersUpOperationTests.cs
@@ -575,10 +575,10 @@ public class PullMembersUpOperationTests
             new LinePosition(0, 0),
             new LinePosition(2, 0));
 
-        Assert.True(PullMembersUpOperation.SpanCoversLine(span, 1));
-        Assert.True(PullMembersUpOperation.SpanCoversLine(span, 2));
-        Assert.False(PullMembersUpOperation.SpanCoversLine(span, 3));
-        Assert.False(PullMembersUpOperation.SpanCoversLine(span, 0));
+        Assert.True(SpanCoverage.SpanCoversLine(span, 1));
+        Assert.True(SpanCoverage.SpanCoversLine(span, 2));
+        Assert.False(SpanCoverage.SpanCoversLine(span, 3));
+        Assert.False(SpanCoverage.SpanCoversLine(span, 0));
     }
 
     [SkippableFact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Hierarchy/PushMembersDownOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Hierarchy/PushMembersDownOperationTests.cs
@@ -612,10 +612,10 @@ public class PushMembersDownOperationTests
             new LinePosition(0, 0),
             new LinePosition(2, 0));
 
-        Assert.True(PushMembersDownOperation.SpanCoversLine(span, 1));
-        Assert.True(PushMembersDownOperation.SpanCoversLine(span, 2));
-        Assert.False(PushMembersDownOperation.SpanCoversLine(span, 3));
-        Assert.False(PushMembersDownOperation.SpanCoversLine(span, 0));
+        Assert.True(SpanCoverage.SpanCoversLine(span, 1));
+        Assert.True(SpanCoverage.SpanCoversLine(span, 2));
+        Assert.False(SpanCoverage.SpanCoversLine(span, 3));
+        Assert.False(SpanCoverage.SpanCoversLine(span, 0));
     }
 
     [SkippableFact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Hierarchy/UseBaseTypeOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Hierarchy/UseBaseTypeOperationTests.cs
@@ -734,10 +734,10 @@ public class UseBaseTypeOperationTests
             new LinePosition(0, 0),
             new LinePosition(2, 0));
 
-        Assert.True(UseBaseTypeOperation.SpanCoversLine(span, 1));
-        Assert.True(UseBaseTypeOperation.SpanCoversLine(span, 2));
-        Assert.False(UseBaseTypeOperation.SpanCoversLine(span, 3));
-        Assert.False(UseBaseTypeOperation.SpanCoversLine(span, 0));
+        Assert.True(SpanCoverage.SpanCoversLine(span, 1));
+        Assert.True(SpanCoverage.SpanCoversLine(span, 2));
+        Assert.False(SpanCoverage.SpanCoversLine(span, 3));
+        Assert.False(SpanCoverage.SpanCoversLine(span, 0));
     }
 
     [SkippableFact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Inline/InlineConstantOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Inline/InlineConstantOperationTests.cs
@@ -1523,9 +1523,9 @@ public class InlineConstantOperationTests
             new LinePosition(0, 0),
             new LinePosition(2, 0));
 
-        Assert.True(InlineConstantOperation.SpanCoversLine(span, 1));
-        Assert.True(InlineConstantOperation.SpanCoversLine(span, 2));
-        Assert.False(InlineConstantOperation.SpanCoversLine(span, 3));
+        Assert.True(SpanCoverage.SpanCoversLine(span, 1));
+        Assert.True(SpanCoverage.SpanCoversLine(span, 2));
+        Assert.False(SpanCoverage.SpanCoversLine(span, 3));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Replace 7 type-local line-only `SpanCoversLine` helpers (Hierarchy / Encapsulate / Extract / Inline) with shared `SpanCoverage.SpanCoversLine` (already on master from #975/#976).
- Retarget exclusive-end unit tests; refresh XML peers (including Convert docs that named deleted helpers).
- CHANGELOG Unreleased/Changed one-liner.

Closes #978

## Test plan
- [x] `dotnet test tests/RoslynMcp.Core.Tests/RoslynMcp.Core.Tests.csproj --filter "FullyQualifiedName~SpanCoversLine"` — 21 passed locally
- [ ] CI Build and Test + CodeQL green
- [ ] Copilot/Codex review threads resolved before squash-merge