### PR TITLE
refactor: extract SpanCoversLine optional-column; replace Convert/Rename duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- Replaced 4 identical Convert/Rename optional-column `SpanCoversLine` copies with shared `SpanCoverage.SpanCoversLine` (`convert_anonymous_to_class` / `convert_tuple_to_struct` / `rename_namespace` / `rename_file_to_match_type`) (#981)
 - Replaced 7 identical Hierarchy/Encapsulate/Extract/Inline `SpanCoversLine` copies with shared `SpanCoverage.SpanCoversLine` (`pull_members_up` / `push_members_down` / `use_base_type` / `encapsulate_field` / `inline_constant` / `extract_interface` / `extract_base_class`) (#978)
 - Extracted shared `SpanCoverage.SpanCoversLine` and replaced 7 identical Generate-family copies (`generate_constructor` / `generate_equals_hashcode` / `generate_overrides` / `generate_property` / `generate_tostring` / `implement_abstract` / `implement_interface`) (#975)
 - Replaced 2 identical Rename `SpanCoversColumn` copies with shared `SpanCoverage.SpanCoversColumn` (`rename_namespace` / `rename_file_to_match_type`) (#973)

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertAnonymousToClassOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertAnonymousToClassOperation.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.FindSymbols;
 using RoslynMcp.Contracts.Enums;
 using RoslynMcp.Contracts.Errors;

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertAnonymousToClassOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertAnonymousToClassOperation.cs
@@ -200,7 +200,7 @@ public sealed class ConvertAnonymousToClassOperation : RefactoringOperationBase<
     {
         var candidates = root.DescendantNodes()
             .OfType<AnonymousObjectCreationExpressionSyntax>()
-            .Where(n => SpanCoversLine(n.GetLocation().GetLineSpan(), @params.Line, @params.Column))
+            .Where(n => SpanCoverage.SpanCoversLine(n.GetLocation().GetLineSpan(), @params.Line, @params.Column))
             .ToList();
 
         if (candidates.Count == 1)
@@ -791,21 +791,6 @@ public sealed class ConvertAnonymousToClassOperation : RefactoringOperationBase<
         }
 
         return true;
-    }
-
-    internal static bool SpanCoversLine(FileLinePositionSpan span, int line, int? column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == endLine && span.EndLinePosition.Character == 0)
-            return false;
-
-        if (!column.HasValue)
-            return true;
-
-        return SpanCoverage.SpanCoversColumn(span, line, column.Value);
     }
 
 

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertAnonymousToClassOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertAnonymousToClassOperation.cs
@@ -1,8 +1,8 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Text;
 using RoslynMcp.Contracts.Enums;
 using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertAnonymousToClassOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertAnonymousToClassOperation.cs
@@ -2,7 +2,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.FindSymbols;
-using Microsoft.CodeAnalysis.Text;
 using RoslynMcp.Contracts.Enums;
 using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
@@ -792,7 +791,6 @@ public sealed class ConvertAnonymousToClassOperation : RefactoringOperationBase<
 
         return true;
     }
-
 
     private static bool TypeNameBindsToDifferentType(
         string display,

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertTupleToStructOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertTupleToStructOperation.cs
@@ -1,7 +1,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 using RoslynMcp.Contracts.Enums;
 using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
@@ -1027,7 +1026,6 @@ public sealed class ConvertTupleToStructOperation : RefactoringOperationBase<Con
 
         return -1;
     }
-
 
     private static bool TypeNameBindsToDifferentType(
         string display,

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertTupleToStructOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertTupleToStructOperation.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
 using RoslynMcp.Contracts.Enums;
 using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertTupleToStructOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertTupleToStructOperation.cs
@@ -205,7 +205,7 @@ public sealed class ConvertTupleToStructOperation : RefactoringOperationBase<Con
     {
         var candidates = root.DescendantNodes()
             .Where(n => IsTupleCreationNode(n, semanticModel))
-            .Where(n => SpanCoversLine(n.GetLocation().GetLineSpan(), @params.Line, @params.Column))
+            .Where(n => SpanCoverage.SpanCoversLine(n.GetLocation().GetLineSpan(), @params.Line, @params.Column))
             .ToList();
 
         if (candidates.Count == 1)
@@ -1026,21 +1026,6 @@ public sealed class ConvertTupleToStructOperation : RefactoringOperationBase<Con
         }
 
         return -1;
-    }
-
-    internal static bool SpanCoversLine(FileLinePositionSpan span, int line, int? column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == endLine && span.EndLinePosition.Character == 0)
-            return false;
-
-        if (!column.HasValue)
-            return true;
-
-        return SpanCoverage.SpanCoversColumn(span, line, column.Value);
     }
 
 

--- a/src/RoslynMcp.Core/Refactoring/Encapsulate/EncapsulateFieldOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Encapsulate/EncapsulateFieldOperation.cs
@@ -666,7 +666,7 @@ public sealed class EncapsulateFieldOperation : RefactoringOperationBase<Encapsu
     /// <paramref name="column"/> keeps today's fieldName + optional
     /// <paramref name="line"/> pick, including omitted-line field
     /// <c>VariableDeclaratorSyntax</c> <c>FirstOrDefault</c> and
-    /// line-only exclusive-end coverage (<see cref="SpanCoverage.SpanCoversLine"/>).
+    /// line-only exclusive-end coverage (<see cref="SpanCoverage.SpanCoversLine(FileLinePositionSpan, int)"/>).
     /// Do not force column 1 when omitted. Locals and other non-field
     /// declarators stay excluded. Column without line keeps today's
     /// <c>FirstOrDefault</c> after the fieldName filter rather than

--- a/src/RoslynMcp.Core/Refactoring/Extract/ExtractBaseClassOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/ExtractBaseClassOperation.cs
@@ -1083,7 +1083,7 @@ public sealed class ExtractBaseClassOperation : RefactoringOperationBase<Extract
     /// <paramref name="line"/> pick, including omitted-line
     /// <c>ClassDeclarationSyntax</c> <c>FirstOrDefault</c> (enum, struct,
     /// interface, and <c>DelegateDeclarationSyntax</c> do not participate)
-    /// and line-only exclusive-end coverage (<see cref="SpanCoverage.SpanCoversLine"/>).
+    /// and line-only exclusive-end coverage (<see cref="SpanCoverage.SpanCoversLine(FileLinePositionSpan, int)"/>).
     /// Do not force column 1 when omitted. Do not change
     /// omitted-line/omitted-column to <c>BaseTypeDeclarationSyntax</c> or
     /// <c>TypeDeclarationSyntax</c> FirstOrDefault. Do not add enums,

--- a/src/RoslynMcp.Core/Refactoring/Extract/ExtractInterfaceOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/ExtractInterfaceOperation.cs
@@ -517,7 +517,7 @@ public sealed class ExtractInterfaceOperation : RefactoringOperationBase<Extract
     /// <paramref name="line"/> pick, including omitted-line
     /// <c>TypeDeclarationSyntax</c> <c>FirstOrDefault</c> (enum and
     /// <c>DelegateDeclarationSyntax</c> do not participate) and
-    /// line-only exclusive-end coverage (<see cref="SpanCoverage.SpanCoversLine"/>).
+    /// line-only exclusive-end coverage (<see cref="SpanCoverage.SpanCoversLine(FileLinePositionSpan, int)"/>).
     /// Do not force column 1 when omitted. Do not change
     /// omitted-line/omitted-column to <c>BaseTypeDeclarationSyntax</c>
     /// FirstOrDefault. Do not add enums or delegates to the omitted-line

--- a/src/RoslynMcp.Core/Refactoring/Generate/GenerateConstructorOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GenerateConstructorOperation.cs
@@ -1230,7 +1230,7 @@ public sealed class GenerateConstructorOperation : RefactoringOperationBase<Gene
     /// <paramref name="column"/> keeps today's typeName + optional
     /// <paramref name="line"/> pick, including omitted-line
     /// <c>FirstOrDefault</c> and line-only exclusive-end coverage
-    /// (<see cref="SpanCoverage.SpanCoversLine"/>). Do not force column 1 when omitted.
+    /// (<see cref="SpanCoverage.SpanCoversLine(FileLinePositionSpan, int)"/>). Do not force column 1 when omitted.
     /// Column without line keeps today's first-match after the typeName
     /// filter rather than substituting each candidate's own start line.
     /// When column is set with line, picks the type whose identifier or

--- a/src/RoslynMcp.Core/Refactoring/Generate/GenerateEqualsHashCodeOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GenerateEqualsHashCodeOperation.cs
@@ -929,7 +929,7 @@ public sealed class GenerateEqualsHashCodeOperation : RefactoringOperationBase<G
     /// <paramref name="column"/> keeps today's typeName + optional
     /// <paramref name="line"/> pick, including omitted-line
     /// <c>FirstOrDefault</c> and line-only exclusive-end coverage
-    /// (<see cref="SpanCoverage.SpanCoversLine"/>). Do not force column 1 when omitted.
+    /// (<see cref="SpanCoverage.SpanCoversLine(FileLinePositionSpan, int)"/>). Do not force column 1 when omitted.
     /// Column without line keeps today's first-match after the typeName
     /// filter rather than substituting each candidate's own start line.
     /// When column is set with line, picks the type whose identifier or

--- a/src/RoslynMcp.Core/Refactoring/Generate/GenerateOverridesOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GenerateOverridesOperation.cs
@@ -1212,7 +1212,7 @@ public sealed class GenerateOverridesOperation : RefactoringOperationBase<Genera
     /// <paramref name="column"/> keeps today's typeName + optional
     /// <paramref name="line"/> pick, including omitted-line
     /// <c>FirstOrDefault</c> and line-only exclusive-end coverage
-    /// (<see cref="SpanCoverage.SpanCoversLine"/>). Do not force column 1 when omitted.
+    /// (<see cref="SpanCoverage.SpanCoversLine(FileLinePositionSpan, int)"/>). Do not force column 1 when omitted.
     /// Column without line keeps today's first-match after the typeName
     /// filter rather than substituting each candidate's own start line.
     /// When column is set with line, picks the type whose identifier or

--- a/src/RoslynMcp.Core/Refactoring/Generate/GeneratePropertyOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GeneratePropertyOperation.cs
@@ -719,7 +719,7 @@ public sealed class GeneratePropertyOperation : RefactoringOperationBase<Generat
     /// <paramref name="line"/> pick, including omitted-line
     /// <c>BaseTypeDeclarationSyntax</c> <c>FirstOrDefault</c> (enum
     /// participates) and line-only exclusive-end coverage
-    /// (<see cref="SpanCoverage.SpanCoversLine"/>). Do not force column 1 when omitted.
+    /// (<see cref="SpanCoverage.SpanCoversLine(FileLinePositionSpan, int)"/>). Do not force column 1 when omitted.
     /// Do not change omitted-line/omitted-column to
     /// <c>TypeDeclarationSyntax</c> / <c>ClassDeclarationSyntax</c>
     /// FirstOrDefault. Column without line keeps today's first-match after

--- a/src/RoslynMcp.Core/Refactoring/Generate/GenerateToStringOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GenerateToStringOperation.cs
@@ -790,7 +790,7 @@ public sealed class GenerateToStringOperation : RefactoringOperationBase<Generat
     /// <paramref name="line"/> pick, including omitted-line
     /// <c>TypeDeclarationSyntax</c> <c>FirstOrDefault</c> (enum and
     /// <c>DelegateDeclarationSyntax</c> do not participate) and
-    /// line-only exclusive-end coverage (<see cref="SpanCoverage.SpanCoversLine"/>).
+    /// line-only exclusive-end coverage (<see cref="SpanCoverage.SpanCoversLine(FileLinePositionSpan, int)"/>).
     /// Do not force column 1 when omitted. Do not change
     /// omitted-line/omitted-column to <c>BaseTypeDeclarationSyntax</c>
     /// FirstOrDefault. Do not add enums or delegates to the omitted-line

--- a/src/RoslynMcp.Core/Refactoring/Generate/ImplementAbstractOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/ImplementAbstractOperation.cs
@@ -1627,7 +1627,7 @@ public sealed class ImplementAbstractOperation : RefactoringOperationBase<Implem
     /// <paramref name="line"/> pick, including omitted-line
     /// <c>BaseTypeDeclarationSyntax</c> <c>FirstOrDefault</c> (enum
     /// participates; <c>DelegateDeclarationSyntax</c> does not) and
-    /// line-only exclusive-end coverage (<see cref="SpanCoverage.SpanCoversLine"/>).
+    /// line-only exclusive-end coverage (<see cref="SpanCoverage.SpanCoversLine(FileLinePositionSpan, int)"/>).
     /// Do not force column 1 when omitted. Do not change
     /// omitted-line/omitted-column to <c>TypeDeclarationSyntax</c> /
     /// <c>ClassDeclarationSyntax</c> FirstOrDefault. Do not add delegates

--- a/src/RoslynMcp.Core/Refactoring/Generate/ImplementInterfaceOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/ImplementInterfaceOperation.cs
@@ -1372,7 +1372,7 @@ public sealed class ImplementInterfaceOperation : RefactoringOperationBase<Imple
     /// <paramref name="column"/> keeps today's typeName + optional
     /// <paramref name="line"/> pick, including omitted-line
     /// <c>FirstOrDefault</c> and line-only exclusive-end coverage
-    /// (<see cref="SpanCoverage.SpanCoversLine"/>). Do not force column 1 when omitted.
+    /// (<see cref="SpanCoverage.SpanCoversLine(FileLinePositionSpan, int)"/>). Do not force column 1 when omitted.
     /// Column without line keeps today's first-match after the typeName
     /// filter rather than substituting each candidate's own start line.
     /// When column is set with line, picks the type whose identifier or

--- a/src/RoslynMcp.Core/Refactoring/Hierarchy/PullMembersUpOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Hierarchy/PullMembersUpOperation.cs
@@ -204,7 +204,7 @@ public sealed class PullMembersUpOperation : RefactoringOperationBase<PullMember
     /// <paramref name="line"/> pick, including omitted-line
     /// <c>TypeDeclarationSyntax</c> <c>FirstOrDefault</c> (enum and
     /// <c>DelegateDeclarationSyntax</c> do not participate) and
-    /// line-only exclusive-end coverage (<see cref="SpanCoverage.SpanCoversLine"/>).
+    /// line-only exclusive-end coverage (<see cref="SpanCoverage.SpanCoversLine(FileLinePositionSpan, int)"/>).
     /// Do not force column 1 when omitted. Do not change
     /// omitted-line/omitted-column to <c>BaseTypeDeclarationSyntax</c>
     /// FirstOrDefault. Do not add enums or delegates to the omitted-line

--- a/src/RoslynMcp.Core/Refactoring/Hierarchy/PushMembersDownOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Hierarchy/PushMembersDownOperation.cs
@@ -226,7 +226,7 @@ public sealed class PushMembersDownOperation : RefactoringOperationBase<PushMemb
     /// <paramref name="line"/> pick, including omitted-line
     /// <c>TypeDeclarationSyntax</c> <c>FirstOrDefault</c> (enum and
     /// <c>DelegateDeclarationSyntax</c> do not participate) and
-    /// line-only exclusive-end coverage (<see cref="SpanCoverage.SpanCoversLine"/>).
+    /// line-only exclusive-end coverage (<see cref="SpanCoverage.SpanCoversLine(FileLinePositionSpan, int)"/>).
     /// Do not force column 1 when omitted. Do not change
     /// omitted-line/omitted-column to <c>BaseTypeDeclarationSyntax</c>
     /// FirstOrDefault. Do not add enums or delegates to the omitted-line

--- a/src/RoslynMcp.Core/Refactoring/Hierarchy/UseBaseTypeOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Hierarchy/UseBaseTypeOperation.cs
@@ -504,7 +504,7 @@ public sealed class UseBaseTypeOperation : RefactoringOperationBase<UseBaseTypeP
     /// <paramref name="line"/> pick, including omitted-line
     /// <c>TypeDeclarationSyntax</c> <c>PickOmittedLineMatch</c> (enum and
     /// <c>DelegateDeclarationSyntax</c> do not participate) and line-only
-    /// exclusive-end coverage (<see cref="SpanCoverage.SpanCoversLine"/>). Do not force
+    /// exclusive-end coverage (<see cref="SpanCoverage.SpanCoversLine(FileLinePositionSpan, int)"/>). Do not force
     /// column 1 when omitted. Do not change omitted-line/omitted-column to
     /// <c>BaseTypeDeclarationSyntax</c> FirstOrDefault. Do not add enums
     /// or delegates to the omitted-line set. Column without line keeps

--- a/src/RoslynMcp.Core/Refactoring/Inline/InlineConstantOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Inline/InlineConstantOperation.cs
@@ -496,7 +496,7 @@ public sealed class InlineConstantOperation : RefactoringOperationBase<InlineCon
     /// that 1-based line (identifier preferred, then smallest covering
     /// declarator/field — same exclusive-end coverage as
     /// <c>EncapsulateFieldOperation.FindFieldDeclarator</c> /
-    /// <see cref="SpanCoverage.SpanCoversLine"/>). When column is set with line, same
+    /// <see cref="SpanCoverage.SpanCoversLine(FileLinePositionSpan, int)"/>). When column is set with line, same
     /// covering-span rules as encapsulate_field (<c>SpanCoverage.SpanCoversColumn</c>,
     /// exclusive end). Nested types participate. Do not require the
     /// declaration to start on line — a split declaration may put the

--- a/src/RoslynMcp.Core/Refactoring/Rename/RenameFileToMatchTypeOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Rename/RenameFileToMatchTypeOperation.cs
@@ -722,7 +722,6 @@ public sealed class RenameFileToMatchTypeOperation : RefactoringOperationBase<Re
         _ => throw new RefactoringException(ErrorCodes.RoslynError, "Node is not a named type declaration.")
     };
 
-
     private static bool IdentifierCoversColumn(SyntaxNode node, int line, int column)
     {
         var identifier = GetTypeIdentifier(node);

--- a/src/RoslynMcp.Core/Refactoring/Rename/RenameFileToMatchTypeOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Rename/RenameFileToMatchTypeOperation.cs
@@ -491,7 +491,7 @@ public sealed class RenameFileToMatchTypeOperation : RefactoringOperationBase<Re
             // pick exactly. SpanCoversLine without a column is multi-line
             // declaration coverage — do not force column 1.
             var atLocation = candidates
-                .Where(t => SpanCoversLine(t.Node.GetLocation().GetLineSpan(), @params.Line.Value, column: null))
+                .Where(t => SpanCoverage.SpanCoversLine(t.Node.GetLocation().GetLineSpan(), @params.Line.Value, column: null))
                 .ToList();
 
             if (atLocation.Count == 1)
@@ -721,21 +721,6 @@ public sealed class RenameFileToMatchTypeOperation : RefactoringOperationBase<Re
         DelegateDeclarationSyntax del => del.Identifier.ValueText,
         _ => throw new RefactoringException(ErrorCodes.RoslynError, "Node is not a named type declaration.")
     };
-
-    internal static bool SpanCoversLine(FileLinePositionSpan span, int line, int? column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == endLine && span.EndLinePosition.Character == 0)
-            return false;
-
-        if (!column.HasValue)
-            return true;
-
-        return SpanCoverage.SpanCoversColumn(span, line, column.Value);
-    }
 
 
     private static bool IdentifierCoversColumn(SyntaxNode node, int line, int column)

--- a/src/RoslynMcp.Core/Refactoring/Rename/RenameNamespaceOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Rename/RenameNamespaceOperation.cs
@@ -317,7 +317,7 @@ public sealed class RenameNamespaceOperation : RefactoringOperationBase<RenameNa
             // pick exactly. SpanCoversLine without a column is multi-line
             // declaration coverage — do not force column 1.
             var atLocation = matches
-                .Where(m => SpanCoversLine(m.Declaration.GetLocation().GetLineSpan(), line.Value, column: null))
+                .Where(m => SpanCoverage.SpanCoversLine(m.Declaration.GetLocation().GetLineSpan(), line.Value, column: null))
                 .ToList();
 
             if (atLocation.Count == 1)
@@ -482,21 +482,6 @@ public sealed class RenameNamespaceOperation : RefactoringOperationBase<RenameNa
         return current;
     }
 
-    internal static bool SpanCoversLine(FileLinePositionSpan span, int line, int? column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == endLine && span.EndLinePosition.Character == 0)
-            return false;
-
-        if (!column.HasValue)
-            return true;
-
-        return SpanCoverage.SpanCoversColumn(span, line, column.Value);
-    }
-
     /// <summary>
     /// True when the identifier token for <paramref name="candidate"/> in
     /// <paramref name="declaration"/>'s name covers the column. Walks from
@@ -568,7 +553,6 @@ public sealed class RenameNamespaceOperation : RefactoringOperationBase<RenameNa
                 break;
         }
     }
-
 
     private static IEnumerable<INamespaceSymbol> EnumerateNamespaceChain(INamespaceSymbol symbol)
     {

--- a/src/RoslynMcp.Core/Resolution/SpanCoverage.cs
+++ b/src/RoslynMcp.Core/Resolution/SpanCoverage.cs
@@ -49,5 +49,21 @@ internal static class SpanCoverage
             return false;
         return true;
     }
+
+    /// <summary>
+    /// 1-based line coverage with optional column. When <paramref name="column"/>
+    /// is omitted, same exclusive-end line rules as <see cref="SpanCoversLine(FileLinePositionSpan, int)"/>.
+    /// When set, also requires <see cref="SpanCoversColumn"/>.
+    /// </summary>
+    internal static bool SpanCoversLine(FileLinePositionSpan span, int line, int? column)
+    {
+        if (!SpanCoversLine(span, line))
+            return false;
+
+        if (!column.HasValue)
+            return true;
+
+        return SpanCoversColumn(span, line, column.Value);
+    }
 }
 

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertAnonymousToClassOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertAnonymousToClassOperationTests.cs
@@ -578,10 +578,10 @@ public class ConvertAnonymousToClassOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(ConvertAnonymousToClassOperation.SpanCoversLine(span, line, startCol));
-        Assert.True(ConvertAnonymousToClassOperation.SpanCoversLine(span, line, endCol - 1));
-        Assert.False(ConvertAnonymousToClassOperation.SpanCoversLine(span, line, endCol));
-        Assert.False(ConvertAnonymousToClassOperation.SpanCoversLine(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversLine(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversLine(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversLine(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversLine(span, line, startCol - 1));
 
         const string multiLineSource = """
             class C
@@ -603,10 +603,10 @@ public class ConvertAnonymousToClassOperationTests
         var endLine = multiLineSpan.EndLinePosition.Line + 1;
 
         for (var coveredLine = startLine; coveredLine <= endLine; coveredLine++)
-            Assert.True(ConvertAnonymousToClassOperation.SpanCoversLine(multiLineSpan, coveredLine, column: null));
+            Assert.True(SpanCoverage.SpanCoversLine(multiLineSpan, coveredLine, column: null));
 
-        Assert.False(ConvertAnonymousToClassOperation.SpanCoversLine(multiLineSpan, startLine - 1, column: null));
-        Assert.False(ConvertAnonymousToClassOperation.SpanCoversLine(multiLineSpan, endLine + 1, column: null));
+        Assert.False(SpanCoverage.SpanCoversLine(multiLineSpan, startLine - 1, column: null));
+        Assert.False(SpanCoverage.SpanCoversLine(multiLineSpan, endLine + 1, column: null));
     }
 
     [Fact]
@@ -617,9 +617,9 @@ public class ConvertAnonymousToClassOperationTests
             new LinePosition(0, 0),
             new LinePosition(2, 0));
 
-        Assert.True(ConvertAnonymousToClassOperation.SpanCoversLine(span, 1, column: null));
-        Assert.True(ConvertAnonymousToClassOperation.SpanCoversLine(span, 2, column: null));
-        Assert.False(ConvertAnonymousToClassOperation.SpanCoversLine(span, 3, column: null));
+        Assert.True(SpanCoverage.SpanCoversLine(span, 1, column: null));
+        Assert.True(SpanCoverage.SpanCoversLine(span, 2, column: null));
+        Assert.False(SpanCoverage.SpanCoversLine(span, 3, column: null));
     }
 
     #endregion

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertTupleToStructOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertTupleToStructOperationTests.cs
@@ -583,10 +583,10 @@ public class ConvertTupleToStructOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(ConvertTupleToStructOperation.SpanCoversLine(span, line, startCol));
-        Assert.True(ConvertTupleToStructOperation.SpanCoversLine(span, line, endCol - 1));
-        Assert.False(ConvertTupleToStructOperation.SpanCoversLine(span, line, endCol));
-        Assert.False(ConvertTupleToStructOperation.SpanCoversLine(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversLine(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversLine(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversLine(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversLine(span, line, startCol - 1));
 
         const string multiLineSource = """
             class C
@@ -608,10 +608,10 @@ public class ConvertTupleToStructOperationTests
         var endLine = multiLineSpan.EndLinePosition.Line + 1;
 
         for (var coveredLine = startLine; coveredLine <= endLine; coveredLine++)
-            Assert.True(ConvertTupleToStructOperation.SpanCoversLine(multiLineSpan, coveredLine, column: null));
+            Assert.True(SpanCoverage.SpanCoversLine(multiLineSpan, coveredLine, column: null));
 
-        Assert.False(ConvertTupleToStructOperation.SpanCoversLine(multiLineSpan, startLine - 1, column: null));
-        Assert.False(ConvertTupleToStructOperation.SpanCoversLine(multiLineSpan, endLine + 1, column: null));
+        Assert.False(SpanCoverage.SpanCoversLine(multiLineSpan, startLine - 1, column: null));
+        Assert.False(SpanCoverage.SpanCoversLine(multiLineSpan, endLine + 1, column: null));
     }
 
     [Fact]
@@ -622,9 +622,9 @@ public class ConvertTupleToStructOperationTests
             new LinePosition(0, 0),
             new LinePosition(2, 0));
 
-        Assert.True(ConvertTupleToStructOperation.SpanCoversLine(span, 1, column: null));
-        Assert.True(ConvertTupleToStructOperation.SpanCoversLine(span, 2, column: null));
-        Assert.False(ConvertTupleToStructOperation.SpanCoversLine(span, 3, column: null));
+        Assert.True(SpanCoverage.SpanCoversLine(span, 1, column: null));
+        Assert.True(SpanCoverage.SpanCoversLine(span, 2, column: null));
+        Assert.False(SpanCoverage.SpanCoversLine(span, 3, column: null));
     }
 
     #endregion

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Rename/RenameFileToMatchTypeOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Rename/RenameFileToMatchTypeOperationTests.cs
@@ -565,9 +565,9 @@ public class RenameFileToMatchTypeOperationTests
             new LinePosition(0, 0),
             new LinePosition(2, 0));
 
-        Assert.True(RenameFileToMatchTypeOperation.SpanCoversLine(span, 1, column: null));
-        Assert.True(RenameFileToMatchTypeOperation.SpanCoversLine(span, 2, column: null));
-        Assert.False(RenameFileToMatchTypeOperation.SpanCoversLine(span, 3, column: null));
+        Assert.True(SpanCoverage.SpanCoversLine(span, 1, column: null));
+        Assert.True(SpanCoverage.SpanCoversLine(span, 2, column: null));
+        Assert.False(SpanCoverage.SpanCoversLine(span, 3, column: null));
     }
 
     #endregion

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Rename/RenameNamespaceOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Rename/RenameNamespaceOperationTests.cs
@@ -1424,10 +1424,10 @@ public class RenameNamespaceOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(RenameNamespaceOperation.SpanCoversLine(span, line, startCol));
-        Assert.True(RenameNamespaceOperation.SpanCoversLine(span, line, endCol - 1));
-        Assert.False(RenameNamespaceOperation.SpanCoversLine(span, line, endCol));
-        Assert.False(RenameNamespaceOperation.SpanCoversLine(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversLine(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversLine(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversLine(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversLine(span, line, startCol - 1));
 
         const string multiLineSource = """
             namespace A
@@ -1443,10 +1443,10 @@ public class RenameNamespaceOperationTests
         var endLine = multiLineSpan.EndLinePosition.Line + 1;
 
         for (var coveredLine = startLine; coveredLine <= endLine; coveredLine++)
-            Assert.True(RenameNamespaceOperation.SpanCoversLine(multiLineSpan, coveredLine, column: null));
+            Assert.True(SpanCoverage.SpanCoversLine(multiLineSpan, coveredLine, column: null));
 
-        Assert.False(RenameNamespaceOperation.SpanCoversLine(multiLineSpan, startLine - 1, column: null));
-        Assert.False(RenameNamespaceOperation.SpanCoversLine(multiLineSpan, endLine + 1, column: null));
+        Assert.False(SpanCoverage.SpanCoversLine(multiLineSpan, startLine - 1, column: null));
+        Assert.False(SpanCoverage.SpanCoversLine(multiLineSpan, endLine + 1, column: null));
     }
 
     [Fact]
@@ -1457,9 +1457,9 @@ public class RenameNamespaceOperationTests
             new LinePosition(0, 0),
             new LinePosition(2, 0));
 
-        Assert.True(RenameNamespaceOperation.SpanCoversLine(span, 1, column: null));
-        Assert.True(RenameNamespaceOperation.SpanCoversLine(span, 2, column: null));
-        Assert.False(RenameNamespaceOperation.SpanCoversLine(span, 3, column: null));
+        Assert.True(SpanCoverage.SpanCoversLine(span, 1, column: null));
+        Assert.True(SpanCoverage.SpanCoversLine(span, 2, column: null));
+        Assert.False(SpanCoverage.SpanCoversLine(span, 3, column: null));
     }
 
     [SkippableFact]


### PR DESCRIPTION
## Summary
- Add shared `SpanCoverage.SpanCoversLine(span, line, int? column)` (line-only gate + optional `SpanCoversColumn`).
- Replace 4 identical Convert/Rename type-local copies (`convert_anonymous_to_class` / `convert_tuple_to_struct` / `rename_namespace` / `rename_file_to_match_type`).
- Retarget exclusive-end / with-column unit tests; disambiguate line-only `SpanCoversLine` XML crefs (CS0419).
- CHANGELOG Unreleased/Changed one-liner.

Closes #981

## Test plan
- [x] `dotnet test tests/RoslynMcp.Core.Tests/RoslynMcp.Core.Tests.csproj --filter "FullyQualifiedName~SpanCoversLine"` — 21 passed locally
- [ ] CI Build and Test + Code Quality green
- [ ] Copilot/Codex review threads resolved before squash-merge