### PR TITLE
refactor: replace AddNullChecks SpanCoversColumn with SpanCoverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- Replaced `AddNullChecksOperation` type-local `SpanCoversColumn` with shared `SpanCoverage.SpanCoversColumn` (`add_null_checks`) (#983)
 - Replaced 4 identical Convert/Rename optional-column `SpanCoversLine` copies with shared `SpanCoverage.SpanCoversLine` (`convert_anonymous_to_class` / `convert_tuple_to_struct` / `rename_namespace` / `rename_file_to_match_type`) (#981)
 - Replaced 7 identical Hierarchy/Encapsulate/Extract/Inline `SpanCoversLine` copies with shared `SpanCoverage.SpanCoversLine` (`pull_members_up` / `push_members_down` / `use_base_type` / `encapsulate_field` / `inline_constant` / `extract_interface` / `extract_base_class`) (#978)
 - Extracted shared `SpanCoverage.SpanCoversLine` and replaced 7 identical Generate-family copies (`generate_constructor` / `generate_equals_hashcode` / `generate_overrides` / `generate_property` / `generate_tostring` / `implement_abstract` / `implement_interface`) (#975)

--- a/src/RoslynMcp.Core/Refactoring/Generate/AddNullChecksOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/AddNullChecksOperation.cs
@@ -7,6 +7,7 @@ using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
 using RoslynMcp.Core.Refactoring.Utilities;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 
 namespace RoslynMcp.Core.Refactoring.Generate;
@@ -393,13 +394,13 @@ public sealed class AddNullChecksOperation : RefactoringOperationBase<AddNullChe
 
     private static bool MemberCoversColumn(SyntaxNode node, int line, int column) =>
         IdentifierCoversColumn(node, line, column) ||
-        SpanCoversColumn(node.GetLocation().GetLineSpan(), line, column);
+        SpanCoverage.SpanCoversColumn(node.GetLocation().GetLineSpan(), line, column);
 
     private static bool IdentifierCoversColumn(SyntaxNode node, int line, int column)
     {
         var identifier = GetIdentifier(node);
         return identifier != default &&
-               SpanCoversColumn(identifier.GetLocation().GetLineSpan(), line, column);
+               SpanCoverage.SpanCoversColumn(identifier.GetLocation().GetLineSpan(), line, column);
     }
 
     private static SyntaxToken GetIdentifier(SyntaxNode node) => node switch
@@ -408,30 +409,6 @@ public sealed class AddNullChecksOperation : RefactoringOperationBase<AddNullChe
         ConstructorDeclarationSyntax constructor => constructor.Identifier,
         _ => default
     };
-
-    /// <summary>
-    /// 1-based line/column coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>
-    /// is exclusive, so <paramref name="column"/> must be strictly before the
-    /// exclusive end (reject <c>column &gt;= endCol</c>). Treating the end as
-    /// inclusive would let the first character of an adjacent method also
-    /// match the previous declaration. Same helper as
-    /// <c>SpanCoverage.SpanCoversColumn</c>.
-    /// </summary>
-    internal static bool SpanCoversColumn(FileLinePositionSpan span, int line, int column)
-    {
-        var startLine = span.StartLinePosition.Line + 1;
-        var endLine = span.EndLinePosition.Line + 1;
-        var startCol = span.StartLinePosition.Character + 1;
-        var endCol = span.EndLinePosition.Character + 1;
-
-        if (line < startLine || line > endLine)
-            return false;
-        if (line == startLine && column < startCol)
-            return false;
-        if (line == endLine && column >= endCol)
-            return false;
-        return true;
-    }
 
     private static BlockSyntax? GetBody(SyntaxNode node) => node switch
     {

--- a/src/RoslynMcp.Core/Refactoring/Generate/GenerateOverridesOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GenerateOverridesOperation.cs
@@ -1217,7 +1217,7 @@ public sealed class GenerateOverridesOperation : RefactoringOperationBase<Genera
     /// filter rather than substituting each candidate's own start line.
     /// When column is set with line, picks the type whose identifier or
     /// declaration span covers that 1-based column (same exclusive-end
-    /// coverage as <c>AddNullChecksOperation.SpanCoversColumn</c>). Prefer
+    /// coverage as <see cref="SpanCoverage.SpanCoversColumn"/>). Prefer
     /// the identifier hit, then the smallest containing type. Nested types
     /// participate (<c>DescendantNodes</c>). Do not require the declaration
     /// to start on <paramref name="line"/> when column is set — a split

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Generate/AddNullChecksOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Generate/AddNullChecksOperationTests.cs
@@ -5,6 +5,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Generate;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 using Xunit;
 
@@ -398,10 +399,10 @@ public class AddNullChecksOperationTests
         var startCol = span.StartLinePosition.Character + 1;
         var endCol = span.EndLinePosition.Character + 1;
 
-        Assert.True(AddNullChecksOperation.SpanCoversColumn(span, line, startCol));
-        Assert.True(AddNullChecksOperation.SpanCoversColumn(span, line, endCol - 1));
-        Assert.False(AddNullChecksOperation.SpanCoversColumn(span, line, endCol));
-        Assert.False(AddNullChecksOperation.SpanCoversColumn(span, line, startCol - 1));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, startCol));
+        Assert.True(SpanCoverage.SpanCoversColumn(span, line, endCol - 1));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, endCol));
+        Assert.False(SpanCoverage.SpanCoversColumn(span, line, startCol - 1));
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- Delete type-local `AddNullChecksOperation.SpanCoversColumn`; call shared `SpanCoverage.SpanCoversColumn` at both coverage call sites.
- Retarget `SpanCoversColumn_TreatsEndAsExclusive` to `SpanCoverage`; refresh GenerateOverrides XML peer that named the deleted helper.
- CHANGELOG Unreleased/Changed one-liner.

Closes #983

## Test plan
- [x] `dotnet test tests/RoslynMcp.Core.Tests/RoslynMcp.Core.Tests.csproj --filter \"FullyQualifiedName~AddNullChecksOperationTests.SpanCoversColumn|FullyQualifiedName~AddNullChecksOperationTests.AddNullChecks_Column\"` — 5 passed locally
- [ ] CI Build and Test + Code Quality green
- [ ] Copilot/Codex review threads resolved before squash-merge