### PR TITLE
refactor: extract SignatureReferenceHelpers; replace 4 Signature-family copies (#986)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- Extracted shared `SignatureReferenceHelpers` and replaced 4 identical Signature-family copies (`add_parameter` / `remove_parameter` / `reorder_parameters` / `change_return_type`) (#986)
 - Replaced `AddNullChecksOperation` type-local `SpanCoversColumn` with shared `SpanCoverage.SpanCoversColumn` (`add_null_checks`) (#983)
 - Replaced 4 identical Convert/Rename optional-column `SpanCoversLine` copies with shared `SpanCoverage.SpanCoversLine` (`convert_anonymous_to_class` / `convert_tuple_to_struct` / `rename_namespace` / `rename_file_to_match_type`) (#981)
 - Replaced 7 identical Hierarchy/Encapsulate/Extract/Inline `SpanCoversLine` copies with shared `SpanCoverage.SpanCoversLine` (`pull_members_up` / `push_members_down` / `use_base_type` / `encapsulate_field` / `inline_constant` / `extract_interface` / `extract_base_class`) (#978)

--- a/src/RoslynMcp.Core/Refactoring/Signature/AddParameterOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Signature/AddParameterOperation.cs
@@ -340,7 +340,6 @@ public sealed class AddParameterOperation : RefactoringOperationBase<AddParamete
     private static bool IdentifierCoversColumn(MethodDeclarationSyntax method, int line, int column) =>
         SpanCoverage.SpanCoversColumn(method.Identifier.GetLocation().GetLineSpan(), line, column);
 
-
     internal static int ComputeInsertionIndex(ParameterListSyntax list, int position)
     {
         var count = list.Parameters.Count;
@@ -557,11 +556,11 @@ public sealed class AddParameterOperation : RefactoringOperationBase<AddParamete
                         continue;
 
                     var node = root.FindNode(location.Location.SourceSpan, getInnermostNodeForTie: true);
-                    if (IsDeclarationName(node, location.Location.SourceSpan))
+                    if (SignatureReferenceHelpers.IsDeclarationName(node, location.Location.SourceSpan))
                         continue;
 
                     var invocation = node.AncestorsAndSelf().OfType<InvocationExpressionSyntax>().FirstOrDefault();
-                    if (invocation != null && IsInvokedMethodName(invocation, location.Location.SourceSpan))
+                    if (invocation != null && SignatureReferenceHelpers.IsInvokedMethodName(invocation, location.Location.SourceSpan))
                     {
                         if (!seen.Add((document.Id, invocation.Span)))
                             continue;
@@ -570,7 +569,7 @@ public sealed class AddParameterOperation : RefactoringOperationBase<AddParamete
                         continue;
                     }
 
-                    if (IsNameOfArgument(node))
+                    if (SignatureReferenceHelpers.IsNameOfArgument(node))
                         continue;
 
                     throw new RefactoringException(
@@ -895,40 +894,6 @@ public sealed class AddParameterOperation : RefactoringOperationBase<AddParamete
     private static bool IsDefaultValueExpression(ExpressionSyntax expression) =>
         expression.IsKind(SyntaxKind.DefaultLiteralExpression) ||
         expression is DefaultExpressionSyntax;
-
-    private static bool IsDeclarationName(SyntaxNode node, TextSpan referenceSpan)
-    {
-        return node.AncestorsAndSelf().OfType<MethodDeclarationSyntax>()
-            .Any(m => m.Identifier.Span.IntersectsWith(referenceSpan));
-    }
-
-    private static bool IsInvokedMethodName(InvocationExpressionSyntax invocation, TextSpan referenceSpan)
-    {
-        if (invocation.ArgumentList.Span.Contains(referenceSpan))
-            return false;
-
-        return invocation.Expression switch
-        {
-            IdentifierNameSyntax identifier => identifier.Span.IntersectsWith(referenceSpan),
-            MemberAccessExpressionSyntax member => member.Name.Span.IntersectsWith(referenceSpan),
-            MemberBindingExpressionSyntax binding => binding.Name.Span.IntersectsWith(referenceSpan),
-            _ => invocation.Expression.Span.IntersectsWith(referenceSpan)
-        };
-    }
-
-    private static bool IsNameOfArgument(SyntaxNode node)
-    {
-        foreach (var invocation in node.AncestorsAndSelf().OfType<InvocationExpressionSyntax>())
-        {
-            if (invocation.Expression is IdentifierNameSyntax identifier &&
-                identifier.Identifier.Text == "nameof")
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
 
     private static bool IsParams(ParameterSyntax parameter) =>
         parameter.Modifiers.Any(m => m.IsKind(SyntaxKind.ParamsKeyword));

--- a/src/RoslynMcp.Core/Refactoring/Signature/ChangeReturnTypeOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Signature/ChangeReturnTypeOperation.cs
@@ -472,7 +472,6 @@ public sealed class ChangeReturnTypeOperation : RefactoringOperationBase<ChangeR
     private static bool IdentifierCoversColumn(MethodDeclarationSyntax method, int line, int column) =>
         SpanCoverage.SpanCoversColumn(method.Identifier.GetLocation().GetLineSpan(), line, column);
 
-
     private async Task<List<IMethodSymbol>> GetRelatedMethodsAsync(
         IMethodSymbol method,
         bool updateOverrides,
@@ -869,20 +868,20 @@ public sealed class ChangeReturnTypeOperation : RefactoringOperationBase<ChangeR
                         continue;
 
                     var node = root.FindNode(location.Location.SourceSpan, getInnermostNodeForTie: true);
-                    if (IsDeclarationName(node, location.Location.SourceSpan))
+                    if (SignatureReferenceHelpers.IsDeclarationName(node, location.Location.SourceSpan))
                         continue;
 
                     var model = await document.GetSemanticModelAsync(cancellationToken)
                         ?? throw new RefactoringException(ErrorCodes.RoslynError, "Could not parse file.");
 
                     var invocation = node.AncestorsAndSelf().OfType<InvocationExpressionSyntax>().FirstOrDefault();
-                    if (invocation != null && IsInvokedMethodName(invocation, location.Location.SourceSpan))
+                    if (invocation != null && SignatureReferenceHelpers.IsInvokedMethodName(invocation, location.Location.SourceSpan))
                     {
                         ValidateInvocationResultContext(invocation, newReturnType, model);
                         continue;
                     }
 
-                    if (IsNameOfArgument(node))
+                    if (SignatureReferenceHelpers.IsNameOfArgument(node))
                         continue;
 
                     if (MethodGroupStillCompatible(node, newReturnType, model))
@@ -1174,40 +1173,6 @@ public sealed class ChangeReturnTypeOperation : RefactoringOperationBase<ChangeR
         }
 
         return RefactoringResult.PreviewResult(operationId, pendingChanges);
-    }
-
-    private static bool IsDeclarationName(SyntaxNode node, TextSpan referenceSpan)
-    {
-        return node.AncestorsAndSelf().OfType<MethodDeclarationSyntax>()
-            .Any(m => m.Identifier.Span.IntersectsWith(referenceSpan));
-    }
-
-    private static bool IsInvokedMethodName(InvocationExpressionSyntax invocation, TextSpan referenceSpan)
-    {
-        if (invocation.ArgumentList.Span.Contains(referenceSpan))
-            return false;
-
-        return invocation.Expression switch
-        {
-            IdentifierNameSyntax identifier => identifier.Span.IntersectsWith(referenceSpan),
-            MemberAccessExpressionSyntax member => member.Name.Span.IntersectsWith(referenceSpan),
-            MemberBindingExpressionSyntax binding => binding.Name.Span.IntersectsWith(referenceSpan),
-            _ => invocation.Expression.Span.IntersectsWith(referenceSpan)
-        };
-    }
-
-    private static bool IsNameOfArgument(SyntaxNode node)
-    {
-        foreach (var invocation in node.AncestorsAndSelf().OfType<InvocationExpressionSyntax>())
-        {
-            if (invocation.Expression is IdentifierNameSyntax identifier &&
-                identifier.Identifier.Text == "nameof")
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     private static bool HasSourceDeclaration(IMethodSymbol method) =>

--- a/src/RoslynMcp.Core/Refactoring/Signature/RemoveParameterOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Signature/RemoveParameterOperation.cs
@@ -333,7 +333,6 @@ public sealed class RemoveParameterOperation : RefactoringOperationBase<RemovePa
     private static bool IdentifierCoversColumn(MethodDeclarationSyntax method, int line, int column) =>
         SpanCoverage.SpanCoversColumn(method.Identifier.GetLocation().GetLineSpan(), line, column);
 
-
     internal static IParameterSymbol FindParameter(IMethodSymbol method, string name)
     {
         var normalized = NormalizeIdentifier(name);
@@ -473,11 +472,11 @@ public sealed class RemoveParameterOperation : RefactoringOperationBase<RemovePa
                         continue;
 
                     var node = root.FindNode(location.Location.SourceSpan, getInnermostNodeForTie: true);
-                    if (IsDeclarationName(node, location.Location.SourceSpan))
+                    if (SignatureReferenceHelpers.IsDeclarationName(node, location.Location.SourceSpan))
                         continue;
 
                     var invocation = node.AncestorsAndSelf().OfType<InvocationExpressionSyntax>().FirstOrDefault();
-                    if (invocation != null && IsInvokedMethodName(invocation, location.Location.SourceSpan))
+                    if (invocation != null && SignatureReferenceHelpers.IsInvokedMethodName(invocation, location.Location.SourceSpan))
                     {
                         if (!seen.Add((document.Id, invocation.Span)))
                             continue;
@@ -490,7 +489,7 @@ public sealed class RemoveParameterOperation : RefactoringOperationBase<RemovePa
                         continue;
                     }
 
-                    if (IsNameOfArgument(node))
+                    if (SignatureReferenceHelpers.IsNameOfArgument(node))
                         continue;
 
                     throw new RefactoringException(
@@ -758,7 +757,7 @@ public sealed class RemoveParameterOperation : RefactoringOperationBase<RemovePa
 
     private static bool CanReplaceWithDefault(IdentifierNameSyntax identifier)
     {
-        if (IsNameOfArgument(identifier))
+        if (SignatureReferenceHelpers.IsNameOfArgument(identifier))
             return false;
 
         if (identifier.Parent is MemberAccessExpressionSyntax member && member.Expression == identifier)
@@ -794,40 +793,6 @@ public sealed class RemoveParameterOperation : RefactoringOperationBase<RemovePa
         }
 
         return true;
-    }
-
-    private static bool IsDeclarationName(SyntaxNode node, TextSpan referenceSpan)
-    {
-        return node.AncestorsAndSelf().OfType<MethodDeclarationSyntax>()
-            .Any(m => m.Identifier.Span.IntersectsWith(referenceSpan));
-    }
-
-    private static bool IsInvokedMethodName(InvocationExpressionSyntax invocation, TextSpan referenceSpan)
-    {
-        if (invocation.ArgumentList.Span.Contains(referenceSpan))
-            return false;
-
-        return invocation.Expression switch
-        {
-            IdentifierNameSyntax identifier => identifier.Span.IntersectsWith(referenceSpan),
-            MemberAccessExpressionSyntax member => member.Name.Span.IntersectsWith(referenceSpan),
-            MemberBindingExpressionSyntax binding => binding.Name.Span.IntersectsWith(referenceSpan),
-            _ => invocation.Expression.Span.IntersectsWith(referenceSpan)
-        };
-    }
-
-    private static bool IsNameOfArgument(SyntaxNode node)
-    {
-        foreach (var invocation in node.AncestorsAndSelf().OfType<InvocationExpressionSyntax>())
-        {
-            if (invocation.Expression is IdentifierNameSyntax identifier &&
-                identifier.Identifier.Text == "nameof")
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     private static bool HasSourceDeclaration(IMethodSymbol method) =>

--- a/src/RoslynMcp.Core/Refactoring/Signature/ReorderParametersOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Signature/ReorderParametersOperation.cs
@@ -475,7 +475,6 @@ public sealed class ReorderParametersOperation : RefactoringOperationBase<Reorde
     private static bool IdentifierCoversColumn(MethodDeclarationSyntax method, int line, int column) =>
         SpanCoverage.SpanCoversColumn(method.Identifier.GetLocation().GetLineSpan(), line, column);
 
-
     private async Task<List<IMethodSymbol>> GetRelatedMethodsAsync(
         IMethodSymbol method,
         bool updateOverrides,
@@ -601,11 +600,11 @@ public sealed class ReorderParametersOperation : RefactoringOperationBase<Reorde
                         continue;
 
                     var node = root.FindNode(location.Location.SourceSpan, getInnermostNodeForTie: true);
-                    if (IsDeclarationName(node, location.Location.SourceSpan))
+                    if (SignatureReferenceHelpers.IsDeclarationName(node, location.Location.SourceSpan))
                         continue;
 
                     var invocation = node.AncestorsAndSelf().OfType<InvocationExpressionSyntax>().FirstOrDefault();
-                    if (invocation != null && IsInvokedMethodName(invocation, location.Location.SourceSpan))
+                    if (invocation != null && SignatureReferenceHelpers.IsInvokedMethodName(invocation, location.Location.SourceSpan))
                     {
                         if (!seen.Add((document.Id, invocation.Span)))
                             continue;
@@ -622,7 +621,7 @@ public sealed class ReorderParametersOperation : RefactoringOperationBase<Reorde
                         continue;
                     }
 
-                    if (IsNameOfArgument(node))
+                    if (SignatureReferenceHelpers.IsNameOfArgument(node))
                         continue;
 
                     throw new RefactoringException(
@@ -852,40 +851,6 @@ public sealed class ReorderParametersOperation : RefactoringOperationBase<Reorde
         }
 
         return RefactoringResult.PreviewResult(operationId, pendingChanges);
-    }
-
-    private static bool IsDeclarationName(SyntaxNode node, TextSpan referenceSpan)
-    {
-        return node.AncestorsAndSelf().OfType<MethodDeclarationSyntax>()
-            .Any(m => m.Identifier.Span.IntersectsWith(referenceSpan));
-    }
-
-    private static bool IsInvokedMethodName(InvocationExpressionSyntax invocation, TextSpan referenceSpan)
-    {
-        if (invocation.ArgumentList.Span.Contains(referenceSpan))
-            return false;
-
-        return invocation.Expression switch
-        {
-            IdentifierNameSyntax identifier => identifier.Span.IntersectsWith(referenceSpan),
-            MemberAccessExpressionSyntax member => member.Name.Span.IntersectsWith(referenceSpan),
-            MemberBindingExpressionSyntax binding => binding.Name.Span.IntersectsWith(referenceSpan),
-            _ => invocation.Expression.Span.IntersectsWith(referenceSpan)
-        };
-    }
-
-    private static bool IsNameOfArgument(SyntaxNode node)
-    {
-        foreach (var invocation in node.AncestorsAndSelf().OfType<InvocationExpressionSyntax>())
-        {
-            if (invocation.Expression is IdentifierNameSyntax identifier &&
-                identifier.Identifier.Text == "nameof")
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     private static bool HasSourceDeclaration(IMethodSymbol method) =>

--- a/src/RoslynMcp.Core/Refactoring/Signature/SignatureReferenceHelpers.cs
+++ b/src/RoslynMcp.Core/Refactoring/Signature/SignatureReferenceHelpers.cs
@@ -1,0 +1,61 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace RoslynMcp.Core.Refactoring.Signature;
+
+/// <summary>
+/// Shared predicates for Signature-family reference filtering
+/// (declaration name vs call-site name vs nameof argument).
+/// </summary>
+internal static class SignatureReferenceHelpers
+{
+    /// <summary>
+    /// True when <paramref name="referenceSpan"/> intersects a
+    /// <see cref="MethodDeclarationSyntax"/> identifier in the ancestor chain of
+    /// <paramref name="node"/> (the method's own declaration name).
+    /// </summary>
+    internal static bool IsDeclarationName(SyntaxNode node, TextSpan referenceSpan)
+    {
+        return node.AncestorsAndSelf().OfType<MethodDeclarationSyntax>()
+            .Any(m => m.Identifier.Span.IntersectsWith(referenceSpan));
+    }
+
+    /// <summary>
+    /// True when <paramref name="referenceSpan"/> hits the invoked method name /
+    /// expression of <paramref name="invocation"/>, not an argument inside the
+    /// argument list.
+    /// </summary>
+    internal static bool IsInvokedMethodName(InvocationExpressionSyntax invocation, TextSpan referenceSpan)
+    {
+        if (invocation.ArgumentList.Span.Contains(referenceSpan))
+            return false;
+
+        return invocation.Expression switch
+        {
+            IdentifierNameSyntax identifier => identifier.Span.IntersectsWith(referenceSpan),
+            MemberAccessExpressionSyntax member => member.Name.Span.IntersectsWith(referenceSpan),
+            MemberBindingExpressionSyntax binding => binding.Name.Span.IntersectsWith(referenceSpan),
+            _ => invocation.Expression.Span.IntersectsWith(referenceSpan)
+        };
+    }
+
+    /// <summary>
+    /// True when <paramref name="node"/> sits inside a <c>nameof(...)</c>
+    /// invocation (identifier expression named nameof).
+    /// </summary>
+    internal static bool IsNameOfArgument(SyntaxNode node)
+    {
+        foreach (var invocation in node.AncestorsAndSelf().OfType<InvocationExpressionSyntax>())
+        {
+            if (invocation.Expression is IdentifierNameSyntax identifier &&
+                identifier.Identifier.Text == "nameof")
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Signature/SignatureReferenceHelpersTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Signature/SignatureReferenceHelpersTests.cs
@@ -1,0 +1,100 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using RoslynMcp.Core.Refactoring.Signature;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Refactoring.Signature;
+
+public class SignatureReferenceHelpersTests
+{
+    [Fact]
+    public void IsDeclarationName_True_WhenSpanHitsMethodIdentifier()
+    {
+        var tree = CSharpSyntaxTree.ParseText("""
+            class C
+            {
+                void M() { }
+            }
+            """);
+        var root = tree.GetRoot();
+        var method = root.DescendantNodes().OfType<MethodDeclarationSyntax>().Single();
+        var idSpan = method.Identifier.Span;
+
+        Assert.True(SignatureReferenceHelpers.IsDeclarationName(method, idSpan));
+        // Body node still walks ancestors to the method identifier.
+        Assert.True(SignatureReferenceHelpers.IsDeclarationName(method.Body!, idSpan));
+    }
+
+    [Fact]
+    public void IsDeclarationName_False_WhenSpanMissesMethodIdentifier()
+    {
+        var tree = CSharpSyntaxTree.ParseText("""
+            class C
+            {
+                void M() { int x = 1; }
+            }
+            """);
+        var root = tree.GetRoot();
+        var method = root.DescendantNodes().OfType<MethodDeclarationSyntax>().Single();
+        var local = root.DescendantNodes().OfType<VariableDeclaratorSyntax>().Single();
+
+        Assert.False(SignatureReferenceHelpers.IsDeclarationName(local, local.Identifier.Span));
+        Assert.False(SignatureReferenceHelpers.IsDeclarationName(method, local.Identifier.Span));
+    }
+
+    [Fact]
+    public void IsInvokedMethodName_True_OnIdentifierAndMemberName_False_InsideArgs()
+    {
+        var tree = CSharpSyntaxTree.ParseText("""
+            class C
+            {
+                void M()
+                {
+                    Foo(1);
+                    this.Bar(2);
+                }
+            }
+            """);
+        var root = tree.GetRoot();
+        var invocations = root.DescendantNodes().OfType<InvocationExpressionSyntax>().ToList();
+        Assert.Equal(2, invocations.Count);
+
+        var foo = invocations[0];
+        var fooName = ((IdentifierNameSyntax)foo.Expression).Identifier;
+        Assert.True(SignatureReferenceHelpers.IsInvokedMethodName(foo, fooName.Span));
+        var fooArg = foo.ArgumentList.Arguments[0];
+        Assert.False(SignatureReferenceHelpers.IsInvokedMethodName(foo, fooArg.Span));
+
+        var bar = invocations[1];
+        var barName = ((MemberAccessExpressionSyntax)bar.Expression).Name;
+        Assert.True(SignatureReferenceHelpers.IsInvokedMethodName(bar, barName.Span));
+        var barArg = bar.ArgumentList.Arguments[0];
+        Assert.False(SignatureReferenceHelpers.IsInvokedMethodName(bar, barArg.Span));
+    }
+
+    [Fact]
+    public void IsNameOfArgument_True_InsideNameof_False_Otherwise()
+    {
+        var tree = CSharpSyntaxTree.ParseText("""
+            class C
+            {
+                void M()
+                {
+                    var a = nameof(C);
+                    var b = Foo(C);
+                }
+            }
+            """);
+        var root = tree.GetRoot();
+        var nameOfId = root.DescendantNodes()
+            .OfType<IdentifierNameSyntax>()
+            .First(n => n.Identifier.Text == "C" && n.Parent is ArgumentSyntax);
+        var otherId = root.DescendantNodes()
+            .OfType<IdentifierNameSyntax>()
+            .Last(n => n.Identifier.Text == "C" && n.Parent is ArgumentSyntax);
+
+        Assert.True(SignatureReferenceHelpers.IsNameOfArgument(nameOfId));
+        Assert.False(SignatureReferenceHelpers.IsNameOfArgument(otherId));
+    }
+}


### PR DESCRIPTION
## Summary
- Extract shared `SignatureReferenceHelpers` (`IsDeclarationName` / `IsInvokedMethodName` / `IsNameOfArgument`) under `RoslynMcp.Core.Refactoring.Signature`
- Delete identical type-local triples from `AddParameterOperation`, `RemoveParameterOperation`, `ReorderParametersOperation`, and `ChangeReturnTypeOperation`; call the shared helpers
- Add focused unit tests for the three helpers; CHANGELOG Unreleased/Changed one-liner

Closes #986

## Test plan
- [x] `SignatureReferenceHelpersTests` pass
- [x] Related Signature operation tests pass (167 total matching filter)
- [ ] CI green on PR