### PR TITLE
refactor: extract TypeCoverage; replace 7 identical type-local copies (#990)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- Extracted shared `TypeCoverage` and replaced 7 identical Hierarchy/Extract/Generate copies (`pull_members_up` / `push_members_down` / `use_base_type` / `extract_interface` / `extract_base_class` / `generate_tostring` / `implement_abstract`) (#990)
 - Extracted shared `SignatureReferenceHelpers` and replaced 4 identical Signature-family copies (`add_parameter` / `remove_parameter` / `reorder_parameters` / `change_return_type`) (#986)
 - Replaced `AddNullChecksOperation` type-local `SpanCoversColumn` with shared `SpanCoverage.SpanCoversColumn` (`add_null_checks`) (#983)
 - Replaced 4 identical Convert/Rename optional-column `SpanCoversLine` copies with shared `SpanCoverage.SpanCoversLine` (`convert_anonymous_to_class` / `convert_tuple_to_struct` / `rename_namespace` / `rename_file_to_match_type`) (#981)

--- a/src/RoslynMcp.Core/Refactoring/Extract/ExtractBaseClassOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/ExtractBaseClassOperation.cs
@@ -1093,8 +1093,8 @@ public sealed class ExtractBaseClassOperation : RefactoringOperationBase<Extract
     /// candidate's own start line. When column is set with line, picks the
     /// type whose identifier or declaration span covers that 1-based
     /// column (same exclusive-end coverage as
-    /// <c>ExtractInterfaceOperation.SpanCoversColumn</c> /
-    /// <c>GenerateToStringOperation.SpanCoversColumn</c>). Prefer the
+    /// <see cref="TypeCoverage.TypeCoversColumn"/> via
+    /// <see cref="SpanCoverage.SpanCoversColumn"/>). Prefer the
     /// identifier hit, then the smallest containing type. Nested types,
     /// enums, structs, interfaces, and <c>DelegateDeclarationSyntax</c>
     /// participate when line is set so a covering enum or delegate still

--- a/src/RoslynMcp.Core/Refactoring/Extract/ExtractBaseClassOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/ExtractBaseClassOperation.cs
@@ -1157,8 +1157,8 @@ public sealed class ExtractBaseClassOperation : RefactoringOperationBase<Extract
             // nothing covers this position, keep today's not-found (null)
             // rather than inventing a first-match.
             return lineCandidates
-                .Where(t => TypeCoversColumn(t, line!.Value, column.Value))
-                .OrderBy(t => IdentifierCoversColumn(t, line!.Value, column.Value) ? 0 : 1)
+                .Where(t => TypeCoverage.TypeCoversColumn(t, line!.Value, column.Value))
+                .OrderBy(t => TypeCoverage.IdentifierCoversColumn(t, line!.Value, column.Value) ? 0 : 1)
                 .ThenBy(t => t.Span.Length)
                 .FirstOrDefault();
         }
@@ -1181,42 +1181,12 @@ public sealed class ExtractBaseClassOperation : RefactoringOperationBase<Extract
             return null;
 
         return lineCandidates
-            .Where(t => TypeCoversLine(t, line.Value))
-            .OrderBy(t => IdentifierCoversLine(t, line.Value) ? 0 : 1)
+            .Where(t => TypeCoverage.TypeCoversLine(t, line.Value))
+            .OrderBy(t => TypeCoverage.IdentifierCoversLine(t, line.Value) ? 0 : 1)
             .ThenBy(t => t.Span.Length)
             .FirstOrDefault()
             ?? classCandidates.FirstOrDefault();
     }
-
-    private static bool TypeCoversLine(MemberDeclarationSyntax type, int line) =>
-        IdentifierCoversLine(type, line) ||
-        SpanCoverage.SpanCoversLine(type.GetLocation().GetLineSpan(), line);
-
-    private static bool IdentifierCoversLine(MemberDeclarationSyntax type, int line)
-    {
-        var identifier = GetTypeIdentifier(type);
-        return identifier != default
-            && SpanCoverage.SpanCoversLine(identifier.GetLocation().GetLineSpan(), line);
-    }
-
-    private static bool TypeCoversColumn(MemberDeclarationSyntax type, int line, int column) =>
-        IdentifierCoversColumn(type, line, column) ||
-        SpanCoverage.SpanCoversColumn(type.GetLocation().GetLineSpan(), line, column);
-
-    private static bool IdentifierCoversColumn(MemberDeclarationSyntax type, int line, int column)
-    {
-        var identifier = GetTypeIdentifier(type);
-        return identifier != default
-            && SpanCoverage.SpanCoversColumn(identifier.GetLocation().GetLineSpan(), line, column);
-    }
-
-    private static SyntaxToken GetTypeIdentifier(MemberDeclarationSyntax type) => type switch
-    {
-        BaseTypeDeclarationSyntax named => named.Identifier,
-        DelegateDeclarationSyntax del => del.Identifier,
-        _ => default
-    };
-
 
     private static ClassDeclarationSyntax RecoverAnnotatedClass(
         SyntaxNode root,

--- a/src/RoslynMcp.Core/Refactoring/Extract/ExtractInterfaceOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/ExtractInterfaceOperation.cs
@@ -526,8 +526,8 @@ public sealed class ExtractInterfaceOperation : RefactoringOperationBase<Extract
     /// substituting each candidate's own start line. When column is set
     /// with line, picks the type whose identifier or declaration span
     /// covers that 1-based column (same exclusive-end coverage as
-    /// <c>GenerateToStringOperation.SpanCoversColumn</c> /
-    /// <c>ImplementAbstractOperation.SpanCoversColumn</c>). Prefer the
+    /// <see cref="TypeCoverage.TypeCoversColumn"/> via
+    /// <see cref="SpanCoverage.SpanCoversColumn"/>). Prefer the
     /// identifier hit, then the smallest containing type. Nested types,
     /// enums, and <c>DelegateDeclarationSyntax</c> participate when line
     /// is set so a covering enum or delegate still reaches

--- a/src/RoslynMcp.Core/Refactoring/Extract/ExtractInterfaceOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/ExtractInterfaceOperation.cs
@@ -590,8 +590,8 @@ public sealed class ExtractInterfaceOperation : RefactoringOperationBase<Extract
             // position, keep today's not-found (null) rather than
             // inventing a first-match.
             return lineCandidates
-                .Where(t => TypeCoversColumn(t, line!.Value, column.Value))
-                .OrderBy(t => IdentifierCoversColumn(t, line!.Value, column.Value) ? 0 : 1)
+                .Where(t => TypeCoverage.TypeCoversColumn(t, line!.Value, column.Value))
+                .OrderBy(t => TypeCoverage.IdentifierCoversColumn(t, line!.Value, column.Value) ? 0 : 1)
                 .ThenBy(t => t.Span.Length)
                 .FirstOrDefault();
         }
@@ -614,40 +614,11 @@ public sealed class ExtractInterfaceOperation : RefactoringOperationBase<Extract
             return null;
 
         return lineCandidates
-            .Where(t => TypeCoversLine(t, line.Value))
-            .OrderBy(t => IdentifierCoversLine(t, line.Value) ? 0 : 1)
+            .Where(t => TypeCoverage.TypeCoversLine(t, line.Value))
+            .OrderBy(t => TypeCoverage.IdentifierCoversLine(t, line.Value) ? 0 : 1)
             .ThenBy(t => t.Span.Length)
             .FirstOrDefault()
             ?? typeCandidates.FirstOrDefault();
     }
-
-    private static bool TypeCoversLine(MemberDeclarationSyntax type, int line) =>
-        IdentifierCoversLine(type, line) ||
-        SpanCoverage.SpanCoversLine(type.GetLocation().GetLineSpan(), line);
-
-    private static bool IdentifierCoversLine(MemberDeclarationSyntax type, int line)
-    {
-        var identifier = GetTypeIdentifier(type);
-        return identifier != default
-            && SpanCoverage.SpanCoversLine(identifier.GetLocation().GetLineSpan(), line);
-    }
-
-    private static bool TypeCoversColumn(MemberDeclarationSyntax type, int line, int column) =>
-        IdentifierCoversColumn(type, line, column) ||
-        SpanCoverage.SpanCoversColumn(type.GetLocation().GetLineSpan(), line, column);
-
-    private static bool IdentifierCoversColumn(MemberDeclarationSyntax type, int line, int column)
-    {
-        var identifier = GetTypeIdentifier(type);
-        return identifier != default
-            && SpanCoverage.SpanCoversColumn(identifier.GetLocation().GetLineSpan(), line, column);
-    }
-
-    private static SyntaxToken GetTypeIdentifier(MemberDeclarationSyntax type) => type switch
-    {
-        BaseTypeDeclarationSyntax named => named.Identifier,
-        DelegateDeclarationSyntax del => del.Identifier,
-        _ => default
-    };
 
 }

--- a/src/RoslynMcp.Core/Refactoring/Generate/GenerateToStringOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GenerateToStringOperation.cs
@@ -864,8 +864,8 @@ public sealed class GenerateToStringOperation : RefactoringOperationBase<Generat
             // position, keep today's not-found (null) rather than
             // inventing a first-match.
             return lineCandidates
-                .Where(t => TypeCoversColumn(t, line!.Value, column.Value))
-                .OrderBy(t => IdentifierCoversColumn(t, line!.Value, column.Value) ? 0 : 1)
+                .Where(t => TypeCoverage.TypeCoversColumn(t, line!.Value, column.Value))
+                .OrderBy(t => TypeCoverage.IdentifierCoversColumn(t, line!.Value, column.Value) ? 0 : 1)
                 .ThenBy(t => t.Span.Length)
                 .FirstOrDefault();
         }
@@ -888,41 +888,12 @@ public sealed class GenerateToStringOperation : RefactoringOperationBase<Generat
             return null;
 
         return lineCandidates
-            .Where(t => TypeCoversLine(t, line.Value))
-            .OrderBy(t => IdentifierCoversLine(t, line.Value) ? 0 : 1)
+            .Where(t => TypeCoverage.TypeCoversLine(t, line.Value))
+            .OrderBy(t => TypeCoverage.IdentifierCoversLine(t, line.Value) ? 0 : 1)
             .ThenBy(t => t.Span.Length)
             .FirstOrDefault()
             ?? typeCandidates.FirstOrDefault();
     }
-
-    private static bool TypeCoversLine(MemberDeclarationSyntax type, int line) =>
-        IdentifierCoversLine(type, line) ||
-        SpanCoverage.SpanCoversLine(type.GetLocation().GetLineSpan(), line);
-
-    private static bool IdentifierCoversLine(MemberDeclarationSyntax type, int line)
-    {
-        var identifier = GetTypeIdentifier(type);
-        return identifier != default
-            && SpanCoverage.SpanCoversLine(identifier.GetLocation().GetLineSpan(), line);
-    }
-
-    private static bool TypeCoversColumn(MemberDeclarationSyntax type, int line, int column) =>
-        IdentifierCoversColumn(type, line, column) ||
-        SpanCoverage.SpanCoversColumn(type.GetLocation().GetLineSpan(), line, column);
-
-    private static bool IdentifierCoversColumn(MemberDeclarationSyntax type, int line, int column)
-    {
-        var identifier = GetTypeIdentifier(type);
-        return identifier != default
-            && SpanCoverage.SpanCoversColumn(identifier.GetLocation().GetLineSpan(), line, column);
-    }
-
-    private static SyntaxToken GetTypeIdentifier(MemberDeclarationSyntax type) => type switch
-    {
-        BaseTypeDeclarationSyntax named => named.Identifier,
-        DelegateDeclarationSyntax del => del.Identifier,
-        _ => default
-    };
 
     private static MethodDeclarationSyntax GenerateToString(
         string typeName,

--- a/src/RoslynMcp.Core/Refactoring/Generate/GenerateToStringOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GenerateToStringOperation.cs
@@ -799,9 +799,8 @@ public sealed class GenerateToStringOperation : RefactoringOperationBase<Generat
     /// substituting each candidate's own start line. When column is set
     /// with line, picks the type whose identifier or declaration span
     /// covers that 1-based column (same exclusive-end coverage as
-    /// <c>GenerateConstructorOperation.SpanCoversColumn</c> /
-    /// <c>ImplementAbstractOperation.SpanCoversColumn</c> /
-    /// <c>GenerateOverridesOperation.SpanCoversColumn</c>). Prefer the
+    /// <see cref="TypeCoverage.TypeCoversColumn"/> via
+    /// <see cref="SpanCoverage.SpanCoversColumn"/>). Prefer the
     /// identifier hit, then the smallest containing type. Nested types,
     /// enums, and <c>DelegateDeclarationSyntax</c> participate when line
     /// is set so a covering enum or delegate still reaches

--- a/src/RoslynMcp.Core/Refactoring/Generate/ImplementAbstractOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/ImplementAbstractOperation.cs
@@ -1713,8 +1713,8 @@ public sealed class ImplementAbstractOperation : RefactoringOperationBase<Implem
             // position, keep today's not-found (null) rather than
             // inventing a first-match.
             return lineCandidates
-                .Where(t => TypeCoversColumn(t, line!.Value, column.Value))
-                .OrderBy(t => IdentifierCoversColumn(t, line!.Value, column.Value) ? 0 : 1)
+                .Where(t => TypeCoverage.TypeCoversColumn(t, line!.Value, column.Value))
+                .OrderBy(t => TypeCoverage.IdentifierCoversColumn(t, line!.Value, column.Value) ? 0 : 1)
                 .ThenBy(t => t.Span.Length)
                 .FirstOrDefault();
         }
@@ -1736,41 +1736,12 @@ public sealed class ImplementAbstractOperation : RefactoringOperationBase<Implem
             return null;
 
         return lineCandidates
-            .Where(t => TypeCoversLine(t, line.Value))
-            .OrderBy(t => IdentifierCoversLine(t, line.Value) ? 0 : 1)
+            .Where(t => TypeCoverage.TypeCoversLine(t, line.Value))
+            .OrderBy(t => TypeCoverage.IdentifierCoversLine(t, line.Value) ? 0 : 1)
             .ThenBy(t => t.Span.Length)
             .FirstOrDefault()
             ?? typeCandidates.FirstOrDefault();
     }
-
-    private static bool TypeCoversLine(MemberDeclarationSyntax type, int line) =>
-        IdentifierCoversLine(type, line) ||
-        SpanCoverage.SpanCoversLine(type.GetLocation().GetLineSpan(), line);
-
-    private static bool IdentifierCoversLine(MemberDeclarationSyntax type, int line)
-    {
-        var identifier = GetTypeIdentifier(type);
-        return identifier != default
-            && SpanCoverage.SpanCoversLine(identifier.GetLocation().GetLineSpan(), line);
-    }
-
-    private static bool TypeCoversColumn(MemberDeclarationSyntax type, int line, int column) =>
-        IdentifierCoversColumn(type, line, column) ||
-        SpanCoverage.SpanCoversColumn(type.GetLocation().GetLineSpan(), line, column);
-
-    private static bool IdentifierCoversColumn(MemberDeclarationSyntax type, int line, int column)
-    {
-        var identifier = GetTypeIdentifier(type);
-        return identifier != default
-            && SpanCoverage.SpanCoversColumn(identifier.GetLocation().GetLineSpan(), line, column);
-    }
-
-    private static SyntaxToken GetTypeIdentifier(MemberDeclarationSyntax type) => type switch
-    {
-        BaseTypeDeclarationSyntax named => named.Identifier,
-        DelegateDeclarationSyntax del => del.Identifier,
-        _ => default
-    };
 
     /// <summary>
     /// Creates a preview result describing generate vs replace.

--- a/src/RoslynMcp.Core/Refactoring/Hierarchy/PullMembersUpOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Hierarchy/PullMembersUpOperation.cs
@@ -279,8 +279,8 @@ public sealed class PullMembersUpOperation : RefactoringOperationBase<PullMember
             // position, keep today's not-found (null) rather than
             // inventing a first-match.
             return lineCandidates
-                .Where(t => TypeCoversColumn(t, line!.Value, column.Value))
-                .OrderBy(t => IdentifierCoversColumn(t, line!.Value, column.Value) ? 0 : 1)
+                .Where(t => TypeCoverage.TypeCoversColumn(t, line!.Value, column.Value))
+                .OrderBy(t => TypeCoverage.IdentifierCoversColumn(t, line!.Value, column.Value) ? 0 : 1)
                 .ThenBy(t => t.Span.Length)
                 .FirstOrDefault();
         }
@@ -303,43 +303,12 @@ public sealed class PullMembersUpOperation : RefactoringOperationBase<PullMember
             return null;
 
         return lineCandidates
-            .Where(t => TypeCoversLine(t, line.Value))
-            .OrderBy(t => IdentifierCoversLine(t, line.Value) ? 0 : 1)
+            .Where(t => TypeCoverage.TypeCoversLine(t, line.Value))
+            .OrderBy(t => TypeCoverage.IdentifierCoversLine(t, line.Value) ? 0 : 1)
             .ThenBy(t => t.Span.Length)
             .FirstOrDefault()
             ?? typeCandidates.FirstOrDefault();
     }
-
-    private static bool TypeCoversLine(MemberDeclarationSyntax type, int line) =>
-        IdentifierCoversLine(type, line) ||
-        SpanCoverage.SpanCoversLine(type.GetLocation().GetLineSpan(), line);
-
-    private static bool IdentifierCoversLine(MemberDeclarationSyntax type, int line)
-    {
-        var identifier = GetTypeIdentifier(type);
-        return identifier != default
-            && SpanCoverage.SpanCoversLine(identifier.GetLocation().GetLineSpan(), line);
-    }
-
-    private static bool TypeCoversColumn(MemberDeclarationSyntax type, int line, int column) =>
-        IdentifierCoversColumn(type, line, column) ||
-        SpanCoverage.SpanCoversColumn(type.GetLocation().GetLineSpan(), line, column);
-
-    private static bool IdentifierCoversColumn(MemberDeclarationSyntax type, int line, int column)
-    {
-        var identifier = GetTypeIdentifier(type);
-        return identifier != default
-            && SpanCoverage.SpanCoversColumn(identifier.GetLocation().GetLineSpan(), line, column);
-    }
-
-    private static SyntaxToken GetTypeIdentifier(MemberDeclarationSyntax type) => type switch
-    {
-        BaseTypeDeclarationSyntax named => named.Identifier,
-        DelegateDeclarationSyntax del => del.Identifier,
-        _ => default
-    };
-
-
 
     private static TypeDeclarationSyntax RecoverAnnotatedType(
         SyntaxNode root,

--- a/src/RoslynMcp.Core/Refactoring/Hierarchy/PushMembersDownOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Hierarchy/PushMembersDownOperation.cs
@@ -301,8 +301,8 @@ public sealed class PushMembersDownOperation : RefactoringOperationBase<PushMemb
             // position, keep today's not-found (null) rather than
             // inventing a first-match.
             return lineCandidates
-                .Where(t => TypeCoversColumn(t, line!.Value, column.Value))
-                .OrderBy(t => IdentifierCoversColumn(t, line!.Value, column.Value) ? 0 : 1)
+                .Where(t => TypeCoverage.TypeCoversColumn(t, line!.Value, column.Value))
+                .OrderBy(t => TypeCoverage.IdentifierCoversColumn(t, line!.Value, column.Value) ? 0 : 1)
                 .ThenBy(t => t.Span.Length)
                 .FirstOrDefault();
         }
@@ -325,43 +325,12 @@ public sealed class PushMembersDownOperation : RefactoringOperationBase<PushMemb
             return null;
 
         return lineCandidates
-            .Where(t => TypeCoversLine(t, line.Value))
-            .OrderBy(t => IdentifierCoversLine(t, line.Value) ? 0 : 1)
+            .Where(t => TypeCoverage.TypeCoversLine(t, line.Value))
+            .OrderBy(t => TypeCoverage.IdentifierCoversLine(t, line.Value) ? 0 : 1)
             .ThenBy(t => t.Span.Length)
             .FirstOrDefault()
             ?? typeCandidates.FirstOrDefault();
     }
-
-    private static bool TypeCoversLine(MemberDeclarationSyntax type, int line) =>
-        IdentifierCoversLine(type, line) ||
-        SpanCoverage.SpanCoversLine(type.GetLocation().GetLineSpan(), line);
-
-    private static bool IdentifierCoversLine(MemberDeclarationSyntax type, int line)
-    {
-        var identifier = GetTypeIdentifier(type);
-        return identifier != default
-            && SpanCoverage.SpanCoversLine(identifier.GetLocation().GetLineSpan(), line);
-    }
-
-    private static bool TypeCoversColumn(MemberDeclarationSyntax type, int line, int column) =>
-        IdentifierCoversColumn(type, line, column) ||
-        SpanCoverage.SpanCoversColumn(type.GetLocation().GetLineSpan(), line, column);
-
-    private static bool IdentifierCoversColumn(MemberDeclarationSyntax type, int line, int column)
-    {
-        var identifier = GetTypeIdentifier(type);
-        return identifier != default
-            && SpanCoverage.SpanCoversColumn(identifier.GetLocation().GetLineSpan(), line, column);
-    }
-
-    private static SyntaxToken GetTypeIdentifier(MemberDeclarationSyntax type) => type switch
-    {
-        BaseTypeDeclarationSyntax named => named.Identifier,
-        DelegateDeclarationSyntax del => del.Identifier,
-        _ => default
-    };
-
-
 
     private static TypeDeclarationSyntax RecoverAnnotatedType(
         SyntaxNode root,

--- a/src/RoslynMcp.Core/Refactoring/Hierarchy/UseBaseTypeOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Hierarchy/UseBaseTypeOperation.cs
@@ -581,8 +581,8 @@ public sealed class UseBaseTypeOperation : RefactoringOperationBase<UseBaseTypeP
             // position, keep today's not-found (null) rather than
             // inventing a first-match.
             return lineCandidates
-                .Where(t => TypeCoversColumn(t, line!.Value, column.Value))
-                .OrderBy(t => IdentifierCoversColumn(t, line!.Value, column.Value) ? 0 : 1)
+                .Where(t => TypeCoverage.TypeCoversColumn(t, line!.Value, column.Value))
+                .OrderBy(t => TypeCoverage.IdentifierCoversColumn(t, line!.Value, column.Value) ? 0 : 1)
                 .ThenBy(t => t.Span.Length)
                 .FirstOrDefault();
         }
@@ -606,8 +606,8 @@ public sealed class UseBaseTypeOperation : RefactoringOperationBase<UseBaseTypeP
             return null;
 
         return lineCandidates
-            .Where(t => TypeCoversLine(t, line.Value))
-            .OrderBy(t => IdentifierCoversLine(t, line.Value) ? 0 : 1)
+            .Where(t => TypeCoverage.TypeCoversLine(t, line.Value))
+            .OrderBy(t => TypeCoverage.IdentifierCoversLine(t, line.Value) ? 0 : 1)
             .ThenBy(t => t.Span.Length)
             .FirstOrDefault()
             ?? PickOmittedLineMatch(typeCandidates, model, typeName, cancellationToken);
@@ -636,37 +636,6 @@ public sealed class UseBaseTypeOperation : RefactoringOperationBase<UseBaseTypeP
 
         return null;
     }
-
-    private static bool TypeCoversLine(MemberDeclarationSyntax type, int line) =>
-        IdentifierCoversLine(type, line) ||
-        SpanCoverage.SpanCoversLine(type.GetLocation().GetLineSpan(), line);
-
-    private static bool IdentifierCoversLine(MemberDeclarationSyntax type, int line)
-    {
-        var identifier = GetTypeIdentifier(type);
-        return identifier != default
-            && SpanCoverage.SpanCoversLine(identifier.GetLocation().GetLineSpan(), line);
-    }
-
-    private static bool TypeCoversColumn(MemberDeclarationSyntax type, int line, int column) =>
-        IdentifierCoversColumn(type, line, column) ||
-        SpanCoverage.SpanCoversColumn(type.GetLocation().GetLineSpan(), line, column);
-
-    private static bool IdentifierCoversColumn(MemberDeclarationSyntax type, int line, int column)
-    {
-        var identifier = GetTypeIdentifier(type);
-        return identifier != default
-            && SpanCoverage.SpanCoversColumn(identifier.GetLocation().GetLineSpan(), line, column);
-    }
-
-    private static SyntaxToken GetTypeIdentifier(MemberDeclarationSyntax type) => type switch
-    {
-        BaseTypeDeclarationSyntax named => named.Identifier,
-        DelegateDeclarationSyntax del => del.Identifier,
-        _ => default
-    };
-
-
 
     internal static bool TypeNameMatches(INamedTypeSymbol symbol, string typeName)
     {

--- a/src/RoslynMcp.Core/Resolution/TypeCoverage.cs
+++ b/src/RoslynMcp.Core/Resolution/TypeCoverage.cs
@@ -1,0 +1,61 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace RoslynMcp.Core.Resolution;
+
+/// <summary>
+/// Shared type-declaration coverage helpers used when disambiguating
+/// same-named types by optional 1-based line / column (identifier preferred,
+/// then containing type span via <see cref="SpanCoverage"/>).
+/// </summary>
+internal static class TypeCoverage
+{
+    /// <summary>
+    /// True when the type's identifier or full declaration span covers
+    /// <paramref name="line"/> (exclusive-end line rules via
+    /// <see cref="SpanCoverage.SpanCoversLine(FileLinePositionSpan, int)"/>).
+    /// </summary>
+    internal static bool TypeCoversLine(MemberDeclarationSyntax type, int line) =>
+        IdentifierCoversLine(type, line) ||
+        SpanCoverage.SpanCoversLine(type.GetLocation().GetLineSpan(), line);
+
+    /// <summary>
+    /// True when the type's declaration identifier covers <paramref name="line"/>.
+    /// </summary>
+    internal static bool IdentifierCoversLine(MemberDeclarationSyntax type, int line)
+    {
+        var identifier = GetTypeIdentifier(type);
+        return identifier != default
+            && SpanCoverage.SpanCoversLine(identifier.GetLocation().GetLineSpan(), line);
+    }
+
+    /// <summary>
+    /// True when the type's identifier or full declaration span covers
+    /// <paramref name="line"/> / <paramref name="column"/> (exclusive-end
+    /// column rules via <see cref="SpanCoverage.SpanCoversColumn"/>).
+    /// </summary>
+    internal static bool TypeCoversColumn(MemberDeclarationSyntax type, int line, int column) =>
+        IdentifierCoversColumn(type, line, column) ||
+        SpanCoverage.SpanCoversColumn(type.GetLocation().GetLineSpan(), line, column);
+
+    /// <summary>
+    /// True when the type's declaration identifier covers
+    /// <paramref name="line"/> / <paramref name="column"/>.
+    /// </summary>
+    internal static bool IdentifierCoversColumn(MemberDeclarationSyntax type, int line, int column)
+    {
+        var identifier = GetTypeIdentifier(type);
+        return identifier != default
+            && SpanCoverage.SpanCoversColumn(identifier.GetLocation().GetLineSpan(), line, column);
+    }
+
+    /// <summary>
+    /// Declaration name token for a named type or delegate; otherwise default.
+    /// </summary>
+    internal static SyntaxToken GetTypeIdentifier(MemberDeclarationSyntax type) => type switch
+    {
+        BaseTypeDeclarationSyntax named => named.Identifier,
+        DelegateDeclarationSyntax del => del.Identifier,
+        _ => default
+    };
+}

--- a/tests/RoslynMcp.Core.Tests/Resolution/TypeCoverageTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Resolution/TypeCoverageTests.cs
@@ -64,6 +64,8 @@ public class TypeCoverageTests
         Assert.True(TypeCoverage.IdentifierCoversColumn(type, line, startCol));
         Assert.True(TypeCoverage.IdentifierCoversColumn(type, line, endCol - 1));
         Assert.False(TypeCoverage.IdentifierCoversColumn(type, line, endCol));
+        // endCol is past the identifier exclusive end but still inside "class C { }".
+        Assert.True(TypeCoverage.TypeCoversColumn(type, line, endCol));
         Assert.False(TypeCoverage.IdentifierCoversColumn(type, line, startCol - 1));
     }
 }

--- a/tests/RoslynMcp.Core.Tests/Resolution/TypeCoverageTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Resolution/TypeCoverageTests.cs
@@ -1,0 +1,69 @@
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using RoslynMcp.Core.Resolution;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Resolution;
+
+public class TypeCoverageTests
+{
+    [Fact]
+    public void GetTypeIdentifier_ReturnsClassAndDelegateIdentifiers_DefaultForMethod()
+    {
+        var tree = CSharpSyntaxTree.ParseText("""
+            class C { void M() { } }
+            delegate void D();
+            """);
+        var root = tree.GetRoot();
+        var type = root.DescendantNodes().OfType<ClassDeclarationSyntax>().Single();
+        var del = root.DescendantNodes().OfType<DelegateDeclarationSyntax>().Single();
+        var method = root.DescendantNodes().OfType<MethodDeclarationSyntax>().Single();
+
+        Assert.Equal("C", TypeCoverage.GetTypeIdentifier(type).ValueText);
+        Assert.Equal("D", TypeCoverage.GetTypeIdentifier(del).ValueText);
+        Assert.Equal(default, TypeCoverage.GetTypeIdentifier(method));
+    }
+
+    [Fact]
+    public void TypeCoversLine_True_OnIdentifierLine_False_Outside()
+    {
+        var tree = CSharpSyntaxTree.ParseText("""
+            class C
+            {
+                void M() { }
+            }
+            """);
+        var root = tree.GetRoot();
+        var type = root.DescendantNodes().OfType<ClassDeclarationSyntax>().Single();
+        var idLine = type.Identifier.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+        var method = root.DescendantNodes().OfType<MethodDeclarationSyntax>().Single();
+        var methodLine = method.Identifier.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+
+        Assert.True(TypeCoverage.TypeCoversLine(type, idLine));
+        Assert.True(TypeCoverage.IdentifierCoversLine(type, idLine));
+        // Method line is still inside the type span.
+        Assert.True(TypeCoverage.TypeCoversLine(type, methodLine));
+        Assert.False(TypeCoverage.IdentifierCoversLine(type, methodLine));
+        Assert.False(TypeCoverage.TypeCoversLine(type, 0));
+    }
+
+    [Fact]
+    public void TypeCoversColumn_True_OnIdentifier_False_AtExclusiveEnd()
+    {
+        var tree = CSharpSyntaxTree.ParseText("""
+            class C { }
+            """);
+        var root = tree.GetRoot();
+        var type = root.DescendantNodes().OfType<ClassDeclarationSyntax>().Single();
+        var idSpan = type.Identifier.GetLocation().GetLineSpan();
+        var line = idSpan.StartLinePosition.Line + 1;
+        var startCol = idSpan.StartLinePosition.Character + 1;
+        var endCol = idSpan.EndLinePosition.Character + 1;
+
+        Assert.True(TypeCoverage.TypeCoversColumn(type, line, startCol));
+        Assert.True(TypeCoverage.IdentifierCoversColumn(type, line, startCol));
+        Assert.True(TypeCoverage.IdentifierCoversColumn(type, line, endCol - 1));
+        Assert.False(TypeCoverage.IdentifierCoversColumn(type, line, endCol));
+        Assert.False(TypeCoverage.IdentifierCoversColumn(type, line, startCol - 1));
+    }
+}


### PR DESCRIPTION
## Summary
- Extract shared `TypeCoverage` (`TypeCoversLine` / `IdentifierCoversLine` / `TypeCoversColumn` / `IdentifierCoversColumn` / `GetTypeIdentifier`) under `RoslynMcp.Core.Resolution`
- Replace 7 identical type-local copies in Hierarchy/Extract/Generate (`pull_members_up` / `push_members_down` / `use_base_type` / `extract_interface` / `extract_base_class` / `generate_tostring` / `implement_abstract`)
- Focused unit tests + CHANGELOG Unreleased/Changed one-liner
- Behavior-preserving only

Closes #990

## Test plan
- [x] `dotnet test` filter TypeCoverage + PullMembersUp/PushMembersDown/UseBaseType/ExtractInterface/ExtractBaseClass/GenerateToString/ImplementAbstract (875 passed)
- [ ] CI green