### PR TITLE
refactor: replace Generate TypeCovers* with TypeCoverage (#994)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- Replaced 5 identical Generate-family TypeCovers* / IdentifierCovers* copies with shared TypeCoverage (generate_constructor / generate_equals_hashcode / generate_overrides / generate_property / implement_interface) (#994)
 - Extracted shared `TypeCoverage` and replaced 7 identical Hierarchy/Extract/Generate copies (`pull_members_up` / `push_members_down` / `use_base_type` / `extract_interface` / `extract_base_class` / `generate_tostring` / `implement_abstract`) (#990)
 - Extracted shared `SignatureReferenceHelpers` and replaced 4 identical Signature-family copies (`add_parameter` / `remove_parameter` / `reorder_parameters` / `change_return_type`) (#986)
 - Replaced `AddNullChecksOperation` type-local `SpanCoversColumn` with shared `SpanCoverage.SpanCoversColumn` (`add_null_checks`) (#983)

--- a/src/RoslynMcp.Core/Refactoring/Generate/GenerateConstructorOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GenerateConstructorOperation.cs
@@ -1279,8 +1279,8 @@ public sealed class GenerateConstructorOperation : RefactoringOperationBase<Gene
             // covers this position, keep today's not-found (null) rather
             // than inventing a first-match.
             return candidates
-                .Where(t => TypeCoversColumn(t, line!.Value, column.Value))
-                .OrderBy(t => IdentifierCoversColumn(t, line!.Value, column.Value) ? 0 : 1)
+                .Where(t => TypeCoverage.TypeCoversColumn(t, line!.Value, column.Value))
+                .OrderBy(t => TypeCoverage.IdentifierCoversColumn(t, line!.Value, column.Value) ? 0 : 1)
                 .ThenBy(t => t.Span.Length)
                 .FirstOrDefault();
         }
@@ -1296,26 +1296,12 @@ public sealed class GenerateConstructorOperation : RefactoringOperationBase<Gene
         // elsewhere — scan every candidate. If nothing covers this line,
         // keep today's first-match rather than inventing a not-found.
         return candidates
-            .Where(t => TypeCoversLine(t, line.Value))
-            .OrderBy(t => IdentifierCoversLine(t, line.Value) ? 0 : 1)
+            .Where(t => TypeCoverage.TypeCoversLine(t, line.Value))
+            .OrderBy(t => TypeCoverage.IdentifierCoversLine(t, line.Value) ? 0 : 1)
             .ThenBy(t => t.Span.Length)
             .FirstOrDefault()
             ?? candidates.FirstOrDefault();
     }
-
-    private static bool TypeCoversLine(TypeDeclarationSyntax type, int line) =>
-        IdentifierCoversLine(type, line) ||
-        SpanCoverage.SpanCoversLine(type.GetLocation().GetLineSpan(), line);
-
-    private static bool IdentifierCoversLine(TypeDeclarationSyntax type, int line) =>
-        SpanCoverage.SpanCoversLine(type.Identifier.GetLocation().GetLineSpan(), line);
-
-    private static bool TypeCoversColumn(TypeDeclarationSyntax type, int line, int column) =>
-        IdentifierCoversColumn(type, line, column) ||
-        SpanCoverage.SpanCoversColumn(type.GetLocation().GetLineSpan(), line, column);
-
-    private static bool IdentifierCoversColumn(TypeDeclarationSyntax type, int line, int column) =>
-        SpanCoverage.SpanCoversColumn(type.Identifier.GetLocation().GetLineSpan(), line, column);
 
     private static ITypeSymbol GetMemberType(ISymbol member)
     {

--- a/src/RoslynMcp.Core/Refactoring/Generate/GenerateEqualsHashCodeOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GenerateEqualsHashCodeOperation.cs
@@ -977,8 +977,8 @@ public sealed class GenerateEqualsHashCodeOperation : RefactoringOperationBase<G
             // covers this position, keep today's not-found (null) rather
             // than inventing a first-match.
             return candidates
-                .Where(t => TypeCoversColumn(t, line!.Value, column.Value))
-                .OrderBy(t => IdentifierCoversColumn(t, line!.Value, column.Value) ? 0 : 1)
+                .Where(t => TypeCoverage.TypeCoversColumn(t, line!.Value, column.Value))
+                .OrderBy(t => TypeCoverage.IdentifierCoversColumn(t, line!.Value, column.Value) ? 0 : 1)
                 .ThenBy(t => t.Span.Length)
                 .FirstOrDefault();
         }
@@ -994,26 +994,12 @@ public sealed class GenerateEqualsHashCodeOperation : RefactoringOperationBase<G
         // elsewhere — scan every candidate. If nothing covers this line,
         // keep today's first-match rather than inventing a not-found.
         return candidates
-            .Where(t => TypeCoversLine(t, line.Value))
-            .OrderBy(t => IdentifierCoversLine(t, line.Value) ? 0 : 1)
+            .Where(t => TypeCoverage.TypeCoversLine(t, line.Value))
+            .OrderBy(t => TypeCoverage.IdentifierCoversLine(t, line.Value) ? 0 : 1)
             .ThenBy(t => t.Span.Length)
             .FirstOrDefault()
             ?? candidates.FirstOrDefault();
     }
-
-    private static bool TypeCoversLine(TypeDeclarationSyntax type, int line) =>
-        IdentifierCoversLine(type, line) ||
-        SpanCoverage.SpanCoversLine(type.GetLocation().GetLineSpan(), line);
-
-    private static bool IdentifierCoversLine(TypeDeclarationSyntax type, int line) =>
-        SpanCoverage.SpanCoversLine(type.Identifier.GetLocation().GetLineSpan(), line);
-
-    private static bool TypeCoversColumn(TypeDeclarationSyntax type, int line, int column) =>
-        IdentifierCoversColumn(type, line, column) ||
-        SpanCoverage.SpanCoversColumn(type.GetLocation().GetLineSpan(), line, column);
-
-    private static bool IdentifierCoversColumn(TypeDeclarationSyntax type, int line, int column) =>
-        SpanCoverage.SpanCoversColumn(type.Identifier.GetLocation().GetLineSpan(), line, column);
 
     private static TypeDeclarationSyntax StripIEquatableInterface(
         TypeDeclarationSyntax original,

--- a/src/RoslynMcp.Core/Refactoring/Generate/GenerateOverridesOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GenerateOverridesOperation.cs
@@ -1260,8 +1260,8 @@ public sealed class GenerateOverridesOperation : RefactoringOperationBase<Genera
             // covers this position, keep today's not-found (null) rather
             // than inventing a first-match.
             return candidates
-                .Where(t => TypeCoversColumn(t, line!.Value, column.Value))
-                .OrderBy(t => IdentifierCoversColumn(t, line!.Value, column.Value) ? 0 : 1)
+                .Where(t => TypeCoverage.TypeCoversColumn(t, line!.Value, column.Value))
+                .OrderBy(t => TypeCoverage.IdentifierCoversColumn(t, line!.Value, column.Value) ? 0 : 1)
                 .ThenBy(t => t.Span.Length)
                 .FirstOrDefault();
         }
@@ -1277,26 +1277,12 @@ public sealed class GenerateOverridesOperation : RefactoringOperationBase<Genera
         // elsewhere — scan every candidate. If nothing covers this line,
         // keep today's first-match rather than inventing a not-found.
         return candidates
-            .Where(t => TypeCoversLine(t, line.Value))
-            .OrderBy(t => IdentifierCoversLine(t, line.Value) ? 0 : 1)
+            .Where(t => TypeCoverage.TypeCoversLine(t, line.Value))
+            .OrderBy(t => TypeCoverage.IdentifierCoversLine(t, line.Value) ? 0 : 1)
             .ThenBy(t => t.Span.Length)
             .FirstOrDefault()
             ?? candidates.FirstOrDefault();
     }
-
-    private static bool TypeCoversLine(TypeDeclarationSyntax type, int line) =>
-        IdentifierCoversLine(type, line) ||
-        SpanCoverage.SpanCoversLine(type.GetLocation().GetLineSpan(), line);
-
-    private static bool IdentifierCoversLine(TypeDeclarationSyntax type, int line) =>
-        SpanCoverage.SpanCoversLine(type.Identifier.GetLocation().GetLineSpan(), line);
-
-    private static bool TypeCoversColumn(TypeDeclarationSyntax type, int line, int column) =>
-        IdentifierCoversColumn(type, line, column) ||
-        SpanCoverage.SpanCoversColumn(type.GetLocation().GetLineSpan(), line, column);
-
-    private static bool IdentifierCoversColumn(TypeDeclarationSyntax type, int line, int column) =>
-        SpanCoverage.SpanCoversColumn(type.Identifier.GetLocation().GetLineSpan(), line, column);
 
     private static RefactoringResult CreatePreviewResult(
         Guid operationId,

--- a/src/RoslynMcp.Core/Refactoring/Generate/GeneratePropertyOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GeneratePropertyOperation.cs
@@ -786,8 +786,8 @@ public sealed class GeneratePropertyOperation : RefactoringOperationBase<Generat
             // every candidate. If nothing covers this position, keep
             // today's not-found (null) rather than inventing a first-match.
             return candidates
-                .Where(t => TypeCoversColumn(t, line!.Value, column.Value))
-                .OrderBy(t => IdentifierCoversColumn(t, line!.Value, column.Value) ? 0 : 1)
+                .Where(t => TypeCoverage.TypeCoversColumn(t, line!.Value, column.Value))
+                .OrderBy(t => TypeCoverage.IdentifierCoversColumn(t, line!.Value, column.Value) ? 0 : 1)
                 .ThenBy(t => t.Span.Length)
                 .FirstOrDefault();
         }
@@ -804,26 +804,12 @@ public sealed class GeneratePropertyOperation : RefactoringOperationBase<Generat
         // candidate. If nothing covers this line, keep today's
         // first-match rather than inventing a not-found.
         return candidates
-            .Where(t => TypeCoversLine(t, line.Value))
-            .OrderBy(t => IdentifierCoversLine(t, line.Value) ? 0 : 1)
+            .Where(t => TypeCoverage.TypeCoversLine(t, line.Value))
+            .OrderBy(t => TypeCoverage.IdentifierCoversLine(t, line.Value) ? 0 : 1)
             .ThenBy(t => t.Span.Length)
             .FirstOrDefault()
             ?? candidates.FirstOrDefault();
     }
-
-    private static bool TypeCoversLine(BaseTypeDeclarationSyntax type, int line) =>
-        IdentifierCoversLine(type, line) ||
-        SpanCoverage.SpanCoversLine(type.GetLocation().GetLineSpan(), line);
-
-    private static bool IdentifierCoversLine(BaseTypeDeclarationSyntax type, int line) =>
-        SpanCoverage.SpanCoversLine(type.Identifier.GetLocation().GetLineSpan(), line);
-
-    private static bool TypeCoversColumn(BaseTypeDeclarationSyntax type, int line, int column) =>
-        IdentifierCoversColumn(type, line, column) ||
-        SpanCoverage.SpanCoversColumn(type.GetLocation().GetLineSpan(), line, column);
-
-    private static bool IdentifierCoversColumn(BaseTypeDeclarationSyntax type, int line, int column) =>
-        SpanCoverage.SpanCoversColumn(type.Identifier.GetLocation().GetLineSpan(), line, column);
 
     /// <summary>
     /// Creates a preview result with the generated property code.

--- a/src/RoslynMcp.Core/Refactoring/Generate/ImplementInterfaceOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/ImplementInterfaceOperation.cs
@@ -1420,8 +1420,8 @@ public sealed class ImplementInterfaceOperation : RefactoringOperationBase<Imple
             // covers this position, keep today's not-found (null) rather
             // than inventing a first-match.
             return candidates
-                .Where(t => TypeCoversColumn(t, line!.Value, column.Value))
-                .OrderBy(t => IdentifierCoversColumn(t, line!.Value, column.Value) ? 0 : 1)
+                .Where(t => TypeCoverage.TypeCoversColumn(t, line!.Value, column.Value))
+                .OrderBy(t => TypeCoverage.IdentifierCoversColumn(t, line!.Value, column.Value) ? 0 : 1)
                 .ThenBy(t => t.Span.Length)
                 .FirstOrDefault();
         }
@@ -1437,26 +1437,12 @@ public sealed class ImplementInterfaceOperation : RefactoringOperationBase<Imple
         // elsewhere — scan every candidate. If nothing covers this line,
         // keep today's first-match rather than inventing a not-found.
         return candidates
-            .Where(t => TypeCoversLine(t, line.Value))
-            .OrderBy(t => IdentifierCoversLine(t, line.Value) ? 0 : 1)
+            .Where(t => TypeCoverage.TypeCoversLine(t, line.Value))
+            .OrderBy(t => TypeCoverage.IdentifierCoversLine(t, line.Value) ? 0 : 1)
             .ThenBy(t => t.Span.Length)
             .FirstOrDefault()
             ?? candidates.FirstOrDefault();
     }
-
-    private static bool TypeCoversLine(TypeDeclarationSyntax type, int line) =>
-        IdentifierCoversLine(type, line) ||
-        SpanCoverage.SpanCoversLine(type.GetLocation().GetLineSpan(), line);
-
-    private static bool IdentifierCoversLine(TypeDeclarationSyntax type, int line) =>
-        SpanCoverage.SpanCoversLine(type.Identifier.GetLocation().GetLineSpan(), line);
-
-    private static bool TypeCoversColumn(TypeDeclarationSyntax type, int line, int column) =>
-        IdentifierCoversColumn(type, line, column) ||
-        SpanCoverage.SpanCoversColumn(type.GetLocation().GetLineSpan(), line, column);
-
-    private static bool IdentifierCoversColumn(TypeDeclarationSyntax type, int line, int column) =>
-        SpanCoverage.SpanCoversColumn(type.Identifier.GetLocation().GetLineSpan(), line, column);
 
     /// <summary>
     /// Creates a preview result describing generate vs replace.


### PR DESCRIPTION
## Summary
- Replaces type-local `TypeCoversLine` / `IdentifierCoversLine` / `TypeCoversColumn` / `IdentifierCoversColumn` in five Generate-family operations with shared `TypeCoverage` (`RoslynMcp.Core.Resolution`).
- Touches `generate_constructor`, `generate_equals_hashcode`, `generate_overrides`, `generate_property`, and `implement_interface`.
- Same pattern already applied for Hierarchy/Extract/`generate_tostring`/`implement_abstract` in #990/#991.

## Test plan
- [x] `rg` confirms private `TypeCovers*` / `IdentifierCovers*` helpers removed from the five Generate files
- [x] `dotnet test tests/RoslynMcp.Core.Tests --filter "FullyQualifiedName~TypeCoverage|FullyQualifiedName~GenerateConstructor|FullyQualifiedName~GenerateEquals|FullyQualifiedName~GenerateOverrides|FullyQualifiedName~GenerateProperty|FullyQualifiedName~ImplementInterface"` — 773 passed

Closes #994