### PR TITLE
refactor: extract MethodCoverage; replace 7 identical method copies (#997)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- Extracted shared `MethodCoverage` and replaced 7 identical MethodCoversColumn / IdentifierCoversColumn copies (`add_parameter` / `remove_parameter` / `reorder_parameters` / `change_signature` / `change_return_type` / `convert_to_async` / `inline_method`) (#997)
 - Replaced 5 identical Generate-family TypeCovers* / IdentifierCovers* copies with shared TypeCoverage (generate_constructor / generate_equals_hashcode / generate_overrides / generate_property / implement_interface) (#994)
 - Extracted shared `TypeCoverage` and replaced 7 identical Hierarchy/Extract/Generate copies (`pull_members_up` / `push_members_down` / `use_base_type` / `extract_interface` / `extract_base_class` / `generate_tostring` / `implement_abstract`) (#990)
 - Extracted shared `SignatureReferenceHelpers` and replaced 4 identical Signature-family copies (`add_parameter` / `remove_parameter` / `reorder_parameters` / `change_return_type`) (#986)

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertToAsyncOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertToAsyncOperation.cs
@@ -790,8 +790,8 @@ public sealed class ConvertToAsyncOperation : RefactoringOperationBase<ConvertTo
             // continuation line whose declaration span still covers that
             // column.
             return methods
-                .Where(m => MethodCoversColumn(m, line ?? StartLine(m), column.Value))
-                .OrderBy(m => IdentifierCoversColumn(m, line ?? StartLine(m), column.Value) ? 0 : 1)
+                .Where(m => MethodCoverage.MethodCoversColumn(m, line ?? StartLine(m), column.Value))
+                .OrderBy(m => MethodCoverage.IdentifierCoversColumn(m, line ?? StartLine(m), column.Value) ? 0 : 1)
                 .ThenBy(m => m.Span.Length)
                 .FirstOrDefault();
         }
@@ -811,14 +811,6 @@ public sealed class ConvertToAsyncOperation : RefactoringOperationBase<ConvertTo
 
     private static int StartLine(MethodDeclarationSyntax method) =>
         method.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
-
-    private static bool MethodCoversColumn(MethodDeclarationSyntax method, int line, int column) =>
-        IdentifierCoversColumn(method, line, column) ||
-        SpanCoverage.SpanCoversColumn(method.GetLocation().GetLineSpan(), line, column);
-
-    private static bool IdentifierCoversColumn(MethodDeclarationSyntax method, int line, int column) =>
-        SpanCoverage.SpanCoversColumn(method.Identifier.GetLocation().GetLineSpan(), line, column);
-
 
     private static async Task<List<CallSite>> CollectCallSitesAsync(
         IMethodSymbol methodSymbol,

--- a/src/RoslynMcp.Core/Refactoring/Inline/InlineMethodOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Inline/InlineMethodOperation.cs
@@ -270,8 +270,8 @@ public sealed class InlineMethodOperation : RefactoringOperationBase<InlineMetho
             // including those that do not start on `line`. If nothing
             // covers this position, keep today's not-found (null).
             return methods
-                .Where(m => MethodCoversColumn(m, line ?? StartLine(m), column.Value))
-                .OrderBy(m => IdentifierCoversColumn(m, line ?? StartLine(m), column.Value) ? 0 : 1)
+                .Where(m => MethodCoverage.MethodCoversColumn(m, line ?? StartLine(m), column.Value))
+                .OrderBy(m => MethodCoverage.IdentifierCoversColumn(m, line ?? StartLine(m), column.Value) ? 0 : 1)
                 .ThenBy(m => m.Span.Length)
                 .FirstOrDefault();
         }
@@ -288,14 +288,6 @@ public sealed class InlineMethodOperation : RefactoringOperationBase<InlineMetho
 
     private static int StartLine(MethodDeclarationSyntax method) =>
         method.Identifier.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
-
-    private static bool MethodCoversColumn(MethodDeclarationSyntax method, int line, int column) =>
-        IdentifierCoversColumn(method, line, column) ||
-        SpanCoverage.SpanCoversColumn(method.GetLocation().GetLineSpan(), line, column);
-
-    private static bool IdentifierCoversColumn(MethodDeclarationSyntax method, int line, int column) =>
-        SpanCoverage.SpanCoversColumn(method.Identifier.GetLocation().GetLineSpan(), line, column);
-
 
     private static void ValidateInlineable(
         MethodDeclarationSyntax methodSyntax,

--- a/src/RoslynMcp.Core/Refactoring/Signature/AddParameterOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Signature/AddParameterOperation.cs
@@ -314,8 +314,8 @@ public sealed class AddParameterOperation : RefactoringOperationBase<AddParamete
             // including those that do not start on `line`. If nothing
             // covers this position, keep today's not-found (null).
             return methods
-                .Where(m => MethodCoversColumn(m, line ?? StartLine(m), column.Value))
-                .OrderBy(m => IdentifierCoversColumn(m, line ?? StartLine(m), column.Value) ? 0 : 1)
+                .Where(m => MethodCoverage.MethodCoversColumn(m, line ?? StartLine(m), column.Value))
+                .OrderBy(m => MethodCoverage.IdentifierCoversColumn(m, line ?? StartLine(m), column.Value) ? 0 : 1)
                 .ThenBy(m => m.Span.Length)
                 .FirstOrDefault();
         }
@@ -332,13 +332,6 @@ public sealed class AddParameterOperation : RefactoringOperationBase<AddParamete
 
     private static int StartLine(MethodDeclarationSyntax method) =>
         method.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
-
-    private static bool MethodCoversColumn(MethodDeclarationSyntax method, int line, int column) =>
-        IdentifierCoversColumn(method, line, column) ||
-        SpanCoverage.SpanCoversColumn(method.GetLocation().GetLineSpan(), line, column);
-
-    private static bool IdentifierCoversColumn(MethodDeclarationSyntax method, int line, int column) =>
-        SpanCoverage.SpanCoversColumn(method.Identifier.GetLocation().GetLineSpan(), line, column);
 
     internal static int ComputeInsertionIndex(ParameterListSyntax list, int position)
     {

--- a/src/RoslynMcp.Core/Refactoring/Signature/ChangeReturnTypeOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Signature/ChangeReturnTypeOperation.cs
@@ -446,8 +446,8 @@ public sealed class ChangeReturnTypeOperation : RefactoringOperationBase<ChangeR
             // including those that do not start on `line`. If nothing
             // covers this position, keep today's not-found (null).
             return methods
-                .Where(m => MethodCoversColumn(m, line ?? StartLine(m), column.Value))
-                .OrderBy(m => IdentifierCoversColumn(m, line ?? StartLine(m), column.Value) ? 0 : 1)
+                .Where(m => MethodCoverage.MethodCoversColumn(m, line ?? StartLine(m), column.Value))
+                .OrderBy(m => MethodCoverage.IdentifierCoversColumn(m, line ?? StartLine(m), column.Value) ? 0 : 1)
                 .ThenBy(m => m.Span.Length)
                 .FirstOrDefault();
         }
@@ -464,13 +464,6 @@ public sealed class ChangeReturnTypeOperation : RefactoringOperationBase<ChangeR
 
     private static int StartLine(MethodDeclarationSyntax method) =>
         method.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
-
-    private static bool MethodCoversColumn(MethodDeclarationSyntax method, int line, int column) =>
-        IdentifierCoversColumn(method, line, column) ||
-        SpanCoverage.SpanCoversColumn(method.GetLocation().GetLineSpan(), line, column);
-
-    private static bool IdentifierCoversColumn(MethodDeclarationSyntax method, int line, int column) =>
-        SpanCoverage.SpanCoversColumn(method.Identifier.GetLocation().GetLineSpan(), line, column);
 
     private async Task<List<IMethodSymbol>> GetRelatedMethodsAsync(
         IMethodSymbol method,

--- a/src/RoslynMcp.Core/Refactoring/Signature/ChangeSignatureOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Signature/ChangeSignatureOperation.cs
@@ -232,8 +232,8 @@ public sealed class ChangeSignatureOperation : RefactoringOperationBase<ChangeSi
             // continuation line whose declaration span still covers that
             // column.
             return methods
-                .Where(m => MethodCoversColumn(m, line ?? StartLine(m), column.Value))
-                .OrderBy(m => IdentifierCoversColumn(m, line ?? StartLine(m), column.Value) ? 0 : 1)
+                .Where(m => MethodCoverage.MethodCoversColumn(m, line ?? StartLine(m), column.Value))
+                .OrderBy(m => MethodCoverage.IdentifierCoversColumn(m, line ?? StartLine(m), column.Value) ? 0 : 1)
                 .ThenBy(m => m.Span.Length)
                 .FirstOrDefault();
         }
@@ -253,14 +253,6 @@ public sealed class ChangeSignatureOperation : RefactoringOperationBase<ChangeSi
 
     private static int StartLine(MethodDeclarationSyntax method) =>
         method.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
-
-    private static bool MethodCoversColumn(MethodDeclarationSyntax method, int line, int column) =>
-        IdentifierCoversColumn(method, line, column) ||
-        SpanCoverage.SpanCoversColumn(method.GetLocation().GetLineSpan(), line, column);
-
-    private static bool IdentifierCoversColumn(MethodDeclarationSyntax method, int line, int column) =>
-        SpanCoverage.SpanCoversColumn(method.Identifier.GetLocation().GetLineSpan(), line, column);
-
 
     private static List<NewParameter> BuildNewParameterList(
         List<IParameterSymbol> originalParams,

--- a/src/RoslynMcp.Core/Refactoring/Signature/RemoveParameterOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Signature/RemoveParameterOperation.cs
@@ -307,8 +307,8 @@ public sealed class RemoveParameterOperation : RefactoringOperationBase<RemovePa
             // including those that do not start on `line`. If nothing
             // covers this position, keep today's not-found (null).
             return methods
-                .Where(m => MethodCoversColumn(m, line ?? StartLine(m), column.Value))
-                .OrderBy(m => IdentifierCoversColumn(m, line ?? StartLine(m), column.Value) ? 0 : 1)
+                .Where(m => MethodCoverage.MethodCoversColumn(m, line ?? StartLine(m), column.Value))
+                .OrderBy(m => MethodCoverage.IdentifierCoversColumn(m, line ?? StartLine(m), column.Value) ? 0 : 1)
                 .ThenBy(m => m.Span.Length)
                 .FirstOrDefault();
         }
@@ -325,13 +325,6 @@ public sealed class RemoveParameterOperation : RefactoringOperationBase<RemovePa
 
     private static int StartLine(MethodDeclarationSyntax method) =>
         method.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
-
-    private static bool MethodCoversColumn(MethodDeclarationSyntax method, int line, int column) =>
-        IdentifierCoversColumn(method, line, column) ||
-        SpanCoverage.SpanCoversColumn(method.GetLocation().GetLineSpan(), line, column);
-
-    private static bool IdentifierCoversColumn(MethodDeclarationSyntax method, int line, int column) =>
-        SpanCoverage.SpanCoversColumn(method.Identifier.GetLocation().GetLineSpan(), line, column);
 
     internal static IParameterSymbol FindParameter(IMethodSymbol method, string name)
     {

--- a/src/RoslynMcp.Core/Refactoring/Signature/ReorderParametersOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Signature/ReorderParametersOperation.cs
@@ -449,8 +449,8 @@ public sealed class ReorderParametersOperation : RefactoringOperationBase<Reorde
             // including those that do not start on `line`. If nothing
             // covers this position, keep today's not-found (null).
             return methods
-                .Where(m => MethodCoversColumn(m, line ?? StartLine(m), column.Value))
-                .OrderBy(m => IdentifierCoversColumn(m, line ?? StartLine(m), column.Value) ? 0 : 1)
+                .Where(m => MethodCoverage.MethodCoversColumn(m, line ?? StartLine(m), column.Value))
+                .OrderBy(m => MethodCoverage.IdentifierCoversColumn(m, line ?? StartLine(m), column.Value) ? 0 : 1)
                 .ThenBy(m => m.Span.Length)
                 .FirstOrDefault();
         }
@@ -467,13 +467,6 @@ public sealed class ReorderParametersOperation : RefactoringOperationBase<Reorde
 
     private static int StartLine(MethodDeclarationSyntax method) =>
         method.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
-
-    private static bool MethodCoversColumn(MethodDeclarationSyntax method, int line, int column) =>
-        IdentifierCoversColumn(method, line, column) ||
-        SpanCoverage.SpanCoversColumn(method.GetLocation().GetLineSpan(), line, column);
-
-    private static bool IdentifierCoversColumn(MethodDeclarationSyntax method, int line, int column) =>
-        SpanCoverage.SpanCoversColumn(method.Identifier.GetLocation().GetLineSpan(), line, column);
 
     private async Task<List<IMethodSymbol>> GetRelatedMethodsAsync(
         IMethodSymbol method,

--- a/src/RoslynMcp.Core/Resolution/MethodCoverage.cs
+++ b/src/RoslynMcp.Core/Resolution/MethodCoverage.cs
@@ -1,0 +1,28 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace RoslynMcp.Core.Resolution;
+
+/// <summary>
+/// Shared method-declaration coverage helpers used when disambiguating
+/// same-named methods by optional 1-based line / column (identifier preferred,
+/// then containing method span via <see cref="SpanCoverage"/>).
+/// </summary>
+internal static class MethodCoverage
+{
+    /// <summary>
+    /// True when the method's identifier or full declaration span covers
+    /// <paramref name="line"/> / <paramref name="column"/> (exclusive-end
+    /// column rules via <see cref="SpanCoverage.SpanCoversColumn"/>).
+    /// </summary>
+    internal static bool MethodCoversColumn(MethodDeclarationSyntax method, int line, int column) =>
+        IdentifierCoversColumn(method, line, column) ||
+        SpanCoverage.SpanCoversColumn(method.GetLocation().GetLineSpan(), line, column);
+
+    /// <summary>
+    /// True when the method's declaration identifier covers
+    /// <paramref name="line"/> / <paramref name="column"/>.
+    /// </summary>
+    internal static bool IdentifierCoversColumn(MethodDeclarationSyntax method, int line, int column) =>
+        SpanCoverage.SpanCoversColumn(method.Identifier.GetLocation().GetLineSpan(), line, column);
+}

--- a/tests/RoslynMcp.Core.Tests/Resolution/MethodCoverageTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Resolution/MethodCoverageTests.cs
@@ -1,0 +1,34 @@
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using RoslynMcp.Core.Resolution;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Resolution;
+
+public class MethodCoverageTests
+{
+    [Fact]
+    public void MethodCoversColumn_True_OnIdentifier_False_AtExclusiveEnd()
+    {
+        var tree = CSharpSyntaxTree.ParseText("""
+            class C
+            {
+                void M() { int x = 1; }
+            }
+            """);
+        var root = tree.GetRoot();
+        var method = root.DescendantNodes().OfType<MethodDeclarationSyntax>().Single();
+        var idSpan = method.Identifier.GetLocation().GetLineSpan();
+        var line = idSpan.StartLinePosition.Line + 1;
+        var startCol = idSpan.StartLinePosition.Character + 1;
+        var endCol = idSpan.EndLinePosition.Character + 1;
+
+        Assert.True(MethodCoverage.MethodCoversColumn(method, line, startCol));
+        Assert.True(MethodCoverage.IdentifierCoversColumn(method, line, startCol));
+        Assert.True(MethodCoverage.IdentifierCoversColumn(method, line, endCol - 1));
+        Assert.False(MethodCoverage.IdentifierCoversColumn(method, line, endCol));
+        // endCol is past the identifier exclusive end but still inside the method span.
+        Assert.True(MethodCoverage.MethodCoversColumn(method, line, endCol));
+        Assert.False(MethodCoverage.IdentifierCoversColumn(method, line, startCol - 1));
+    }
+}


### PR DESCRIPTION
## Summary
- Extracted shared `MethodCoverage` (`MethodCoversColumn` / `IdentifierCoversColumn`) under `RoslynMcp.Core.Resolution`, mirroring `TypeCoverage`.
- Replaced 7 identical private copies in Signature / Convert / Inline operations with calls to the shared helper.
- Behavior-preserving only (exclusive-end column rules via `SpanCoverage`).

Closes #997

## Test plan
- [x] `MethodCoverageTests` (identifier start true; exclusive end of identifier false; `MethodCoversColumn` true past id but inside method span)
- [x] Filtered Core tests: `MethodCoverage|AddParameter|ChangeSignature|InlineMethod|ConvertToAsync` (166 passed)
- [x] `RoslynMcp.Core` builds clean