### PR TITLE
refactor: extract FieldCoverage; replace EncapsulateField + InlineConstant copies (#1002)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- Extracted shared `FieldCoverage` and replaced EncapsulateField + InlineConstant FieldCovers* / IdentifierCovers* / GetFieldDeclaration / SmallestCoveringSpanLength copies (`encapsulate_field` / `inline_constant`) (#1002)
 - Extracted shared `MethodCoverage` and replaced 7 identical MethodCoversColumn / IdentifierCoversColumn copies (`add_parameter` / `remove_parameter` / `reorder_parameters` / `change_signature` / `change_return_type` / `convert_to_async` / `inline_method`) (#997)
 - Replaced 5 identical Generate-family TypeCovers* / IdentifierCovers* copies with shared TypeCoverage (generate_constructor / generate_equals_hashcode / generate_overrides / generate_property / implement_interface) (#994)
 - Extracted shared `TypeCoverage` and replaced 7 identical Hierarchy/Extract/Generate copies (`pull_members_up` / `push_members_down` / `use_base_type` / `extract_interface` / `extract_base_class` / `generate_tostring` / `implement_abstract`) (#990)

--- a/src/RoslynMcp.Core/Refactoring/Encapsulate/EncapsulateFieldOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Encapsulate/EncapsulateFieldOperation.cs
@@ -716,9 +716,9 @@ public sealed class EncapsulateFieldOperation : RefactoringOperationBase<Encapsu
             // candidate. If nothing covers this position, keep today's
             // not-found (null) rather than inventing a first-match.
             return matches
-                .Where(declarator => FieldCoversColumn(declarator, line!.Value, column.Value))
-                .OrderBy(declarator => IdentifierCoversColumn(declarator, line!.Value, column.Value) ? 0 : 1)
-                .ThenBy(declarator => SmallestCoveringSpanLength(declarator, line!.Value, column.Value))
+                .Where(declarator => FieldCoverage.FieldCoversColumn(declarator, line!.Value, column.Value))
+                .OrderBy(declarator => FieldCoverage.IdentifierCoversColumn(declarator, line!.Value, column.Value) ? 0 : 1)
+                .ThenBy(declarator => FieldCoverage.SmallestCoveringSpanLength(declarator, line!.Value, column.Value))
                 .FirstOrDefault();
         }
 
@@ -726,67 +726,15 @@ public sealed class EncapsulateFieldOperation : RefactoringOperationBase<Encapsu
             return matches.FirstOrDefault();
 
         return matches
-            .Where(declarator => FieldCoversLine(declarator, line.Value))
-            .OrderBy(declarator => IdentifierCoversLine(declarator, line.Value) ? 0 : 1)
-            .ThenBy(declarator => SmallestCoveringSpanLength(declarator, line.Value))
+            .Where(declarator => FieldCoverage.FieldCoversLine(declarator, line.Value))
+            .OrderBy(declarator => FieldCoverage.IdentifierCoversLine(declarator, line.Value) ? 0 : 1)
+            .ThenBy(declarator => FieldCoverage.SmallestCoveringSpanLength(declarator, line.Value))
             .FirstOrDefault();
 
         bool IsMatchingFieldDeclarator(VariableDeclaratorSyntax declarator) =>
             declarator.Identifier.Text == fieldName &&
             IsFieldDeclarator(declarator);
     }
-
-    private static bool FieldCoversLine(VariableDeclaratorSyntax declarator, int line) =>
-        IdentifierCoversLine(declarator, line) ||
-        SpanCoverage.SpanCoversLine(declarator.GetLocation().GetLineSpan(), line) ||
-        (GetFieldDeclaration(declarator) is { } field &&
-         SpanCoverage.SpanCoversLine(field.GetLocation().GetLineSpan(), line));
-
-    private static bool IdentifierCoversLine(VariableDeclaratorSyntax declarator, int line) =>
-        SpanCoverage.SpanCoversLine(declarator.Identifier.GetLocation().GetLineSpan(), line);
-
-    private static bool FieldCoversColumn(VariableDeclaratorSyntax declarator, int line, int column) =>
-        IdentifierCoversColumn(declarator, line, column) ||
-        SpanCoverage.SpanCoversColumn(declarator.GetLocation().GetLineSpan(), line, column) ||
-        (GetFieldDeclaration(declarator) is { } field &&
-         SpanCoverage.SpanCoversColumn(field.GetLocation().GetLineSpan(), line, column));
-
-    private static bool IdentifierCoversColumn(VariableDeclaratorSyntax declarator, int line, int column) =>
-        SpanCoverage.SpanCoversColumn(declarator.Identifier.GetLocation().GetLineSpan(), line, column);
-
-    private static int SmallestCoveringSpanLength(VariableDeclaratorSyntax declarator, int line)
-    {
-        var smallest = int.MaxValue;
-        if (SpanCoverage.SpanCoversLine(declarator.GetLocation().GetLineSpan(), line))
-            smallest = Math.Min(smallest, declarator.Span.Length);
-
-        if (GetFieldDeclaration(declarator) is { } field &&
-            SpanCoverage.SpanCoversLine(field.GetLocation().GetLineSpan(), line))
-        {
-            smallest = Math.Min(smallest, field.Span.Length);
-        }
-
-        return smallest;
-    }
-
-    private static int SmallestCoveringSpanLength(VariableDeclaratorSyntax declarator, int line, int column)
-    {
-        var smallest = int.MaxValue;
-        if (SpanCoverage.SpanCoversColumn(declarator.GetLocation().GetLineSpan(), line, column))
-            smallest = Math.Min(smallest, declarator.Span.Length);
-
-        if (GetFieldDeclaration(declarator) is { } field &&
-            SpanCoverage.SpanCoversColumn(field.GetLocation().GetLineSpan(), line, column))
-        {
-            smallest = Math.Min(smallest, field.Span.Length);
-        }
-
-        return smallest;
-    }
-
-    private static FieldDeclarationSyntax? GetFieldDeclaration(VariableDeclaratorSyntax declarator) =>
-        declarator.Parent?.Parent as FieldDeclarationSyntax;
-
 
     /// <summary>
     /// True when the reference lives in the selected field's containing

--- a/src/RoslynMcp.Core/Refactoring/Inline/InlineConstantOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Inline/InlineConstantOperation.cs
@@ -542,9 +542,9 @@ public sealed class InlineConstantOperation : RefactoringOperationBase<InlineCon
             // candidate. If nothing covers this position, keep today's
             // not-found rather than inventing a first-match.
             var covering = candidates
-                .Where(declarator => FieldCoversColumn(declarator, @params.Line!.Value, @params.Column.Value))
-                .OrderBy(declarator => IdentifierCoversColumn(declarator, @params.Line!.Value, @params.Column.Value) ? 0 : 1)
-                .ThenBy(declarator => SmallestCoveringSpanLength(declarator, @params.Line!.Value, @params.Column.Value))
+                .Where(declarator => FieldCoverage.FieldCoversColumn(declarator, @params.Line!.Value, @params.Column.Value))
+                .OrderBy(declarator => FieldCoverage.IdentifierCoversColumn(declarator, @params.Line!.Value, @params.Column.Value) ? 0 : 1)
+                .ThenBy(declarator => FieldCoverage.SmallestCoveringSpanLength(declarator, @params.Line!.Value, @params.Column.Value))
                 .ToList();
 
             if (covering.Count == 0)
@@ -557,9 +557,9 @@ public sealed class InlineConstantOperation : RefactoringOperationBase<InlineCon
             return PickOmittedLineMatch(candidates, semanticModel, @params, cancellationToken);
 
         var lineCovering = candidates
-            .Where(declarator => FieldCoversLine(declarator, @params.Line.Value))
-            .OrderBy(declarator => IdentifierCoversLine(declarator, @params.Line.Value) ? 0 : 1)
-            .ThenBy(declarator => SmallestCoveringSpanLength(declarator, @params.Line.Value))
+            .Where(declarator => FieldCoverage.FieldCoversLine(declarator, @params.Line.Value))
+            .OrderBy(declarator => FieldCoverage.IdentifierCoversLine(declarator, @params.Line.Value) ? 0 : 1)
+            .ThenBy(declarator => FieldCoverage.SmallestCoveringSpanLength(declarator, @params.Line.Value))
             .ToList();
 
         if (lineCovering.Count == 0)
@@ -598,59 +598,6 @@ public sealed class InlineConstantOperation : RefactoringOperationBase<InlineCon
             string.IsNullOrWhiteSpace(@params.TypeName)
                 ? $"Constant '{@params.ConstantName}' not found."
                 : $"Constant '{@params.ConstantName}' not found on type '{@params.TypeName}'.");
-
-    private static bool FieldCoversLine(VariableDeclaratorSyntax declarator, int line) =>
-        IdentifierCoversLine(declarator, line) ||
-        SpanCoverage.SpanCoversLine(declarator.GetLocation().GetLineSpan(), line) ||
-        (GetFieldDeclaration(declarator) is { } field &&
-         SpanCoverage.SpanCoversLine(field.GetLocation().GetLineSpan(), line));
-
-    private static bool IdentifierCoversLine(VariableDeclaratorSyntax declarator, int line) =>
-        SpanCoverage.SpanCoversLine(declarator.Identifier.GetLocation().GetLineSpan(), line);
-
-    private static bool FieldCoversColumn(VariableDeclaratorSyntax declarator, int line, int column) =>
-        IdentifierCoversColumn(declarator, line, column) ||
-        SpanCoverage.SpanCoversColumn(declarator.GetLocation().GetLineSpan(), line, column) ||
-        (GetFieldDeclaration(declarator) is { } field &&
-         SpanCoverage.SpanCoversColumn(field.GetLocation().GetLineSpan(), line, column));
-
-    private static bool IdentifierCoversColumn(VariableDeclaratorSyntax declarator, int line, int column) =>
-        SpanCoverage.SpanCoversColumn(declarator.Identifier.GetLocation().GetLineSpan(), line, column);
-
-    private static int SmallestCoveringSpanLength(VariableDeclaratorSyntax declarator, int line)
-    {
-        var smallest = int.MaxValue;
-        if (SpanCoverage.SpanCoversLine(declarator.GetLocation().GetLineSpan(), line))
-            smallest = Math.Min(smallest, declarator.Span.Length);
-
-        if (GetFieldDeclaration(declarator) is { } field &&
-            SpanCoverage.SpanCoversLine(field.GetLocation().GetLineSpan(), line))
-        {
-            smallest = Math.Min(smallest, field.Span.Length);
-        }
-
-        return smallest;
-    }
-
-    private static int SmallestCoveringSpanLength(VariableDeclaratorSyntax declarator, int line, int column)
-    {
-        var smallest = int.MaxValue;
-        if (SpanCoverage.SpanCoversColumn(declarator.GetLocation().GetLineSpan(), line, column))
-            smallest = Math.Min(smallest, declarator.Span.Length);
-
-        if (GetFieldDeclaration(declarator) is { } field &&
-            SpanCoverage.SpanCoversColumn(field.GetLocation().GetLineSpan(), line, column))
-        {
-            smallest = Math.Min(smallest, field.Span.Length);
-        }
-
-        return smallest;
-    }
-
-    private static FieldDeclarationSyntax? GetFieldDeclaration(VariableDeclaratorSyntax declarator) =>
-        declarator.Parent?.Parent as FieldDeclarationSyntax;
-
-
 
     private static bool MatchesTypeName(IFieldSymbol? field, string typeName)
     {

--- a/src/RoslynMcp.Core/Resolution/FieldCoverage.cs
+++ b/src/RoslynMcp.Core/Resolution/FieldCoverage.cs
@@ -1,0 +1,92 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace RoslynMcp.Core.Resolution;
+
+/// <summary>
+/// Shared field-declarator coverage helpers used when disambiguating
+/// same-named fields by optional 1-based line / column (identifier preferred,
+/// then declarator / containing field span via <see cref="SpanCoverage"/>).
+/// </summary>
+internal static class FieldCoverage
+{
+    /// <summary>
+    /// True when the declarator's identifier, declarator span, or containing
+    /// field declaration covers <paramref name="line"/> (exclusive-end line
+    /// rules via <see cref="SpanCoverage.SpanCoversLine(FileLinePositionSpan, int)"/>).
+    /// </summary>
+    internal static bool FieldCoversLine(VariableDeclaratorSyntax declarator, int line) =>
+        IdentifierCoversLine(declarator, line) ||
+        SpanCoverage.SpanCoversLine(declarator.GetLocation().GetLineSpan(), line) ||
+        (GetFieldDeclaration(declarator) is { } field &&
+         SpanCoverage.SpanCoversLine(field.GetLocation().GetLineSpan(), line));
+
+    /// <summary>
+    /// True when the declarator's identifier covers <paramref name="line"/>.
+    /// </summary>
+    internal static bool IdentifierCoversLine(VariableDeclaratorSyntax declarator, int line) =>
+        SpanCoverage.SpanCoversLine(declarator.Identifier.GetLocation().GetLineSpan(), line);
+
+    /// <summary>
+    /// True when the declarator's identifier, declarator span, or containing
+    /// field declaration covers <paramref name="line"/> / <paramref name="column"/>
+    /// (exclusive-end column rules via <see cref="SpanCoverage.SpanCoversColumn"/>).
+    /// </summary>
+    internal static bool FieldCoversColumn(VariableDeclaratorSyntax declarator, int line, int column) =>
+        IdentifierCoversColumn(declarator, line, column) ||
+        SpanCoverage.SpanCoversColumn(declarator.GetLocation().GetLineSpan(), line, column) ||
+        (GetFieldDeclaration(declarator) is { } field &&
+         SpanCoverage.SpanCoversColumn(field.GetLocation().GetLineSpan(), line, column));
+
+    /// <summary>
+    /// True when the declarator's identifier covers
+    /// <paramref name="line"/> / <paramref name="column"/>.
+    /// </summary>
+    internal static bool IdentifierCoversColumn(VariableDeclaratorSyntax declarator, int line, int column) =>
+        SpanCoverage.SpanCoversColumn(declarator.Identifier.GetLocation().GetLineSpan(), line, column);
+
+    /// <summary>
+    /// Smallest spanning length among the declarator and containing field that
+    /// cover <paramref name="line"/>; <see cref="int.MaxValue"/> if none cover.
+    /// </summary>
+    internal static int SmallestCoveringSpanLength(VariableDeclaratorSyntax declarator, int line)
+    {
+        var smallest = int.MaxValue;
+        if (SpanCoverage.SpanCoversLine(declarator.GetLocation().GetLineSpan(), line))
+            smallest = Math.Min(smallest, declarator.Span.Length);
+
+        if (GetFieldDeclaration(declarator) is { } field &&
+            SpanCoverage.SpanCoversLine(field.GetLocation().GetLineSpan(), line))
+        {
+            smallest = Math.Min(smallest, field.Span.Length);
+        }
+
+        return smallest;
+    }
+
+    /// <summary>
+    /// Smallest spanning length among the declarator and containing field that
+    /// cover <paramref name="line"/> / <paramref name="column"/>;
+    /// <see cref="int.MaxValue"/> if none cover.
+    /// </summary>
+    internal static int SmallestCoveringSpanLength(VariableDeclaratorSyntax declarator, int line, int column)
+    {
+        var smallest = int.MaxValue;
+        if (SpanCoverage.SpanCoversColumn(declarator.GetLocation().GetLineSpan(), line, column))
+            smallest = Math.Min(smallest, declarator.Span.Length);
+
+        if (GetFieldDeclaration(declarator) is { } field &&
+            SpanCoverage.SpanCoversColumn(field.GetLocation().GetLineSpan(), line, column))
+        {
+            smallest = Math.Min(smallest, field.Span.Length);
+        }
+
+        return smallest;
+    }
+
+    /// <summary>
+    /// Containing <see cref="FieldDeclarationSyntax"/> for a field declarator, if any.
+    /// </summary>
+    internal static FieldDeclarationSyntax? GetFieldDeclaration(VariableDeclaratorSyntax declarator) =>
+        declarator.Parent?.Parent as FieldDeclarationSyntax;
+}

--- a/tests/RoslynMcp.Core.Tests/Resolution/FieldCoverageTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Resolution/FieldCoverageTests.cs
@@ -1,0 +1,127 @@
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using RoslynMcp.Core.Resolution;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Resolution;
+
+public class FieldCoverageTests
+{
+    [Fact]
+    public void GetFieldDeclaration_ReturnsField_NullForLocal()
+    {
+        var tree = CSharpSyntaxTree.ParseText("""
+            class C
+            {
+                int _x = 1;
+                void M() { int y = 2; }
+            }
+            """);
+        var root = tree.GetRoot();
+        var fieldDecl = root.DescendantNodes().OfType<VariableDeclaratorSyntax>()
+            .Single(d => d.Identifier.ValueText == "_x");
+        var localDecl = root.DescendantNodes().OfType<VariableDeclaratorSyntax>()
+            .Single(d => d.Identifier.ValueText == "y");
+
+        Assert.NotNull(FieldCoverage.GetFieldDeclaration(fieldDecl));
+        Assert.IsType<FieldDeclarationSyntax>(FieldCoverage.GetFieldDeclaration(fieldDecl));
+        Assert.Null(FieldCoverage.GetFieldDeclaration(localDecl));
+    }
+
+    [Fact]
+    public void IdentifierCoversLine_True_OnIdentifierLine_False_OnOtherFieldLine()
+    {
+        var tree = CSharpSyntaxTree.ParseText("""
+            class C
+            {
+                int _a = 1;
+
+                int _b = 2;
+            }
+            """);
+        var root = tree.GetRoot();
+        var a = root.DescendantNodes().OfType<VariableDeclaratorSyntax>()
+            .Single(d => d.Identifier.ValueText == "_a");
+        var b = root.DescendantNodes().OfType<VariableDeclaratorSyntax>()
+            .Single(d => d.Identifier.ValueText == "_b");
+        var aLine = a.Identifier.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+        var bLine = b.Identifier.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+
+        Assert.True(FieldCoverage.IdentifierCoversLine(a, aLine));
+        Assert.True(FieldCoverage.FieldCoversLine(a, aLine));
+        Assert.False(FieldCoverage.IdentifierCoversLine(a, bLine));
+        Assert.False(FieldCoverage.FieldCoversLine(a, bLine));
+        Assert.False(FieldCoverage.FieldCoversLine(a, 0));
+    }
+
+    [Fact]
+    public void FieldCoversColumn_True_OnIdentifier_False_AtExclusiveEnd()
+    {
+        var tree = CSharpSyntaxTree.ParseText("""
+            class C
+            {
+                int _x = 1;
+            }
+            """);
+        var root = tree.GetRoot();
+        var decl = root.DescendantNodes().OfType<VariableDeclaratorSyntax>().Single();
+        var idSpan = decl.Identifier.GetLocation().GetLineSpan();
+        var line = idSpan.StartLinePosition.Line + 1;
+        var startCol = idSpan.StartLinePosition.Character + 1;
+        var endCol = idSpan.EndLinePosition.Character + 1;
+
+        Assert.True(FieldCoverage.FieldCoversColumn(decl, line, startCol));
+        Assert.True(FieldCoverage.IdentifierCoversColumn(decl, line, startCol));
+        Assert.True(FieldCoverage.IdentifierCoversColumn(decl, line, endCol - 1));
+        Assert.False(FieldCoverage.IdentifierCoversColumn(decl, line, endCol));
+        // endCol is past the identifier exclusive end but still inside the field span.
+        Assert.True(FieldCoverage.FieldCoversColumn(decl, line, endCol));
+        Assert.False(FieldCoverage.IdentifierCoversColumn(decl, line, startCol - 1));
+    }
+
+    [Fact]
+    public void FieldCoversLine_True_OnFieldSpanFallback_WhenPastIdentifier()
+    {
+        // Multi-line field: identifier on first line; type/modifiers line still covers via field span.
+        var tree = CSharpSyntaxTree.ParseText("""
+            class C
+            {
+                private static readonly int
+                    LongName = 1;
+            }
+            """);
+        var root = tree.GetRoot();
+        var decl = root.DescendantNodes().OfType<VariableDeclaratorSyntax>().Single();
+        var field = FieldCoverage.GetFieldDeclaration(decl)!;
+        var fieldStartLine = field.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+        var idLine = decl.Identifier.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+
+        Assert.NotEqual(fieldStartLine, idLine);
+        Assert.False(FieldCoverage.IdentifierCoversLine(decl, fieldStartLine));
+        Assert.True(FieldCoverage.FieldCoversLine(decl, fieldStartLine));
+        Assert.True(FieldCoverage.FieldCoversLine(decl, idLine));
+    }
+
+    [Fact]
+    public void SmallestCoveringSpanLength_PrefersDeclaratorOverField()
+    {
+        var tree = CSharpSyntaxTree.ParseText("""
+            class C
+            {
+                int _x = 1, _y = 2;
+            }
+            """);
+        var root = tree.GetRoot();
+        var x = root.DescendantNodes().OfType<VariableDeclaratorSyntax>()
+            .Single(d => d.Identifier.ValueText == "_x");
+        var line = x.Identifier.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+        var field = FieldCoverage.GetFieldDeclaration(x)!;
+
+        var smallest = FieldCoverage.SmallestCoveringSpanLength(x, line);
+        Assert.True(smallest < field.Span.Length);
+        Assert.Equal(x.Span.Length, smallest);
+
+        var col = x.Identifier.GetLocation().GetLineSpan().StartLinePosition.Character + 1;
+        Assert.Equal(x.Span.Length, FieldCoverage.SmallestCoveringSpanLength(x, line, col));
+    }
+}


### PR DESCRIPTION
## Summary
- Extract shared `FieldCoverage` under `RoslynMcp.Core.Resolution` for identical field-declarator coverage helpers (`FieldCoversLine` / `IdentifierCoversLine` / `FieldCoversColumn` / `IdentifierCoversColumn` / `GetFieldDeclaration` / `SmallestCoveringSpanLength` overloads).
- Replace type-local copies in `EncapsulateFieldOperation` and `InlineConstantOperation` with `FieldCoverage.*` call sites.
- Add focused `FieldCoverageTests`; CHANGELOG Unreleased one-liner.
- Behavior-preserving only. Closes #1002.

## Test plan
- [x] `dotnet test tests/RoslynMcp.Core.Tests --filter FullyQualifiedName~FieldCoverage` (5 passed)
- [x] Broader filter EncapsulateField|InlineConstant|FieldCoverage (169 passed)
- [ ] CI Build & Test + CodeQL green