### PR TITLE
Extract AccessibilityModifiers.HasAccessibility; replace 4 Hierarchy copies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- Extracted shared `AccessibilityModifiers.HasAccessibility` and replaced 4 identical Hierarchy copies (`pull_members_up` / `push_members_down` / HierarchyAbstractMemberRewriter / OverrideAccessibilityReducer) (#1006)
 - Extracted shared `FieldCoverage` and replaced EncapsulateField + InlineConstant FieldCovers* / IdentifierCovers* / GetFieldDeclaration / SmallestCoveringSpanLength copies (`encapsulate_field` / `inline_constant`) (#1002)
 - Extracted shared `MethodCoverage` and replaced 7 identical MethodCoversColumn / IdentifierCoversColumn copies (`add_parameter` / `remove_parameter` / `reorder_parameters` / `change_signature` / `change_return_type` / `convert_to_async` / `inline_method`) (#997)
 - Replaced 5 identical Generate-family TypeCovers* / IdentifierCovers* copies with shared TypeCoverage (generate_constructor / generate_equals_hashcode / generate_overrides / generate_property / implement_interface) (#994)

--- a/src/RoslynMcp.Core/Refactoring/Hierarchy/HierarchyAbstractMemberRewriter.cs
+++ b/src/RoslynMcp.Core/Refactoring/Hierarchy/HierarchyAbstractMemberRewriter.cs
@@ -2,6 +2,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using RoslynMcp.Contracts.Errors;
+using RoslynMcp.Core.Refactoring.Utilities;
 
 namespace RoslynMcp.Core.Refactoring.Hierarchy;
 
@@ -239,7 +240,7 @@ internal static class HierarchyAbstractMemberRewriter
                 SyntaxKind.AsyncKeyword)
             .ToList();
 
-        if (!HasAccessibility(tokens))
+        if (!AccessibilityModifiers.HasAccessibility(tokens))
             tokens.Insert(0, SyntaxFactory.Token(SyntaxKind.ProtectedKeyword));
 
         tokens.Add(SyntaxFactory.Token(SyntaxKind.AbstractKeyword));
@@ -257,7 +258,7 @@ internal static class HierarchyAbstractMemberRewriter
                 SyntaxKind.NewKeyword)
             .ToList();
 
-        if (modifiers.Any(SyntaxKind.PrivateKeyword) || !HasAccessibility(tokens))
+        if (modifiers.Any(SyntaxKind.PrivateKeyword) || !AccessibilityModifiers.HasAccessibility(tokens))
             tokens.Insert(0, SyntaxFactory.Token(SyntaxKind.ProtectedKeyword));
 
         tokens.Add(SyntaxFactory.Token(SyntaxKind.OverrideKeyword)
@@ -271,10 +272,4 @@ internal static class HierarchyAbstractMemberRewriter
         return modifiers.Where(token => !kindSet.Contains(token.Kind()));
     }
 
-    private static bool HasAccessibility(IEnumerable<SyntaxToken> modifiers) =>
-        modifiers.Any(token =>
-            token.IsKind(SyntaxKind.PublicKeyword) ||
-            token.IsKind(SyntaxKind.ProtectedKeyword) ||
-            token.IsKind(SyntaxKind.InternalKeyword) ||
-            token.IsKind(SyntaxKind.PrivateKeyword));
 }

--- a/src/RoslynMcp.Core/Refactoring/Hierarchy/OverrideAccessibilityReducer.cs
+++ b/src/RoslynMcp.Core/Refactoring/Hierarchy/OverrideAccessibilityReducer.cs
@@ -28,7 +28,7 @@ internal static class OverrideAccessibilityReducer
             return modifiers;
 
         var tokens = modifiers.Where(token => !token.IsKind(SyntaxKind.InternalKeyword)).ToList();
-        if (!HasAccessibility(tokens))
+        if (!AccessibilityModifiers.HasAccessibility(tokens))
             tokens.Insert(0, SyntaxFactory.Token(SyntaxKind.ProtectedKeyword));
         return SyntaxFactory.TokenList(tokens);
     }
@@ -112,10 +112,4 @@ internal static class OverrideAccessibilityReducer
         return member.WithAccessorList(SyntaxFactory.AccessorList(SyntaxFactory.List(accessors)));
     }
 
-    private static bool HasAccessibility(IEnumerable<SyntaxToken> modifiers) =>
-        modifiers.Any(token =>
-            token.IsKind(SyntaxKind.PublicKeyword) ||
-            token.IsKind(SyntaxKind.ProtectedKeyword) ||
-            token.IsKind(SyntaxKind.InternalKeyword) ||
-            token.IsKind(SyntaxKind.PrivateKeyword));
 }

--- a/src/RoslynMcp.Core/Refactoring/Hierarchy/PullMembersUpOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Hierarchy/PullMembersUpOperation.cs
@@ -9,6 +9,7 @@ using RoslynMcp.Core.Refactoring.Base;
 using RoslynMcp.Core.Refactoring.Generate;
 using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
+using RoslynMcp.Core.Refactoring.Utilities;
 
 namespace RoslynMcp.Core.Refactoring.Hierarchy;
 
@@ -985,7 +986,7 @@ public sealed class PullMembersUpOperation : RefactoringOperationBase<PullMember
                 SyntaxKind.NewKeyword)
             .ToList();
 
-        if (modifiers.Any(SyntaxKind.PrivateKeyword) || !HasAccessibility(tokens))
+        if (modifiers.Any(SyntaxKind.PrivateKeyword) || !AccessibilityModifiers.HasAccessibility(tokens))
             tokens.Insert(0, SyntaxFactory.Token(SyntaxKind.ProtectedKeyword));
 
         var alreadyOverridable = tokens.Any(t =>
@@ -1005,12 +1006,6 @@ public sealed class PullMembersUpOperation : RefactoringOperationBase<PullMember
         return modifiers.Where(token => !kindSet.Contains(token.Kind()));
     }
 
-    private static bool HasAccessibility(IEnumerable<SyntaxToken> modifiers) =>
-        modifiers.Any(token =>
-            token.IsKind(SyntaxKind.PublicKeyword) ||
-            token.IsKind(SyntaxKind.ProtectedKeyword) ||
-            token.IsKind(SyntaxKind.InternalKeyword) ||
-            token.IsKind(SyntaxKind.PrivateKeyword));
 
     private static TypeDeclarationSyntax BuildDerivedReplacement(
         TypeDeclarationSyntax derivedDecl,

--- a/src/RoslynMcp.Core/Refactoring/Hierarchy/PullMembersUpOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Hierarchy/PullMembersUpOperation.cs
@@ -7,9 +7,9 @@ using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
 using RoslynMcp.Core.Refactoring.Generate;
+using RoslynMcp.Core.Refactoring.Utilities;
 using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
-using RoslynMcp.Core.Refactoring.Utilities;
 
 namespace RoslynMcp.Core.Refactoring.Hierarchy;
 

--- a/src/RoslynMcp.Core/Refactoring/Hierarchy/PushMembersDownOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Hierarchy/PushMembersDownOperation.cs
@@ -8,9 +8,9 @@ using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
 using RoslynMcp.Core.Refactoring.Generate;
+using RoslynMcp.Core.Refactoring.Utilities;
 using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
-using RoslynMcp.Core.Refactoring.Utilities;
 
 namespace RoslynMcp.Core.Refactoring.Hierarchy;
 

--- a/src/RoslynMcp.Core/Refactoring/Hierarchy/PushMembersDownOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Hierarchy/PushMembersDownOperation.cs
@@ -10,6 +10,7 @@ using RoslynMcp.Core.Refactoring.Base;
 using RoslynMcp.Core.Refactoring.Generate;
 using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
+using RoslynMcp.Core.Refactoring.Utilities;
 
 namespace RoslynMcp.Core.Refactoring.Hierarchy;
 
@@ -1197,7 +1198,7 @@ public sealed class PushMembersDownOperation : RefactoringOperationBase<PushMemb
 
     private static MemberDeclarationSyntax EnsurePublicAccessibility(MemberDeclarationSyntax member)
     {
-        if (HasAccessibility(member.Modifiers))
+        if (AccessibilityModifiers.HasAccessibility(member.Modifiers))
             return member;
 
         return member.WithModifiers(
@@ -1710,7 +1711,7 @@ public sealed class PushMembersDownOperation : RefactoringOperationBase<PushMemb
                 SyntaxKind.NewKeyword)
             .ToList();
 
-        if (!HasAccessibility(tokens))
+        if (!AccessibilityModifiers.HasAccessibility(tokens))
             tokens.Insert(0, SyntaxFactory.Token(SyntaxKind.ProtectedKeyword));
 
         tokens.Add(SyntaxFactory.Token(SyntaxKind.AbstractKeyword));
@@ -1735,7 +1736,7 @@ public sealed class PushMembersDownOperation : RefactoringOperationBase<PushMemb
                 SyntaxKind.SealedKeyword)
             .ToList();
 
-        if (modifiers.Any(SyntaxKind.PrivateKeyword) || !HasAccessibility(tokens))
+        if (modifiers.Any(SyntaxKind.PrivateKeyword) || !AccessibilityModifiers.HasAccessibility(tokens))
             tokens.Insert(0, SyntaxFactory.Token(SyntaxKind.ProtectedKeyword));
 
         tokens.Add(SyntaxFactory.Token(SyntaxKind.OverrideKeyword)
@@ -1752,12 +1753,6 @@ public sealed class PushMembersDownOperation : RefactoringOperationBase<PushMemb
         return modifiers.Where(token => !kindSet.Contains(token.Kind()));
     }
 
-    private static bool HasAccessibility(IEnumerable<SyntaxToken> modifiers) =>
-        modifiers.Any(token =>
-            token.IsKind(SyntaxKind.PublicKeyword) ||
-            token.IsKind(SyntaxKind.ProtectedKeyword) ||
-            token.IsKind(SyntaxKind.InternalKeyword) ||
-            token.IsKind(SyntaxKind.PrivateKeyword));
 
     private static TypeDeclarationSyntax BuildSourceReplacement(
         TypeDeclarationSyntax sourceDecl,

--- a/src/RoslynMcp.Core/Refactoring/Utilities/AccessibilityModifiers.cs
+++ b/src/RoslynMcp.Core/Refactoring/Utilities/AccessibilityModifiers.cs
@@ -1,0 +1,23 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace RoslynMcp.Core.Refactoring.Utilities;
+
+/// <summary>
+/// Shared modifier-accessibility helpers used by hierarchy pull/push and
+/// override emission when deciding whether an explicit accessibility keyword
+/// is already present on a member.
+/// </summary>
+internal static class AccessibilityModifiers
+{
+    /// <summary>
+    /// True when <paramref name="modifiers"/> contains any of
+    /// <c>public</c>, <c>protected</c>, <c>internal</c>, or <c>private</c>.
+    /// </summary>
+    internal static bool HasAccessibility(IEnumerable<SyntaxToken> modifiers) =>
+        modifiers.Any(token =>
+            token.IsKind(SyntaxKind.PublicKeyword) ||
+            token.IsKind(SyntaxKind.ProtectedKeyword) ||
+            token.IsKind(SyntaxKind.InternalKeyword) ||
+            token.IsKind(SyntaxKind.PrivateKeyword));
+}

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Utilities/AccessibilityModifiersTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Utilities/AccessibilityModifiersTests.cs
@@ -1,0 +1,55 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using RoslynMcp.Core.Refactoring.Utilities;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Refactoring.Utilities;
+
+public class AccessibilityModifiersTests
+{
+    [Theory]
+    [InlineData(SyntaxKind.PublicKeyword)]
+    [InlineData(SyntaxKind.ProtectedKeyword)]
+    [InlineData(SyntaxKind.InternalKeyword)]
+    [InlineData(SyntaxKind.PrivateKeyword)]
+    public void HasAccessibility_True_ForEachAccessibilityKeyword(SyntaxKind kind)
+    {
+        var modifiers = new[] { SyntaxFactory.Token(kind) };
+        Assert.True(AccessibilityModifiers.HasAccessibility(modifiers));
+    }
+
+    [Fact]
+    public void HasAccessibility_True_WhenMixedWithNonAccessibility()
+    {
+        var modifiers = new[]
+        {
+            SyntaxFactory.Token(SyntaxKind.StaticKeyword),
+            SyntaxFactory.Token(SyntaxKind.ProtectedKeyword),
+            SyntaxFactory.Token(SyntaxKind.VirtualKeyword),
+        };
+        Assert.True(AccessibilityModifiers.HasAccessibility(modifiers));
+    }
+
+    [Fact]
+    public void HasAccessibility_False_WhenEmpty()
+    {
+        Assert.False(AccessibilityModifiers.HasAccessibility(Array.Empty<SyntaxToken>()));
+    }
+
+    [Fact]
+    public void HasAccessibility_False_WhenOnlyNonAccessibilityModifiers()
+    {
+        var modifiers = new[]
+        {
+            SyntaxFactory.Token(SyntaxKind.StaticKeyword),
+            SyntaxFactory.Token(SyntaxKind.AsyncKeyword),
+            SyntaxFactory.Token(SyntaxKind.VirtualKeyword),
+            SyntaxFactory.Token(SyntaxKind.OverrideKeyword),
+            SyntaxFactory.Token(SyntaxKind.AbstractKeyword),
+            SyntaxFactory.Token(SyntaxKind.SealedKeyword),
+            SyntaxFactory.Token(SyntaxKind.NewKeyword),
+            SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword),
+        };
+        Assert.False(AccessibilityModifiers.HasAccessibility(modifiers));
+    }
+}


### PR DESCRIPTION
## Summary
- Extract shared `AccessibilityModifiers.HasAccessibility` under `RoslynMcp.Core.Refactoring.Utilities` (byte-identical body).
- Replace type-local copies in `PullMembersUpOperation`, `PushMembersDownOperation`, `HierarchyAbstractMemberRewriter`, and `OverrideAccessibilityReducer`.
- Add focused unit tests; CHANGELOG Unreleased Changed one-liner.
- Closes #1006

## Test plan
- [x] `dotnet test` filter `AccessibilityModifiersTests|PullMembersUp|PushMembersDown|UseBaseType|Hierarchy` — 367 passed locally
- [ ] CI green (Build & Test + CodeQL)
- [ ] Dependabot untouched; do not squash-merge from this agent