### PR TITLE
Extract DeclarationIdentifiers; replace MakeStatic + MakeNonStatic copies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- Extracted shared `DeclarationIdentifiers` and replaced MakeStatic + MakeNonStatic GetDeclarationIdentifier / IdentifierOverlaps copies (`make_static` / `make_non_static`) (#1009)
 - Extracted shared `AccessibilityModifiers.HasAccessibility` and replaced 4 identical Hierarchy copies (`pull_members_up` / `push_members_down` / HierarchyAbstractMemberRewriter / OverrideAccessibilityReducer) (#1006)
 - Extracted shared `FieldCoverage` and replaced EncapsulateField + InlineConstant FieldCovers* / IdentifierCovers* / GetFieldDeclaration / SmallestCoveringSpanLength copies (`encapsulate_field` / `inline_constant`) (#1002)
 - Extracted shared `MethodCoverage` and replaced 7 identical MethodCoversColumn / IdentifierCoversColumn copies (`add_parameter` / `remove_parameter` / `reorder_parameters` / `change_signature` / `change_return_type` / `convert_to_async` / `inline_method`) (#997)

--- a/src/RoslynMcp.Core/Refactoring/Extract/DeclarationIdentifiers.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/DeclarationIdentifiers.cs
@@ -1,0 +1,47 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace RoslynMcp.Core.Refactoring.Extract;
+
+/// <summary>
+/// Shared declaration-identifier helpers used by make_static / make_non_static
+/// when matching a text span to a declaration name token (method, local
+/// function, constructor, destructor, operator, conversion, property, event,
+/// variable, type, or parameter).
+/// </summary>
+internal static class DeclarationIdentifiers
+{
+    /// <summary>
+    /// True when the node's declaration identifier overlaps
+    /// <paramref name="span"/> (either direction of
+    /// <see cref="TextSpan.OverlapsWith(TextSpan)"/>).
+    /// </summary>
+    internal static bool IdentifierOverlaps(SyntaxNode node, TextSpan span)
+    {
+        var identifier = GetDeclarationIdentifier(node);
+        return identifier != null &&
+            (identifier.Value.Span.OverlapsWith(span) || span.OverlapsWith(identifier.Value.Span));
+    }
+
+    /// <summary>
+    /// Declaration name token for supported declaration shapes; otherwise
+    /// <see langword="null"/>. Conversion operators use the last token of
+    /// the return type (same as the MakeStatic / MakeNonStatic copies).
+    /// </summary>
+    internal static SyntaxToken? GetDeclarationIdentifier(SyntaxNode node) => node switch
+    {
+        MethodDeclarationSyntax method => method.Identifier,
+        LocalFunctionStatementSyntax localFunction => localFunction.Identifier,
+        ConstructorDeclarationSyntax constructor => constructor.Identifier,
+        DestructorDeclarationSyntax destructor => destructor.Identifier,
+        OperatorDeclarationSyntax @operator => @operator.OperatorToken,
+        ConversionOperatorDeclarationSyntax conversion => conversion.Type.GetLastToken(),
+        PropertyDeclarationSyntax property => property.Identifier,
+        EventDeclarationSyntax @event => @event.Identifier,
+        VariableDeclaratorSyntax variable => variable.Identifier,
+        TypeDeclarationSyntax type => type.Identifier,
+        ParameterSyntax parameter => parameter.Identifier,
+        _ => null
+    };
+}

--- a/src/RoslynMcp.Core/Refactoring/Extract/MakeNonStaticOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/MakeNonStaticOperation.cs
@@ -564,7 +564,7 @@ public sealed class MakeNonStaticOperation : RefactoringOperationBase<MakeNonSta
             if (tokenNode != null)
             {
                 var declaredOnToken = semanticModel.GetDeclaredSymbol(tokenNode, cancellationToken);
-                if (declaredOnToken != null && IdentifierOverlaps(tokenNode, span))
+                if (declaredOnToken != null && DeclarationIdentifiers.IdentifierOverlaps(tokenNode, span))
                     return ConfirmSymbolName(declaredOnToken, @params.SymbolName);
 
                 if (token.IsKind(SyntaxKind.IdentifierToken))
@@ -578,7 +578,7 @@ public sealed class MakeNonStaticOperation : RefactoringOperationBase<MakeNonSta
 
         var node = root.FindNode(span, getInnermostNodeForTie: true);
         var declared = semanticModel.GetDeclaredSymbol(node, cancellationToken);
-        if (declared != null && IdentifierOverlaps(node, span))
+        if (declared != null && DeclarationIdentifiers.IdentifierOverlaps(node, span))
             return ConfirmSymbolName(declared, @params.SymbolName);
 
         throw new RefactoringException(
@@ -598,28 +598,7 @@ public sealed class MakeNonStaticOperation : RefactoringOperationBase<MakeNonSta
         return symbol;
     }
 
-    private static bool IdentifierOverlaps(SyntaxNode node, TextSpan span)
-    {
-        var identifier = GetDeclarationIdentifier(node);
-        return identifier != null &&
-            (identifier.Value.Span.OverlapsWith(span) || span.OverlapsWith(identifier.Value.Span));
-    }
 
-    private static SyntaxToken? GetDeclarationIdentifier(SyntaxNode node) => node switch
-    {
-        MethodDeclarationSyntax method => method.Identifier,
-        LocalFunctionStatementSyntax localFunction => localFunction.Identifier,
-        ConstructorDeclarationSyntax constructor => constructor.Identifier,
-        DestructorDeclarationSyntax destructor => destructor.Identifier,
-        OperatorDeclarationSyntax @operator => @operator.OperatorToken,
-        ConversionOperatorDeclarationSyntax conversion => conversion.Type.GetLastToken(),
-        PropertyDeclarationSyntax property => property.Identifier,
-        EventDeclarationSyntax @event => @event.Identifier,
-        VariableDeclaratorSyntax variable => variable.Identifier,
-        TypeDeclarationSyntax type => type.Identifier,
-        ParameterSyntax parameter => parameter.Identifier,
-        _ => null
-    };
 
     private static IMethodSymbol NormalizeMethodSymbol(ISymbol symbol)
     {

--- a/src/RoslynMcp.Core/Refactoring/Extract/MakeStaticOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/MakeStaticOperation.cs
@@ -557,7 +557,7 @@ public sealed class MakeStaticOperation : RefactoringOperationBase<MakeStaticPar
             if (tokenNode != null)
             {
                 var declaredOnToken = semanticModel.GetDeclaredSymbol(tokenNode, cancellationToken);
-                if (declaredOnToken != null && IdentifierOverlaps(tokenNode, span))
+                if (declaredOnToken != null && DeclarationIdentifiers.IdentifierOverlaps(tokenNode, span))
                     return ConfirmSymbolName(declaredOnToken, @params.SymbolName);
 
                 if (token.IsKind(SyntaxKind.IdentifierToken))
@@ -571,7 +571,7 @@ public sealed class MakeStaticOperation : RefactoringOperationBase<MakeStaticPar
 
         var node = root.FindNode(span, getInnermostNodeForTie: true);
         var declared = semanticModel.GetDeclaredSymbol(node, cancellationToken);
-        if (declared != null && IdentifierOverlaps(node, span))
+        if (declared != null && DeclarationIdentifiers.IdentifierOverlaps(node, span))
             return ConfirmSymbolName(declared, @params.SymbolName);
 
         throw new RefactoringException(
@@ -591,28 +591,7 @@ public sealed class MakeStaticOperation : RefactoringOperationBase<MakeStaticPar
         return symbol;
     }
 
-    private static bool IdentifierOverlaps(SyntaxNode node, TextSpan span)
-    {
-        var identifier = GetDeclarationIdentifier(node);
-        return identifier != null &&
-            (identifier.Value.Span.OverlapsWith(span) || span.OverlapsWith(identifier.Value.Span));
-    }
 
-    private static SyntaxToken? GetDeclarationIdentifier(SyntaxNode node) => node switch
-    {
-        MethodDeclarationSyntax method => method.Identifier,
-        LocalFunctionStatementSyntax localFunction => localFunction.Identifier,
-        ConstructorDeclarationSyntax constructor => constructor.Identifier,
-        DestructorDeclarationSyntax destructor => destructor.Identifier,
-        OperatorDeclarationSyntax @operator => @operator.OperatorToken,
-        ConversionOperatorDeclarationSyntax conversion => conversion.Type.GetLastToken(),
-        PropertyDeclarationSyntax property => property.Identifier,
-        EventDeclarationSyntax @event => @event.Identifier,
-        VariableDeclaratorSyntax variable => variable.Identifier,
-        TypeDeclarationSyntax type => type.Identifier,
-        ParameterSyntax parameter => parameter.Identifier,
-        _ => null
-    };
 
     private static IMethodSymbol NormalizeMethodSymbol(ISymbol symbol)
     {

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Extract/DeclarationIdentifiersTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Extract/DeclarationIdentifiersTests.cs
@@ -1,0 +1,89 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+using RoslynMcp.Core.Refactoring.Extract;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Refactoring.Extract;
+
+public class DeclarationIdentifiersTests
+{
+    [Fact]
+    public void GetDeclarationIdentifier_ReturnsExpectedTokens()
+    {
+        var tree = CSharpSyntaxTree.ParseText("""
+            class C
+            {
+                int f;
+                int P { get; set; }
+                event System.Action E { add { } remove { } }
+                C() { }
+                ~C() { }
+                void M(int p) { void Local() { } }
+                public static C operator +(C a, C b) => a;
+                public static explicit operator int(C c) => 0;
+            }
+            """);
+        var root = tree.GetRoot();
+
+        var type = root.DescendantNodes().OfType<ClassDeclarationSyntax>().Single();
+        Assert.Equal("C", DeclarationIdentifiers.GetDeclarationIdentifier(type)!.Value.ValueText);
+
+        var field = root.DescendantNodes().OfType<VariableDeclaratorSyntax>().Single(v => v.Identifier.Text == "f");
+        Assert.Equal("f", DeclarationIdentifiers.GetDeclarationIdentifier(field)!.Value.ValueText);
+
+        var property = root.DescendantNodes().OfType<PropertyDeclarationSyntax>().Single();
+        Assert.Equal("P", DeclarationIdentifiers.GetDeclarationIdentifier(property)!.Value.ValueText);
+
+        var @event = root.DescendantNodes().OfType<EventDeclarationSyntax>().Single();
+        Assert.Equal("E", DeclarationIdentifiers.GetDeclarationIdentifier(@event)!.Value.ValueText);
+
+        var ctor = root.DescendantNodes().OfType<ConstructorDeclarationSyntax>().Single();
+        Assert.Equal("C", DeclarationIdentifiers.GetDeclarationIdentifier(ctor)!.Value.ValueText);
+
+        var dtor = root.DescendantNodes().OfType<DestructorDeclarationSyntax>().Single();
+        Assert.Equal("C", DeclarationIdentifiers.GetDeclarationIdentifier(dtor)!.Value.ValueText);
+
+        var method = root.DescendantNodes().OfType<MethodDeclarationSyntax>().Single();
+        Assert.Equal("M", DeclarationIdentifiers.GetDeclarationIdentifier(method)!.Value.ValueText);
+
+        var parameter = method.ParameterList.Parameters.Single();
+        Assert.Equal("p", DeclarationIdentifiers.GetDeclarationIdentifier(parameter)!.Value.ValueText);
+
+        var local = root.DescendantNodes().OfType<LocalFunctionStatementSyntax>().Single();
+        Assert.Equal("Local", DeclarationIdentifiers.GetDeclarationIdentifier(local)!.Value.ValueText);
+
+        var op = root.DescendantNodes().OfType<OperatorDeclarationSyntax>().Single();
+        Assert.Equal(op.OperatorToken, DeclarationIdentifiers.GetDeclarationIdentifier(op));
+
+        var conversion = root.DescendantNodes().OfType<ConversionOperatorDeclarationSyntax>().Single();
+        Assert.Equal(conversion.Type.GetLastToken(), DeclarationIdentifiers.GetDeclarationIdentifier(conversion));
+    }
+
+    [Fact]
+    public void GetDeclarationIdentifier_Null_ForUnsupportedNode()
+    {
+        var tree = CSharpSyntaxTree.ParseText("class C { void M() { int x = 1; } }");
+        var literal = tree.GetRoot().DescendantNodes().OfType<LiteralExpressionSyntax>().Single();
+        Assert.Null(DeclarationIdentifiers.GetDeclarationIdentifier(literal));
+    }
+
+    [Fact]
+    public void IdentifierOverlaps_True_OnIdentifier_False_Outside()
+    {
+        var tree = CSharpSyntaxTree.ParseText("""
+            class C
+            {
+                void M() { }
+            }
+            """);
+        var method = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Single();
+        var idSpan = method.Identifier.Span;
+        var bodySpan = method.Body!.Span;
+
+        Assert.True(DeclarationIdentifiers.IdentifierOverlaps(method, idSpan));
+        Assert.False(DeclarationIdentifiers.IdentifierOverlaps(method, bodySpan));
+        Assert.False(DeclarationIdentifiers.IdentifierOverlaps(method, new TextSpan(bodySpan.End, 0)));
+    }
+}


### PR DESCRIPTION
## Summary
- Extract shared `DeclarationIdentifiers.GetDeclarationIdentifier` / `IdentifierOverlaps` under `RoslynMcp.Core.Refactoring.Extract` (byte-identical bodies).
- Replace type-local copies in `MakeStaticOperation` and `MakeNonStaticOperation`.
- Leave `PlanConflictsWithClaimedSpans` and SafeDelete `GetDeclarationIdentifier` alone (different dependencies / switch).
- Add focused unit tests; CHANGELOG Unreleased Changed one-liner.
- Closes #1009

## Test plan
- [x] `dotnet test` filter `DeclarationIdentifiersTests|MakeStatic|MakeNonStatic` — 87 passed locally
- [ ] CI green (Build & Test + CodeQL)
- [ ] Dependabot untouched; do not squash-merge from this agent