### PR TITLE
Extract IdentifierValidation; replace 5 char-based IsValidIdentifier copies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- Extracted shared `IdentifierValidation.IsValidIdentifier` and replaced 5 identical char-based Encapsulate/Extract copies (`encapsulate_field` / `extract_constant` / `extract_interface` / `extract_variable` / `extract_base_class`) (#1012)
 - Extracted shared `DeclarationIdentifiers` and replaced MakeStatic + MakeNonStatic GetDeclarationIdentifier / IdentifierOverlaps copies (`make_static` / `make_non_static`) (#1009)
 - Extracted shared `AccessibilityModifiers.HasAccessibility` and replaced 4 identical Hierarchy copies (`pull_members_up` / `push_members_down` / HierarchyAbstractMemberRewriter / OverrideAccessibilityReducer) (#1006)
 - Extracted shared `FieldCoverage` and replaced EncapsulateField + InlineConstant FieldCovers* / IdentifierCovers* / GetFieldDeclaration / SmallestCoveringSpanLength copies (`encapsulate_field` / `inline_constant`) (#1002)

--- a/src/RoslynMcp.Core/Refactoring/Encapsulate/EncapsulateFieldOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Encapsulate/EncapsulateFieldOperation.cs
@@ -88,7 +88,7 @@ public sealed class EncapsulateFieldOperation : RefactoringOperationBase<Encapsu
         if (!File.Exists(@params.SourceFile))
             throw new RefactoringException(ErrorCodes.SourceFileNotFound, $"Source file not found: {@params.SourceFile}");
 
-        if (@params.PropertyName != null && !IsValidIdentifier(@params.PropertyName))
+        if (@params.PropertyName != null && !IdentifierValidation.IsValidIdentifier(@params.PropertyName))
             throw new RefactoringException(ErrorCodes.InvalidSymbolName, $"Invalid property name: {@params.PropertyName}");
     }
 
@@ -869,10 +869,4 @@ public sealed class EncapsulateFieldOperation : RefactoringOperationBase<Encapsu
         return $"Encapsulate field '{fieldName}' as property '{propertyName}' ({referenceClause})";
     }
 
-    private static bool IsValidIdentifier(string name)
-    {
-        if (string.IsNullOrEmpty(name)) return false;
-        if (!char.IsLetter(name[0]) && name[0] != '_') return false;
-        return name.All(c => char.IsLetterOrDigit(c) || c == '_');
-    }
 }

--- a/src/RoslynMcp.Core/Refactoring/Extract/ExtractBaseClassOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/ExtractBaseClassOperation.cs
@@ -8,6 +8,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Refactoring.Utilities;
 using RoslynMcp.Core.Refactoring.Generate;
 using RoslynMcp.Core.Refactoring.Hierarchy;
 using RoslynMcp.Core.Refactoring.Rename;
@@ -76,7 +77,7 @@ public sealed class ExtractBaseClassOperation : RefactoringOperationBase<Extract
         if (!File.Exists(@params.SourceFile))
             throw new RefactoringException(ErrorCodes.SourceFileNotFound, $"Source file not found: {@params.SourceFile}");
 
-        if (!IsValidIdentifier(@params.BaseClassName))
+        if (!IdentifierValidation.IsValidIdentifier(@params.BaseClassName))
             throw new RefactoringException(ErrorCodes.InvalidSymbolName, $"Invalid base class name: {@params.BaseClassName}");
 
         if (@params.TargetFile != null)
@@ -1070,12 +1071,6 @@ public sealed class ExtractBaseClassOperation : RefactoringOperationBase<Extract
         return RefactoringResult.PreviewResult(operationId, pendingChanges);
     }
 
-    private static bool IsValidIdentifier(string name)
-    {
-        if (string.IsNullOrEmpty(name)) return false;
-        if (!char.IsLetter(name[0]) && name[0] != '_') return false;
-        return name.All(c => char.IsLetterOrDigit(c) || c == '_');
-    }
 
     /// <summary>
     /// Finds a type by <paramref name="typeName"/>. Omitted

--- a/src/RoslynMcp.Core/Refactoring/Extract/ExtractBaseClassOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/ExtractBaseClassOperation.cs
@@ -8,10 +8,10 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
-using RoslynMcp.Core.Refactoring.Utilities;
 using RoslynMcp.Core.Refactoring.Generate;
 using RoslynMcp.Core.Refactoring.Hierarchy;
 using RoslynMcp.Core.Refactoring.Rename;
+using RoslynMcp.Core.Refactoring.Utilities;
 using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 

--- a/src/RoslynMcp.Core/Refactoring/Extract/ExtractConstantOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/ExtractConstantOperation.cs
@@ -7,6 +7,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Refactoring.Utilities;
 using RoslynMcp.Core.Workspace;
 
 namespace RoslynMcp.Core.Refactoring.Extract;
@@ -56,7 +57,7 @@ public sealed class ExtractConstantOperation : RefactoringOperationBase<ExtractC
             (@params.StartLine == @params.EndLine && @params.StartColumn >= @params.EndColumn))
             throw new RefactoringException(ErrorCodes.InvalidSelectionRange, "Selection start must be before end.");
 
-        if (!IsValidIdentifier(@params.ConstantName))
+        if (!IdentifierValidation.IsValidIdentifier(@params.ConstantName))
             throw new RefactoringException(ErrorCodes.InvalidSymbolName, $"Invalid constant name: {@params.ConstantName}");
 
         if (!ValidVisibilities.Contains(@params.Visibility))
@@ -322,12 +323,6 @@ public sealed class ExtractConstantOperation : RefactoringOperationBase<ExtractC
         return RefactoringResult.PreviewResult(operationId, pendingChanges);
     }
 
-    private static bool IsValidIdentifier(string name)
-    {
-        if (string.IsNullOrEmpty(name)) return false;
-        if (!char.IsLetter(name[0]) && name[0] != '_') return false;
-        return name.All(c => char.IsLetterOrDigit(c) || c == '_');
-    }
 
     private static int GetPosition(SourceText text, int line, int column)
     {

--- a/src/RoslynMcp.Core/Refactoring/Extract/ExtractInterfaceOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/ExtractInterfaceOperation.cs
@@ -69,7 +69,7 @@ public sealed class ExtractInterfaceOperation : RefactoringOperationBase<Extract
         if (!File.Exists(@params.SourceFile))
             throw new RefactoringException(ErrorCodes.SourceFileNotFound, $"Source file not found: {@params.SourceFile}");
 
-        if (!IsValidIdentifier(@params.InterfaceName))
+        if (!IdentifierValidation.IsValidIdentifier(@params.InterfaceName))
             throw new RefactoringException(ErrorCodes.InvalidSymbolName, $"Invalid interface name: {@params.InterfaceName}");
 
         if (@params.TargetFile != null)
@@ -504,12 +504,6 @@ public sealed class ExtractInterfaceOperation : RefactoringOperationBase<Extract
         return RefactoringResult.PreviewResult(operationId, pendingChanges);
     }
 
-    private static bool IsValidIdentifier(string name)
-    {
-        if (string.IsNullOrEmpty(name)) return false;
-        if (!char.IsLetter(name[0]) && name[0] != '_') return false;
-        return name.All(c => char.IsLetterOrDigit(c) || c == '_');
-    }
 
     /// <summary>
     /// Finds a type by <paramref name="typeName"/>. Omitted

--- a/src/RoslynMcp.Core/Refactoring/Extract/ExtractVariableOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/ExtractVariableOperation.cs
@@ -7,6 +7,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Refactoring.Utilities;
 using RoslynMcp.Core.Workspace;
 
 namespace RoslynMcp.Core.Refactoring.Extract;
@@ -51,7 +52,7 @@ public sealed class ExtractVariableOperation : RefactoringOperationBase<ExtractV
             (@params.StartLine == @params.EndLine && @params.StartColumn >= @params.EndColumn))
             throw new RefactoringException(ErrorCodes.InvalidSelectionRange, "Selection start must be before end.");
 
-        if (!IsValidIdentifier(@params.VariableName))
+        if (!IdentifierValidation.IsValidIdentifier(@params.VariableName))
             throw new RefactoringException(ErrorCodes.InvalidSymbolName, $"Invalid variable name: {@params.VariableName}");
     }
 
@@ -604,10 +605,4 @@ public sealed class ExtractVariableOperation : RefactoringOperationBase<ExtractV
         return lineInfo.Start + columnIndex;
     }
 
-    private static bool IsValidIdentifier(string name)
-    {
-        if (string.IsNullOrEmpty(name)) return false;
-        if (!char.IsLetter(name[0]) && name[0] != '_') return false;
-        return name.All(c => char.IsLetterOrDigit(c) || c == '_');
-    }
 }

--- a/src/RoslynMcp.Core/Refactoring/Utilities/IdentifierValidation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Utilities/IdentifierValidation.cs
@@ -1,0 +1,22 @@
+namespace RoslynMcp.Core.Refactoring.Utilities;
+
+/// <summary>
+/// Shared char-based identifier validation used by encapsulate_field and
+/// extract_* name checks (letter-or-underscore start; letter/digit/underscore
+/// body). Does not apply SyntaxFacts / verbatim @-keyword rules.
+/// </summary>
+internal static class IdentifierValidation
+{
+    /// <summary>
+    /// True when <paramref name="name"/> is non-empty, starts with a letter or
+    /// <c>_</c>, and every remaining character is a letter, digit, or <c>_</c>
+    /// (same body as the EncapsulateField / ExtractConstant / ExtractInterface /
+    /// ExtractVariable / ExtractBaseClass copies).
+    /// </summary>
+    internal static bool IsValidIdentifier(string name)
+    {
+        if (string.IsNullOrEmpty(name)) return false;
+        if (!char.IsLetter(name[0]) && name[0] != '_') return false;
+        return name.All(c => char.IsLetterOrDigit(c) || c == '_');
+    }
+}

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Utilities/IdentifierValidationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Utilities/IdentifierValidationTests.cs
@@ -1,0 +1,47 @@
+using RoslynMcp.Core.Refactoring.Utilities;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Refactoring.Utilities;
+
+public class IdentifierValidationTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void IsValidIdentifier_False_ForNullOrEmpty(string? name)
+    {
+        Assert.False(IdentifierValidation.IsValidIdentifier(name!));
+    }
+
+    [Theory]
+    [InlineData("1abc")]
+    [InlineData("9")]
+    [InlineData("-name")]
+    [InlineData(" name")]
+    public void IsValidIdentifier_False_ForBadStart(string name)
+    {
+        Assert.False(IdentifierValidation.IsValidIdentifier(name));
+    }
+
+    [Theory]
+    [InlineData("a-b")]
+    [InlineData("foo.bar")]
+    [InlineData("x y")]
+    [InlineData("@class")]
+    public void IsValidIdentifier_False_ForInvalidBodyOrVerbatim(string name)
+    {
+        Assert.False(IdentifierValidation.IsValidIdentifier(name));
+    }
+
+    [Theory]
+    [InlineData("Name")]
+    [InlineData("_private")]
+    [InlineData("a1")]
+    [InlineData("MaxRetries")]
+    [InlineData("_")]
+    [InlineData("Δ")]
+    public void IsValidIdentifier_True_ForLetterOrUnderscoreForms(string name)
+    {
+        Assert.True(IdentifierValidation.IsValidIdentifier(name));
+    }
+}


### PR DESCRIPTION
## Summary
- Extract shared `IdentifierValidation.IsValidIdentifier` under `RoslynMcp.Core.Refactoring.Utilities` (byte-identical char-based bodies).
- Replace type-local copies in `EncapsulateFieldOperation`, `ExtractConstantOperation`, `ExtractInterfaceOperation`, `ExtractVariableOperation`, and `ExtractBaseClassOperation`.
- Leave SyntaxFacts-based validators alone (InlineConstant / Generate* / AddParameter / IntroduceField — different bodies).
- Add focused unit tests; CHANGELOG Unreleased Changed one-liner.
- Closes #1012

## Test plan
- [x] `dotnet test` filter `IdentifierValidationTests|ExtractConstant|ExtractInterface|ExtractVariable|ExtractBaseClass|EncapsulateField` — 306 passed locally
- [ ] CI green (Build & Test + CodeQL)
- [ ] Dependabot untouched; do not squash-merge from this agent