### PR TITLE
Extract SyntaxIdentifierValidation; replace 6 SyntaxFacts IsValidIdentifier copies (#1015)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- Extracted shared `SyntaxIdentifierValidation.IsValidIdentifier` and replaced 6 identical SyntaxFacts Inline/Generate/Signature/Convert copies (`inline_constant` / `generate_method_stub` / `generate_property` / `add_parameter` / `convert_anonymous_to_class` / `convert_tuple_to_struct`) (#1015)
 - Extracted shared `IdentifierValidation.IsValidIdentifier` and replaced 5 identical char-based Encapsulate/Extract copies (`encapsulate_field` / `extract_constant` / `extract_interface` / `extract_variable` / `extract_base_class`) (#1012)
 - Extracted shared `DeclarationIdentifiers` and replaced MakeStatic + MakeNonStatic GetDeclarationIdentifier / IdentifierOverlaps copies (`make_static` / `make_non_static`) (#1009)
 - Extracted shared `AccessibilityModifiers.HasAccessibility` and replaced 4 identical Hierarchy copies (`pull_members_up` / `push_members_down` / HierarchyAbstractMemberRewriter / OverrideAccessibilityReducer) (#1006)

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertAnonymousToClassOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertAnonymousToClassOperation.cs
@@ -8,6 +8,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Refactoring.Utilities;
 using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 using SymbolKind = RoslynMcp.Contracts.Enums.SymbolKind;
@@ -57,7 +58,7 @@ public sealed class ConvertAnonymousToClassOperation : RefactoringOperationBase<
         if (!File.Exists(@params.SourceFile))
             throw new RefactoringException(ErrorCodes.SourceFileNotFound, $"Source file not found: {@params.SourceFile}");
 
-        if (!IsValidTypeName(@params.NewTypeName))
+        if (!SyntaxIdentifierValidation.IsValidIdentifier(@params.NewTypeName))
         {
             throw new RefactoringException(
                 ErrorCodes.InvalidSymbolName,
@@ -175,24 +176,6 @@ public sealed class ConvertAnonymousToClassOperation : RefactoringOperationBase<
             0);
     }
 
-    internal static bool IsValidTypeName(string name)
-    {
-        if (string.IsNullOrWhiteSpace(name))
-            return false;
-
-        if (name.StartsWith('@') && name.Length > 1)
-        {
-            var bare = name[1..];
-            return SyntaxFacts.IsValidIdentifier(bare) ||
-                   SyntaxFacts.GetKeywordKind(bare) != SyntaxKind.None;
-        }
-
-        if (!SyntaxFacts.IsValidIdentifier(name))
-            return false;
-
-        var keywordKind = SyntaxFacts.GetKeywordKind(name);
-        return keywordKind == SyntaxKind.None || !SyntaxFacts.IsReservedKeyword(keywordKind);
-    }
 
     internal static AnonymousObjectCreationExpressionSyntax FindAnonymousCreation(
         SyntaxNode root,

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertTupleToStructOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertTupleToStructOperation.cs
@@ -7,6 +7,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Refactoring.Utilities;
 using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 using SymbolKind = RoslynMcp.Contracts.Enums.SymbolKind;
@@ -56,7 +57,7 @@ public sealed class ConvertTupleToStructOperation : RefactoringOperationBase<Con
         if (!File.Exists(@params.SourceFile))
             throw new RefactoringException(ErrorCodes.SourceFileNotFound, $"Source file not found: {@params.SourceFile}");
 
-        if (!IsValidTypeName(@params.NewTypeName))
+        if (!SyntaxIdentifierValidation.IsValidIdentifier(@params.NewTypeName))
         {
             throw new RefactoringException(
                 ErrorCodes.InvalidSymbolName,
@@ -179,24 +180,6 @@ public sealed class ConvertTupleToStructOperation : RefactoringOperationBase<Con
             0);
     }
 
-    internal static bool IsValidTypeName(string name)
-    {
-        if (string.IsNullOrWhiteSpace(name))
-            return false;
-
-        if (name.StartsWith('@') && name.Length > 1)
-        {
-            var bare = name[1..];
-            return SyntaxFacts.IsValidIdentifier(bare) ||
-                   SyntaxFacts.GetKeywordKind(bare) != SyntaxKind.None;
-        }
-
-        if (!SyntaxFacts.IsValidIdentifier(name))
-            return false;
-
-        var keywordKind = SyntaxFacts.GetKeywordKind(name);
-        return keywordKind == SyntaxKind.None || !SyntaxFacts.IsReservedKeyword(keywordKind);
-    }
 
     internal static ExpressionSyntax FindTupleCreation(
         SyntaxNode root,

--- a/src/RoslynMcp.Core/Refactoring/Generate/GenerateMethodStubOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GenerateMethodStubOperation.cs
@@ -66,7 +66,7 @@ public sealed class GenerateMethodStubOperation : RefactoringOperationBase<Gener
         if (@params.Column < 1)
             throw new RefactoringException(ErrorCodes.InvalidColumnNumber, "column must be >= 1.");
 
-        if (@params.MethodName != null && !IsValidIdentifier(@params.MethodName))
+        if (@params.MethodName != null && !SyntaxIdentifierValidation.IsValidIdentifier(@params.MethodName))
             throw new RefactoringException(ErrorCodes.InvalidSymbolName, $"Invalid method name: {@params.MethodName}");
 
         if (!string.IsNullOrWhiteSpace(@params.ReturnType) && !IsValidTypeName(@params.ReturnType))
@@ -521,13 +521,13 @@ public sealed class GenerateMethodStubOperation : RefactoringOperationBase<Gener
             candidate = argument.NameColon.Name.Identifier.ValueText;
         }
         else if (Unwrap(argument.Expression) is IdentifierNameSyntax identifier
-                 && IsValidIdentifier(identifier.Identifier.ValueText))
+                 && SyntaxIdentifierValidation.IsValidIdentifier(identifier.Identifier.ValueText))
         {
             candidate = identifier.Identifier.ValueText;
         }
         else if (Unwrap(argument.Expression) is DeclarationExpressionSyntax declaration
                  && declaration.Designation is SingleVariableDesignationSyntax single
-                 && IsValidIdentifier(single.Identifier.ValueText))
+                 && SyntaxIdentifierValidation.IsValidIdentifier(single.Identifier.ValueText))
         {
             candidate = single.Identifier.ValueText;
         }
@@ -1480,25 +1480,6 @@ public sealed class GenerateMethodStubOperation : RefactoringOperationBase<Gener
         "internal" => SyntaxFactory.Token(SyntaxKind.InternalKeyword),
         _ => SyntaxFactory.Token(SyntaxKind.PrivateKeyword)
     };
-
-    internal static bool IsValidIdentifier(string name)
-    {
-        if (string.IsNullOrWhiteSpace(name))
-            return false;
-
-        if (name.StartsWith('@') && name.Length > 1)
-        {
-            var bare = name[1..];
-            return SyntaxFacts.IsValidIdentifier(bare) ||
-                   SyntaxFacts.GetKeywordKind(bare) != SyntaxKind.None;
-        }
-
-        if (!SyntaxFacts.IsValidIdentifier(name))
-            return false;
-
-        var keywordKind = SyntaxFacts.GetKeywordKind(name);
-        return keywordKind == SyntaxKind.None || !SyntaxFacts.IsReservedKeyword(keywordKind);
-    }
 
     internal static bool IsValidTypeName(string typeName)
     {

--- a/src/RoslynMcp.Core/Refactoring/Generate/GeneratePropertyOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GeneratePropertyOperation.cs
@@ -7,6 +7,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Refactoring.Utilities;
 using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 
@@ -65,7 +66,7 @@ public sealed class GeneratePropertyOperation : RefactoringOperationBase<Generat
         if (string.IsNullOrWhiteSpace(@params.PropertyType) && !hasField)
             throw new RefactoringException(ErrorCodes.MissingRequiredParam, "propertyType is required unless fieldName is provided.");
 
-        if (@params.PropertyName != null && !IsValidIdentifier(@params.PropertyName))
+        if (@params.PropertyName != null && !SyntaxIdentifierValidation.IsValidIdentifier(@params.PropertyName))
             throw new RefactoringException(ErrorCodes.InvalidSymbolName, $"Invalid property name: {@params.PropertyName}");
 
         if (!string.IsNullOrWhiteSpace(@params.Visibility) && !ValidVisibilities.Contains(@params.Visibility.Trim()))
@@ -900,23 +901,4 @@ public sealed class GeneratePropertyOperation : RefactoringOperationBase<Generat
         "internal" => SyntaxFactory.Token(SyntaxKind.InternalKeyword),
         _ => SyntaxFactory.Token(SyntaxKind.PublicKeyword)
     };
-
-    internal static bool IsValidIdentifier(string name)
-    {
-        if (string.IsNullOrWhiteSpace(name))
-            return false;
-
-        if (name.StartsWith('@') && name.Length > 1)
-        {
-            var bare = name[1..];
-            return SyntaxFacts.IsValidIdentifier(bare) ||
-                   SyntaxFacts.GetKeywordKind(bare) != SyntaxKind.None;
-        }
-
-        if (!SyntaxFacts.IsValidIdentifier(name))
-            return false;
-
-        var keywordKind = SyntaxFacts.GetKeywordKind(name);
-        return keywordKind == SyntaxKind.None || !SyntaxFacts.IsReservedKeyword(keywordKind);
-    }
 }

--- a/src/RoslynMcp.Core/Refactoring/Inline/InlineConstantOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Inline/InlineConstantOperation.cs
@@ -8,6 +8,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Refactoring.Utilities;
 using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 
@@ -77,7 +78,7 @@ public sealed class InlineConstantOperation : RefactoringOperationBase<InlineCon
         if (!File.Exists(sourceFile))
             throw new RefactoringException(ErrorCodes.SourceFileNotFound, $"Source file not found: {sourceFile}");
 
-        if (!IsValidIdentifier(constantName))
+        if (!SyntaxIdentifierValidation.IsValidIdentifier(constantName))
             throw new RefactoringException(ErrorCodes.InvalidSymbolName, $"'{constantName}' is not a valid constant name.");
 
         if (@params.TypeName != null && string.IsNullOrWhiteSpace(@params.TypeName))
@@ -1020,25 +1021,6 @@ public sealed class InlineConstantOperation : RefactoringOperationBase<InlineCon
         TextSpan Span,
         bool CanReplace,
         bool InAttribute);
-
-    internal static bool IsValidIdentifier(string name)
-    {
-        if (string.IsNullOrWhiteSpace(name))
-            return false;
-
-        if (name.StartsWith('@') && name.Length > 1)
-        {
-            var bare = name[1..];
-            return SyntaxFacts.IsValidIdentifier(bare) ||
-                   SyntaxFacts.GetKeywordKind(bare) != SyntaxKind.None;
-        }
-
-        if (!SyntaxFacts.IsValidIdentifier(name))
-            return false;
-
-        var keywordKind = SyntaxFacts.GetKeywordKind(name);
-        return keywordKind == SyntaxKind.None || !SyntaxFacts.IsReservedKeyword(keywordKind);
-    }
 
     private static bool NamesMatch(SyntaxToken identifier, string constantName)
     {

--- a/src/RoslynMcp.Core/Refactoring/Signature/AddParameterOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Signature/AddParameterOperation.cs
@@ -8,6 +8,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Refactoring.Utilities;
 using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 
@@ -56,7 +57,7 @@ public sealed class AddParameterOperation : RefactoringOperationBase<AddParamete
         if (!File.Exists(@params.SourceFile))
             throw new RefactoringException(ErrorCodes.SourceFileNotFound, $"Source file not found: {@params.SourceFile}");
 
-        if (!IsValidIdentifier(@params.ParameterName))
+        if (!SyntaxIdentifierValidation.IsValidIdentifier(@params.ParameterName))
             throw new RefactoringException(ErrorCodes.InvalidSymbolName, $"'{@params.ParameterName}' is not a valid parameter name.");
 
         if (!IsValidParameterType(@params.ParameterType))
@@ -770,24 +771,6 @@ public sealed class AddParameterOperation : RefactoringOperationBase<AddParamete
         return RefactoringResult.PreviewResult(operationId, pendingChanges);
     }
 
-    internal static bool IsValidIdentifier(string name)
-    {
-        if (string.IsNullOrWhiteSpace(name))
-            return false;
-
-        if (name.StartsWith('@') && name.Length > 1)
-        {
-            var bare = name[1..];
-            return SyntaxFacts.IsValidIdentifier(bare) ||
-                   SyntaxFacts.GetKeywordKind(bare) != SyntaxKind.None;
-        }
-
-        if (!SyntaxFacts.IsValidIdentifier(name))
-            return false;
-
-        var keywordKind = SyntaxFacts.GetKeywordKind(name);
-        return keywordKind == SyntaxKind.None || !SyntaxFacts.IsReservedKeyword(keywordKind);
-    }
 
     internal static bool IsValidParameterType(string type)
     {

--- a/src/RoslynMcp.Core/Refactoring/Utilities/SyntaxIdentifierValidation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Utilities/SyntaxIdentifierValidation.cs
@@ -1,0 +1,40 @@
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace RoslynMcp.Core.Refactoring.Utilities;
+
+/// <summary>
+/// Shared SyntaxFacts-based identifier validation used by inline_constant,
+/// generate_method_stub / generate_property, add_parameter, and
+/// convert_anonymous_to_class / convert_tuple_to_struct name checks.
+/// Applies verbatim <c>@</c>-keyword and reserved-keyword rules via
+/// <see cref="SyntaxFacts"/>. Distinct from char-based
+/// <see cref="IdentifierValidation"/>.
+/// </summary>
+internal static class SyntaxIdentifierValidation
+{
+    /// <summary>
+    /// True when <paramref name="name"/> is a non-whitespace C# identifier
+    /// per <see cref="SyntaxFacts"/>, allowing verbatim <c>@</c>-prefixed
+    /// keywords and rejecting reserved keywords without the verbatim prefix
+    /// (same body as the InlineConstant / GenerateMethodStub /
+    /// GenerateProperty / AddParameter / ConvertAnonymous / ConvertTuple copies).
+    /// </summary>
+    internal static bool IsValidIdentifier(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return false;
+
+        if (name.StartsWith('@') && name.Length > 1)
+        {
+            var bare = name[1..];
+            return SyntaxFacts.IsValidIdentifier(bare) ||
+                   SyntaxFacts.GetKeywordKind(bare) != SyntaxKind.None;
+        }
+
+        if (!SyntaxFacts.IsValidIdentifier(name))
+            return false;
+
+        var keywordKind = SyntaxFacts.GetKeywordKind(name);
+        return keywordKind == SyntaxKind.None || !SyntaxFacts.IsReservedKeyword(keywordKind);
+    }
+}

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertAnonymousToClassOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertAnonymousToClassOperationTests.cs
@@ -113,7 +113,7 @@ public class ConvertAnonymousToClassOperationTests
     }
 
     [Fact]
-    public void IsValidTypeName_RejectsInvalidAndKeywords()
+    public void IsValidIdentifier_RejectsInvalidAndKeywords()
     {
         Assert.False(SyntaxIdentifierValidation.IsValidIdentifier("123Bad"));
         Assert.False(SyntaxIdentifierValidation.IsValidIdentifier("class"));

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertAnonymousToClassOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertAnonymousToClassOperationTests.cs
@@ -6,6 +6,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Convert;
+using RoslynMcp.Core.Refactoring.Utilities;
 using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 using Xunit;
@@ -114,12 +115,12 @@ public class ConvertAnonymousToClassOperationTests
     [Fact]
     public void IsValidTypeName_RejectsInvalidAndKeywords()
     {
-        Assert.False(ConvertAnonymousToClassOperation.IsValidTypeName("123Bad"));
-        Assert.False(ConvertAnonymousToClassOperation.IsValidTypeName("class"));
-        Assert.False(ConvertAnonymousToClassOperation.IsValidTypeName("int"));
-        Assert.False(ConvertAnonymousToClassOperation.IsValidTypeName("@@@"));
-        Assert.True(ConvertAnonymousToClassOperation.IsValidTypeName("Person"));
-        Assert.True(ConvertAnonymousToClassOperation.IsValidTypeName("_Info"));
+        Assert.False(SyntaxIdentifierValidation.IsValidIdentifier("123Bad"));
+        Assert.False(SyntaxIdentifierValidation.IsValidIdentifier("class"));
+        Assert.False(SyntaxIdentifierValidation.IsValidIdentifier("int"));
+        Assert.False(SyntaxIdentifierValidation.IsValidIdentifier("@@@"));
+        Assert.True(SyntaxIdentifierValidation.IsValidIdentifier("Person"));
+        Assert.True(SyntaxIdentifierValidation.IsValidIdentifier("_Info"));
     }
 
     #endregion

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertTupleToStructOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertTupleToStructOperationTests.cs
@@ -113,7 +113,7 @@ public class ConvertTupleToStructOperationTests
     }
 
     [Fact]
-    public void IsValidTypeName_RejectsInvalidAndKeywords()
+    public void IsValidIdentifier_RejectsInvalidAndKeywords()
     {
         Assert.False(SyntaxIdentifierValidation.IsValidIdentifier("123Bad"));
         Assert.False(SyntaxIdentifierValidation.IsValidIdentifier("class"));

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertTupleToStructOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Convert/ConvertTupleToStructOperationTests.cs
@@ -6,6 +6,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Convert;
+using RoslynMcp.Core.Refactoring.Utilities;
 using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 using Xunit;
@@ -114,12 +115,12 @@ public class ConvertTupleToStructOperationTests
     [Fact]
     public void IsValidTypeName_RejectsInvalidAndKeywords()
     {
-        Assert.False(ConvertTupleToStructOperation.IsValidTypeName("123Bad"));
-        Assert.False(ConvertTupleToStructOperation.IsValidTypeName("class"));
-        Assert.False(ConvertTupleToStructOperation.IsValidTypeName("int"));
-        Assert.False(ConvertTupleToStructOperation.IsValidTypeName("@@@"));
-        Assert.True(ConvertTupleToStructOperation.IsValidTypeName("Point"));
-        Assert.True(ConvertTupleToStructOperation.IsValidTypeName("_Info"));
+        Assert.False(SyntaxIdentifierValidation.IsValidIdentifier("123Bad"));
+        Assert.False(SyntaxIdentifierValidation.IsValidIdentifier("class"));
+        Assert.False(SyntaxIdentifierValidation.IsValidIdentifier("int"));
+        Assert.False(SyntaxIdentifierValidation.IsValidIdentifier("@@@"));
+        Assert.True(SyntaxIdentifierValidation.IsValidIdentifier("Point"));
+        Assert.True(SyntaxIdentifierValidation.IsValidIdentifier("_Info"));
     }
 
     #endregion

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GenerateMethodStubOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GenerateMethodStubOperationTests.cs
@@ -6,6 +6,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Generate;
+using RoslynMcp.Core.Refactoring.Utilities;
 using RoslynMcp.Core.Workspace;
 using Xunit;
 
@@ -140,10 +141,10 @@ public class GenerateMethodStubOperationTests
     [Fact]
     public void IsValidIdentifier_ReservedKeyword_IsFalse()
     {
-        Assert.False(GenerateMethodStubOperation.IsValidIdentifier("class"));
-        Assert.False(GenerateMethodStubOperation.IsValidIdentifier("namespace"));
-        Assert.True(GenerateMethodStubOperation.IsValidIdentifier("DoWork"));
-        Assert.True(GenerateMethodStubOperation.IsValidIdentifier("@class"));
+        Assert.False(SyntaxIdentifierValidation.IsValidIdentifier("class"));
+        Assert.False(SyntaxIdentifierValidation.IsValidIdentifier("namespace"));
+        Assert.True(SyntaxIdentifierValidation.IsValidIdentifier("DoWork"));
+        Assert.True(SyntaxIdentifierValidation.IsValidIdentifier("@class"));
     }
 
     [Fact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GeneratePropertyOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GeneratePropertyOperationTests.cs
@@ -7,6 +7,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Generate;
+using RoslynMcp.Core.Refactoring.Utilities;
 using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 using Xunit;
@@ -268,10 +269,10 @@ public class GeneratePropertyOperationTests
     [Fact]
     public void IsValidIdentifier_ReservedKeyword_IsFalse()
     {
-        Assert.False(GeneratePropertyOperation.IsValidIdentifier("class"));
-        Assert.False(GeneratePropertyOperation.IsValidIdentifier("namespace"));
-        Assert.True(GeneratePropertyOperation.IsValidIdentifier("Name"));
-        Assert.True(GeneratePropertyOperation.IsValidIdentifier("@class"));
+        Assert.False(SyntaxIdentifierValidation.IsValidIdentifier("class"));
+        Assert.False(SyntaxIdentifierValidation.IsValidIdentifier("namespace"));
+        Assert.True(SyntaxIdentifierValidation.IsValidIdentifier("Name"));
+        Assert.True(SyntaxIdentifierValidation.IsValidIdentifier("@class"));
     }
 
     [Fact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Inline/InlineConstantOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Inline/InlineConstantOperationTests.cs
@@ -6,6 +6,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Refactoring.Inline;
+using RoslynMcp.Core.Refactoring.Utilities;
 using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 using Xunit;
@@ -97,11 +98,11 @@ public class InlineConstantOperationTests
     [Fact]
     public void IsValidIdentifier_AcceptsVerbatimAndUnicode()
     {
-        Assert.True(InlineConstantOperation.IsValidIdentifier("@default"));
-        Assert.True(InlineConstantOperation.IsValidIdentifier("Δ"));
-        Assert.True(InlineConstantOperation.IsValidIdentifier("MaxRetries"));
-        Assert.False(InlineConstantOperation.IsValidIdentifier("123bad"));
-        Assert.False(InlineConstantOperation.IsValidIdentifier("class"));
+        Assert.True(SyntaxIdentifierValidation.IsValidIdentifier("@default"));
+        Assert.True(SyntaxIdentifierValidation.IsValidIdentifier("Δ"));
+        Assert.True(SyntaxIdentifierValidation.IsValidIdentifier("MaxRetries"));
+        Assert.False(SyntaxIdentifierValidation.IsValidIdentifier("123bad"));
+        Assert.False(SyntaxIdentifierValidation.IsValidIdentifier("class"));
     }
 
     [Fact]

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Utilities/SyntaxIdentifierValidationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Utilities/SyntaxIdentifierValidationTests.cs
@@ -1,0 +1,43 @@
+using RoslynMcp.Core.Refactoring.Utilities;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Refactoring.Utilities;
+
+public class SyntaxIdentifierValidationTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    public void IsValidIdentifier_False_ForWhitespaceOrEmpty(string? name)
+    {
+        Assert.False(SyntaxIdentifierValidation.IsValidIdentifier(name!));
+    }
+
+    [Theory]
+    [InlineData("class")]
+    [InlineData("namespace")]
+    public void IsValidIdentifier_False_ForReservedKeyword(string name)
+    {
+        Assert.False(SyntaxIdentifierValidation.IsValidIdentifier(name));
+    }
+
+    [Theory]
+    [InlineData("@class")]
+    [InlineData("Δ")]
+    [InlineData("MaxRetries")]
+    [InlineData("DoWork")]
+    [InlineData("Name")]
+    public void IsValidIdentifier_True_ForVerbatimUnicodeAndNormal(string name)
+    {
+        Assert.True(SyntaxIdentifierValidation.IsValidIdentifier(name));
+    }
+
+    [Theory]
+    [InlineData("123bad")]
+    public void IsValidIdentifier_False_ForDigitStart(string name)
+    {
+        Assert.False(SyntaxIdentifierValidation.IsValidIdentifier(name));
+    }
+}


### PR DESCRIPTION
## Summary
- Closes #1015
- Extract shared `SyntaxIdentifierValidation.IsValidIdentifier` (SyntaxFacts / verbatim `@`-keyword / reserved-keyword rules) under `RoslynMcp.Core.Refactoring.Utilities`
- Replace identical copies in `InlineConstantOperation`, `GenerateMethodStubOperation`, `GeneratePropertyOperation`, `AddParameterOperation`, `ConvertAnonymousToClassOperation` (`IsValidTypeName`), and `ConvertTupleToStructOperation` (`IsValidTypeName`)
- Keep `GenerateMethodStubOperation.IsValidTypeName` (ParseTypeName) and char-based `IdentifierValidation` unchanged
- Add `SyntaxIdentifierValidationTests`; retarget existing op validation tests; CHANGELOG Unreleased one-liner

## Test plan
- [x] `dotnet test --filter "FullyQualifiedName~SyntaxIdentifierValidationTests|FullyQualifiedName~InlineConstant|FullyQualifiedName~GenerateMethodStub|FullyQualifiedName~GenerateProperty|FullyQualifiedName~AddParameter|FullyQualifiedName~ConvertAnonymous|FullyQualifiedName~ConvertTuple"` — Core 374 + Server 65 + Cli 6 passed
- [x] `dotnet format RoslynMcp.sln --verify-no-changes` clean
- [ ] CI Build & Test green
- [ ] CI Format Check green
- [ ] Dependabot untouched