### PR TITLE
Extract EventFieldDeclarator.TryGet; replace GenerateOverrides + ImplementInterface + ImplementAbstract copies (#1018)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- Extracted shared `EventFieldDeclarator.TryGet` and replaced 3 identical Generate copies (`generate_overrides` / `implement_interface` / `implement_abstract`) (#1018)
 - Extracted shared `SyntaxIdentifierValidation.IsValidIdentifier` and replaced 6 identical SyntaxFacts Inline/Generate/Signature/Convert copies (`inline_constant` / `generate_method_stub` / `generate_property` / `add_parameter` / `convert_anonymous_to_class` / `convert_tuple_to_struct`) (#1015)
 - Extracted shared `IdentifierValidation.IsValidIdentifier` and replaced 5 identical char-based Encapsulate/Extract copies (`encapsulate_field` / `extract_constant` / `extract_interface` / `extract_variable` / `extract_base_class`) (#1012)
 - Extracted shared `DeclarationIdentifiers` and replaced MakeStatic + MakeNonStatic GetDeclarationIdentifier / IdentifierOverlaps copies (`make_static` / `make_non_static`) (#1009)

--- a/src/RoslynMcp.Core/Refactoring/Generate/GenerateOverridesOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GenerateOverridesOperation.cs
@@ -1033,7 +1033,7 @@ public sealed class GenerateOverridesOperation : RefactoringOperationBase<Genera
             foreach (var reference in existing.DeclaringSyntaxReferences)
             {
                 var syntax = await reference.GetSyntaxAsync(cancellationToken);
-                if (TryGetEventFieldDeclarator(syntax, out var eventField, out var declarator)
+                if (EventFieldDeclarator.TryGet(syntax, out var eventField, out var declarator)
                     && eventField.Parent is TypeDeclarationSyntax eventPart)
                 {
                     if (eventField.Declaration.Variables.Count > 1)
@@ -1187,24 +1187,6 @@ public sealed class GenerateOverridesOperation : RefactoringOperationBase<Genera
         }
 
         keys.Add(key);
-    }
-
-    private static bool TryGetEventFieldDeclarator(
-        SyntaxNode syntax,
-        out EventFieldDeclarationSyntax eventField,
-        out VariableDeclaratorSyntax declarator)
-    {
-        if (syntax is VariableDeclaratorSyntax variable
-            && variable.Parent?.Parent is EventFieldDeclarationSyntax field)
-        {
-            eventField = field;
-            declarator = variable;
-            return true;
-        }
-
-        eventField = null!;
-        declarator = null!;
-        return false;
     }
 
     /// <summary>

--- a/src/RoslynMcp.Core/Refactoring/Generate/ImplementAbstractOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/ImplementAbstractOperation.cs
@@ -1411,7 +1411,7 @@ public sealed class ImplementAbstractOperation : RefactoringOperationBase<Implem
             foreach (var reference in existing.DeclaringSyntaxReferences)
             {
                 var syntax = await reference.GetSyntaxAsync(cancellationToken);
-                if (TryGetEventFieldDeclarator(syntax, out var eventField, out var declarator)
+                if (EventFieldDeclarator.TryGet(syntax, out var eventField, out var declarator)
                     && eventField.Parent is TypeDeclarationSyntax eventPart)
                 {
                     if (eventField.Declaration.Variables.Count > 1)
@@ -1586,24 +1586,6 @@ public sealed class ImplementAbstractOperation : RefactoringOperationBase<Implem
         }
 
         keys.Add(key);
-    }
-
-    private static bool TryGetEventFieldDeclarator(
-        SyntaxNode syntax,
-        out EventFieldDeclarationSyntax eventField,
-        out VariableDeclaratorSyntax declarator)
-    {
-        if (syntax is VariableDeclaratorSyntax variable
-            && variable.Parent?.Parent is EventFieldDeclarationSyntax field)
-        {
-            eventField = field;
-            declarator = variable;
-            return true;
-        }
-
-        eventField = null!;
-        declarator = null!;
-        return false;
     }
 
     private static MemberDeclarationSyntax? AsRemovableMember(SyntaxNode syntax)

--- a/src/RoslynMcp.Core/Refactoring/Generate/ImplementInterfaceOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/ImplementInterfaceOperation.cs
@@ -1157,7 +1157,7 @@ public sealed class ImplementInterfaceOperation : RefactoringOperationBase<Imple
             foreach (var reference in existing.DeclaringSyntaxReferences)
             {
                 var syntax = await reference.GetSyntaxAsync(cancellationToken);
-                if (TryGetEventFieldDeclarator(syntax, out var eventField, out var declarator)
+                if (EventFieldDeclarator.TryGet(syntax, out var eventField, out var declarator)
                     && eventField.Parent is TypeDeclarationSyntax eventPart)
                 {
                     if (eventField.Declaration.Variables.Count > 1)
@@ -1332,24 +1332,6 @@ public sealed class ImplementInterfaceOperation : RefactoringOperationBase<Imple
         }
 
         keys.Add(key);
-    }
-
-    private static bool TryGetEventFieldDeclarator(
-        SyntaxNode syntax,
-        out EventFieldDeclarationSyntax eventField,
-        out VariableDeclaratorSyntax declarator)
-    {
-        if (syntax is VariableDeclaratorSyntax variable
-            && variable.Parent?.Parent is EventFieldDeclarationSyntax field)
-        {
-            eventField = field;
-            declarator = variable;
-            return true;
-        }
-
-        eventField = null!;
-        declarator = null!;
-        return false;
     }
 
     private static MemberDeclarationSyntax? AsRemovableMember(SyntaxNode syntax)

--- a/src/RoslynMcp.Core/Refactoring/Utilities/EventFieldDeclarator.cs
+++ b/src/RoslynMcp.Core/Refactoring/Utilities/EventFieldDeclarator.cs
@@ -1,0 +1,39 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace RoslynMcp.Core.Refactoring.Utilities;
+
+/// <summary>
+/// Shared event-field declarator recognition used by generate_overrides,
+/// implement_interface, and implement_abstract when collecting existing
+/// override / implementation members that are event field declarators
+/// (including multi-variable <c>event</c> fields).
+/// </summary>
+internal static class EventFieldDeclarator
+{
+    /// <summary>
+    /// True when <paramref name="syntax"/> is a
+    /// <see cref="VariableDeclaratorSyntax"/> whose grandparent is an
+    /// <see cref="EventFieldDeclarationSyntax"/>; sets
+    /// <paramref name="eventField"/> and <paramref name="declarator"/>
+    /// to that pair (same body as the GenerateOverrides /
+    /// ImplementInterface / ImplementAbstract copies).
+    /// </summary>
+    internal static bool TryGet(
+        SyntaxNode syntax,
+        out EventFieldDeclarationSyntax eventField,
+        out VariableDeclaratorSyntax declarator)
+    {
+        if (syntax is VariableDeclaratorSyntax variable
+            && variable.Parent?.Parent is EventFieldDeclarationSyntax field)
+        {
+            eventField = field;
+            declarator = variable;
+            return true;
+        }
+
+        eventField = null!;
+        declarator = null!;
+        return false;
+    }
+}

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Utilities/EventFieldDeclaratorTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Utilities/EventFieldDeclaratorTests.cs
@@ -1,0 +1,84 @@
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using RoslynMcp.Core.Refactoring.Utilities;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Refactoring.Utilities;
+
+public class EventFieldDeclaratorTests
+{
+    [Fact]
+    public void TryGet_True_ForVariableDeclaratorUnderEventField()
+    {
+        var tree = CSharpSyntaxTree.ParseText("""
+            class C
+            {
+                event System.Action E;
+            }
+            """);
+        var declarator = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Single();
+        var field = tree.GetRoot().DescendantNodes().OfType<EventFieldDeclarationSyntax>().Single();
+
+        Assert.True(EventFieldDeclarator.TryGet(declarator, out var eventField, out var matched));
+        Assert.Same(field, eventField);
+        Assert.Same(declarator, matched);
+        Assert.Equal("E", matched.Identifier.Text);
+    }
+
+    [Fact]
+    public void TryGet_False_ForVariableDeclaratorUnderFieldDeclaration()
+    {
+        var tree = CSharpSyntaxTree.ParseText("""
+            class C
+            {
+                int f;
+            }
+            """);
+        var declarator = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Single();
+
+        Assert.False(EventFieldDeclarator.TryGet(declarator, out var eventField, out var matched));
+        Assert.Null(eventField);
+        Assert.Null(matched);
+    }
+
+    [Fact]
+    public void TryGet_False_ForOtherSyntaxNode()
+    {
+        var tree = CSharpSyntaxTree.ParseText("""
+            class C
+            {
+                event System.Action E { add { } remove { } }
+                void M() { }
+            }
+            """);
+        var method = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().Single();
+        var eventDecl = tree.GetRoot().DescendantNodes().OfType<EventDeclarationSyntax>().Single();
+
+        Assert.False(EventFieldDeclarator.TryGet(method, out _, out _));
+        Assert.False(EventFieldDeclarator.TryGet(eventDecl, out _, out _));
+    }
+
+    [Fact]
+    public void TryGet_True_ForMatchingDeclaratorInMultiVariableEventField()
+    {
+        var tree = CSharpSyntaxTree.ParseText("""
+            class C
+            {
+                event System.Action A, B;
+            }
+            """);
+        var field = tree.GetRoot().DescendantNodes().OfType<EventFieldDeclarationSyntax>().Single();
+        var a = field.Declaration.Variables[0];
+        var b = field.Declaration.Variables[1];
+
+        Assert.True(EventFieldDeclarator.TryGet(a, out var fieldForA, out var matchedA));
+        Assert.Same(field, fieldForA);
+        Assert.Same(a, matchedA);
+        Assert.Equal("A", matchedA.Identifier.Text);
+
+        Assert.True(EventFieldDeclarator.TryGet(b, out var fieldForB, out var matchedB));
+        Assert.Same(field, fieldForB);
+        Assert.Same(b, matchedB);
+        Assert.Equal("B", matchedB.Identifier.Text);
+    }
+}


### PR DESCRIPTION
## Summary
- Closes #1018
- Extract shared `EventFieldDeclarator.TryGet` under `RoslynMcp.Core.Refactoring.Utilities`
- Replace identical `TryGetEventFieldDeclarator` copies in `GenerateOverridesOperation`, `ImplementInterfaceOperation`, and `ImplementAbstractOperation`
- Add `EventFieldDeclaratorTests` (event field → true; ordinary field → false; other SyntaxNode → false; multi-variable event field matching declarator); CHANGELOG Unreleased one-liner

## Test plan
- [x] `dotnet test tests/RoslynMcp.Core.Tests/RoslynMcp.Core.Tests.csproj --filter "FullyQualifiedName~EventFieldDeclarator|FullyQualifiedName~GenerateOverrides|FullyQualifiedName~ImplementInterface|FullyQualifiedName~ImplementAbstract"` — 438 passed
- [ ] CI Build & Test green
- [ ] CI Format Check green
- [ ] Dependabot untouched