### PR TITLE
Release v0.6.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roslyn-mcp",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Roslyn-powered C# refactoring MCP server — 50 tools for code navigation, analysis, generation, and refactoring across entire .NET solutions",
   "author": {
     "name": "Joshua Ramirez"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-09-12
+
+### Fixed
+- `analyze_data_flow` sibling-list filter: braced method regions / nested statements no longer rejected by ValidateStatementRange (#931)
+- `analyze_data_flow` accepts expression-bodied regions via AnalyzeDataFlow(ExpressionSyntax) (#932)
+- `analyze_data_flow` accepts EqualsValueClause initializer regions (Value expression) (#933)
+- `analyze_control_flow` sibling filter no longer allows cross-block First/Last that tripped RoslynError (#936)
+
 ### Changed
 - Extracted shared `SyntaxIdentifierValidation.IsValidIdentifier` and replaced 6 identical SyntaxFacts Inline/Generate/Signature/Convert copies (`inline_constant` / `generate_method_stub` / `generate_property` / `add_parameter` / `convert_anonymous_to_class` / `convert_tuple_to_struct`) (#1015)
 - Extracted shared `IdentifierValidation.IsValidIdentifier` and replaced 5 identical char-based Encapsulate/Extract copies (`encapsulate_field` / `extract_constant` / `extract_interface` / `extract_variable` / `extract_base_class`) (#1012)
@@ -334,7 +342,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - Cross-platform .NET global tool (`roslyn-mcp`)
 - MCP protocol support for Claude Code and Claude Desktop
 
-[Unreleased]: https://github.com/JoshuaRamirez/RoslynMcpServer/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/JoshuaRamirez/RoslynMcpServer/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/JoshuaRamirez/RoslynMcpServer/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/JoshuaRamirez/RoslynMcpServer/compare/v0.5.2...v0.6.0
 [0.5.2]: https://github.com/JoshuaRamirez/RoslynMcpServer/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/JoshuaRamirez/RoslynMcpServer/compare/v0.5.0...v0.5.1

--- a/src/RoslynMcp.Cli/RoslynMcp.Cli.csproj
+++ b/src/RoslynMcp.Cli/RoslynMcp.Cli.csproj
@@ -14,7 +14,7 @@
     <ToolCommandName>roslyn-cli</ToolCommandName>
 
     <PackageId>RoslynMcp.Cli</PackageId>
-    <Version>0.6.0</Version>
+    <Version>0.6.1</Version>
     <Authors>Joshua Ramirez</Authors>
     <Company>RedJay</Company>
     <Description>Standalone CLI for 42 Roslyn-powered C# refactoring, analysis, and navigation tools.</Description>

--- a/src/RoslynMcp.Contracts/RoslynMcp.Contracts.csproj
+++ b/src/RoslynMcp.Contracts/RoslynMcp.Contracts.csproj
@@ -9,7 +9,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>RoslynMcp.Contracts</PackageId>
-    <Version>0.6.0</Version>
+    <Version>0.6.1</Version>
     <Authors>Joshua Ramirez</Authors>
     <Company>RedJay</Company>
     <Description>Contract definitions and models for Roslyn MCP Server - Model Context Protocol integration for C# refactoring operations powered by Roslyn.</Description>

--- a/src/RoslynMcp.Core/RoslynMcp.Core.csproj
+++ b/src/RoslynMcp.Core/RoslynMcp.Core.csproj
@@ -9,7 +9,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>RoslynMcp.Core</PackageId>
-    <Version>0.6.0</Version>
+    <Version>0.6.1</Version>
     <Authors>Joshua Ramirez</Authors>
     <Company>RedJay</Company>
     <Description>Core library for Roslyn MCP Server providing C# refactoring operations including move type, rename symbol, extract method, and more. Powered by Roslyn and MSBuild.</Description>

--- a/src/RoslynMcp.Server/RoslynMcp.Server.csproj
+++ b/src/RoslynMcp.Server/RoslynMcp.Server.csproj
@@ -15,7 +15,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>RoslynMcp.Server</PackageId>
-    <Version>0.6.0</Version>
+    <Version>0.6.1</Version>
     <Authors>Joshua Ramirez</Authors>
     <Company>RedJay</Company>
     <Description>MCP Server for Roslyn-powered C# refactoring operations. Install as a global tool to use with Claude Code, Claude Desktop, or other MCP clients. Provides 50 tools: 27 refactoring operations, 5 code navigation tools, 6 analysis and metrics tools, 4 code generation tools, and 8 code conversion tools.</Description>


### PR DESCRIPTION
## Summary
Continuous deployment release **v0.6.1** (patch) after analyze_* region correctness fixes and shared coverage/helper extracts landed on master since v0.6.0.

### Fixed
- `analyze_data_flow` sibling-list filter: braced method regions / nested statements no longer rejected by ValidateStatementRange (#931)
- `analyze_data_flow` accepts expression-bodied regions via AnalyzeDataFlow(ExpressionSyntax) (#932)
- `analyze_data_flow` accepts EqualsValueClause initializer regions (Value expression) (#933)
- `analyze_control_flow` sibling filter no longer allows cross-block First/Last that tripped RoslynError (#936)

### Changed
- Shared helper extracts: SpanCoverage, TypeCoverage, MethodCoverage, FieldCoverage, SignatureReferenceHelpers, DeclarationIdentifiers, IdentifierValidation, SyntaxIdentifierValidation, AccessibilityModifiers (#955–#1015)

### Version bumps
- NuGet packages Contracts/Core/Server/Cli: 0.6.0 → 0.6.1
- `.claude-plugin/plugin.json`: 0.6.0 → 0.6.1
- CHANGELOG: Unreleased → `[0.6.1] - 2026-09-12` Fixed + Changed

## Test plan
- [x] Master CI green at tip before release branch
- [ ] Release PR CI green (build/quality)
- [ ] GitHub release `v0.6.1` publishes NuGet packages