### PR TITLE
Extract KeywordCoverage.KeywordCoversColumn; replace AddBraces + RemoveBraces copies (#1025)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Changed
+- Extracted shared `KeywordCoverage.KeywordCoversColumn` and replaced 2 identical AddBraces + RemoveBraces copies (`add_braces` / `remove_braces`) (#1025)
+
 ## [0.6.1] - 2026-09-12
 
 ### Fixed

--- a/src/RoslynMcp.Core/Refactoring/Convert/AddBracesOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/AddBracesOperation.cs
@@ -553,7 +553,7 @@ public sealed class AddBracesOperation : RefactoringOperationBase<AddBracesParam
         if (column.HasValue)
         {
             var atColumn = onLine
-                .Where(target => KeywordCoversColumn(target.Keyword, line, column.Value))
+                .Where(target => KeywordCoverage.KeywordCoversColumn(target.Keyword, line, column.Value))
                 .OrderBy(target => target.Keyword.Span.Length)
                 .ToList();
             return atColumn.Count == 0 ? null : atColumn[0];
@@ -611,11 +611,6 @@ public sealed class AddBracesOperation : RefactoringOperationBase<AddBracesParam
     {
         var span = keyword.GetLocation().GetLineSpan();
         return span.StartLinePosition.Line + 1 == line;
-    }
-
-    private static bool KeywordCoversColumn(SyntaxToken keyword, int line, int column)
-    {
-        return SpanCoverage.SpanCoversColumn(keyword.GetLocation().GetLineSpan(), line, column);
     }
 
 

--- a/src/RoslynMcp.Core/Refactoring/Convert/RemoveBracesOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/RemoveBracesOperation.cs
@@ -641,7 +641,7 @@ public sealed class RemoveBracesOperation : RefactoringOperationBase<RemoveBrace
         if (column.HasValue)
         {
             var atColumn = onLine
-                .Where(target => KeywordCoversColumn(target.Keyword, line, column.Value))
+                .Where(target => KeywordCoverage.KeywordCoversColumn(target.Keyword, line, column.Value))
                 .OrderBy(target => target.Keyword.Span.Length)
                 .ToList();
             return atColumn.Count == 0 ? null : atColumn[0];
@@ -711,11 +711,6 @@ public sealed class RemoveBracesOperation : RefactoringOperationBase<RemoveBrace
     {
         var span = keyword.GetLocation().GetLineSpan();
         return span.StartLinePosition.Line + 1 == line;
-    }
-
-    private static bool KeywordCoversColumn(SyntaxToken keyword, int line, int column)
-    {
-        return SpanCoverage.SpanCoversColumn(keyword.GetLocation().GetLineSpan(), line, column);
     }
 
 

--- a/src/RoslynMcp.Core/Resolution/KeywordCoverage.cs
+++ b/src/RoslynMcp.Core/Resolution/KeywordCoverage.cs
@@ -1,0 +1,19 @@
+using Microsoft.CodeAnalysis;
+
+namespace RoslynMcp.Core.Resolution;
+
+/// <summary>
+/// Shared keyword-token coverage helpers used when disambiguating
+/// control-statement keywords by optional 1-based line / column via
+/// <see cref="SpanCoverage"/>.
+/// </summary>
+internal static class KeywordCoverage
+{
+    /// <summary>
+    /// True when <paramref name="keyword"/>'s location covers
+    /// <paramref name="line"/> / <paramref name="column"/> (exclusive-end
+    /// column rules via <see cref="SpanCoverage.SpanCoversColumn"/>).
+    /// </summary>
+    internal static bool KeywordCoversColumn(SyntaxToken keyword, int line, int column) =>
+        SpanCoverage.SpanCoversColumn(keyword.GetLocation().GetLineSpan(), line, column);
+}

--- a/tests/RoslynMcp.Core.Tests/Resolution/KeywordCoverageTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Resolution/KeywordCoverageTests.cs
@@ -1,0 +1,44 @@
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using RoslynMcp.Core.Resolution;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Resolution;
+
+public class KeywordCoverageTests
+{
+    [Fact]
+    public void KeywordCoversColumn_True_OnKeyword_False_Before_AtExclusiveEnd_WrongLine()
+    {
+        var tree = CSharpSyntaxTree.ParseText("""
+            class C
+            {
+                void M()
+                {
+                    if (true) { }
+                    for (int i = 0; i < 1; i++) { }
+                }
+            }
+            """);
+        var root = tree.GetRoot();
+        var ifKeyword = root.DescendantNodes().OfType<IfStatementSyntax>().Single().IfKeyword;
+        var forKeyword = root.DescendantNodes().OfType<ForStatementSyntax>().Single().ForKeyword;
+
+        var ifSpan = ifKeyword.GetLocation().GetLineSpan();
+        var ifLine = ifSpan.StartLinePosition.Line + 1;
+        var ifStartCol = ifSpan.StartLinePosition.Character + 1;
+        var ifEndCol = ifSpan.EndLinePosition.Character + 1;
+
+        Assert.True(KeywordCoverage.KeywordCoversColumn(ifKeyword, ifLine, ifStartCol));
+        Assert.True(KeywordCoverage.KeywordCoversColumn(ifKeyword, ifLine, ifEndCol - 1));
+        Assert.False(KeywordCoverage.KeywordCoversColumn(ifKeyword, ifLine, ifStartCol - 1));
+        Assert.False(KeywordCoverage.KeywordCoversColumn(ifKeyword, ifLine, ifEndCol));
+        Assert.False(KeywordCoverage.KeywordCoversColumn(ifKeyword, ifLine + 1, ifStartCol));
+
+        var forSpan = forKeyword.GetLocation().GetLineSpan();
+        var forLine = forSpan.StartLinePosition.Line + 1;
+        var forStartCol = forSpan.StartLinePosition.Character + 1;
+        Assert.True(KeywordCoverage.KeywordCoversColumn(forKeyword, forLine, forStartCol));
+        Assert.False(KeywordCoverage.KeywordCoversColumn(forKeyword, ifLine, ifStartCol));
+    }
+}


### PR DESCRIPTION
## Summary
- Extract shared `KeywordCoverage.KeywordCoversColumn` under `RoslynMcp.Core.Resolution` (delegates to `SpanCoverage.SpanCoversColumn`).
- Replace the two identical type-local copies in `AddBracesOperation` and `RemoveBracesOperation`; retarget call sites.
- Add focused `KeywordCoverageTests` (covering column / before / exclusive end / wrong line on `if`/`for` keywords).
- CHANGELOG Unreleased / Changed one-liner.

Closes #1025

## Test plan
- [x] `dotnet test ... --filter FullyQualifiedName~KeywordCoverage`
- [x] `dotnet test ... --filter FullyQualifiedName~AddBraces|RemoveBraces|KeywordCoverage` (117 passed)
- [ ] CI Build and Test + Code Quality green