### PR TITLE
Extract KeywordCoverage.KeywordIsOnLine; replace AddBraces + RemoveBraces copies; retarget InvertIf + ConvertForeachLinq wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- Extracted shared `KeywordCoverage.KeywordIsOnLine` and replaced AddBraces + RemoveBraces copies; retargeted InvertIf + ConvertForeachLinq KeywordCoverage wrappers (`add_braces` / `remove_braces` / `invert_if` / `convert_foreach_linq`) (#1028)
 - Extracted shared `KeywordCoverage.KeywordCoversColumn` and replaced 2 identical AddBraces + RemoveBraces copies (`add_braces` / `remove_braces`) (#1025)
 
 ## [0.6.1] - 2026-09-12

--- a/src/RoslynMcp.Core/Refactoring/Convert/AddBracesOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/AddBracesOperation.cs
@@ -544,7 +544,7 @@ public sealed class AddBracesOperation : RefactoringOperationBase<AddBracesParam
     internal static ControlTarget? FindControlTarget(SyntaxNode root, int line, int? column)
     {
         var onLine = CollectTargets(root)
-            .Where(target => KeywordIsOnLine(target.Keyword, line))
+            .Where(target => KeywordCoverage.KeywordIsOnLine(target.Keyword, line))
             .ToList();
 
         if (onLine.Count == 0)
@@ -605,12 +605,6 @@ public sealed class AddBracesOperation : RefactoringOperationBase<AddBracesParam
             return block;
 
         return SyntaxFactory.Block(statement);
-    }
-
-    private static bool KeywordIsOnLine(SyntaxToken keyword, int line)
-    {
-        var span = keyword.GetLocation().GetLineSpan();
-        return span.StartLinePosition.Line + 1 == line;
     }
 
 

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertForeachLinqOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertForeachLinqOperation.cs
@@ -312,7 +312,7 @@ public sealed class ConvertForeachLinqOperation : RefactoringOperationBase<Conve
     {
         var onLine = root.DescendantNodes()
             .OfType<ForEachStatementSyntax>()
-            .Where(statement => KeywordIsOnLine(statement, line))
+            .Where(statement => KeywordCoverage.KeywordIsOnLine(statement.ForEachKeyword, line))
             .ToList();
 
         if (onLine.Count == 0)
@@ -321,7 +321,7 @@ public sealed class ConvertForeachLinqOperation : RefactoringOperationBase<Conve
         if (column.HasValue)
         {
             var atColumn = onLine
-                .Where(statement => KeywordCoversColumn(statement, line, column.Value))
+                .Where(statement => KeywordCoverage.KeywordCoversColumn(statement.ForEachKeyword, line, column.Value))
                 .OrderBy(statement => statement.ForEachKeyword.Span.Length)
                 .ToList();
             return atColumn.FirstOrDefault();
@@ -533,17 +533,6 @@ public sealed class ConvertForeachLinqOperation : RefactoringOperationBase<Conve
         SyntaxFactory.ExpressionStatement(linqExpr)
             .WithLeadingTrivia(foreach_.GetLeadingTrivia())
             .WithTrailingTrivia(foreach_.GetTrailingTrivia());
-
-    private static bool KeywordIsOnLine(ForEachStatementSyntax statement, int line)
-    {
-        var span = statement.ForEachKeyword.GetLocation().GetLineSpan();
-        return span.StartLinePosition.Line + 1 == line;
-    }
-
-    private static bool KeywordCoversColumn(ForEachStatementSyntax statement, int line, int column)
-    {
-        return SpanCoverage.SpanCoversColumn(statement.ForEachKeyword.GetLocation().GetLineSpan(), line, column);
-    }
 
 }
 

--- a/src/RoslynMcp.Core/Refactoring/Convert/InvertIfOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/InvertIfOperation.cs
@@ -343,7 +343,7 @@ public sealed class InvertIfOperation : RefactoringOperationBase<InvertIfParams>
     {
         var onLine = root.DescendantNodes()
             .OfType<IfStatementSyntax>()
-            .Where(statement => KeywordIsOnLine(statement, line))
+            .Where(statement => KeywordCoverage.KeywordIsOnLine(statement.IfKeyword, line))
             .ToList();
 
         if (onLine.Count == 0)
@@ -352,25 +352,13 @@ public sealed class InvertIfOperation : RefactoringOperationBase<InvertIfParams>
         if (column.HasValue)
         {
             var atColumn = onLine
-                .Where(statement => KeywordCoversColumn(statement, line, column.Value))
+                .Where(statement => KeywordCoverage.KeywordCoversColumn(statement.IfKeyword, line, column.Value))
                 .OrderBy(statement => statement.Span.Length)
                 .ToList();
             return atColumn.FirstOrDefault();
         }
 
         return onLine.OrderBy(statement => statement.IfKeyword.SpanStart).First();
-    }
-
-    private static bool KeywordIsOnLine(IfStatementSyntax statement, int line)
-    {
-        var span = statement.IfKeyword.GetLocation().GetLineSpan();
-        return span.StartLinePosition.Line + 1 == line;
-    }
-
-    private static bool KeywordCoversColumn(IfStatementSyntax statement, int line, int column)
-    {
-        var span = statement.IfKeyword.GetLocation().GetLineSpan();
-        return SpanCoverage.SpanCoversColumn(span, line, column);
     }
 
 

--- a/src/RoslynMcp.Core/Refactoring/Convert/RemoveBracesOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/RemoveBracesOperation.cs
@@ -632,7 +632,7 @@ public sealed class RemoveBracesOperation : RefactoringOperationBase<RemoveBrace
     internal static ControlTarget? FindControlTarget(SyntaxNode root, int line, int? column)
     {
         var onLine = CollectTargets(root)
-            .Where(target => KeywordIsOnLine(target.Keyword, line))
+            .Where(target => KeywordCoverage.KeywordIsOnLine(target.Keyword, line))
             .ToList();
 
         if (onLine.Count == 0)
@@ -706,12 +706,6 @@ public sealed class RemoveBracesOperation : RefactoringOperationBase<RemoveBrace
     private static IEnumerable<SyntaxTrivia> NonWhitespaceTrivia(SyntaxTriviaList trivia) =>
         trivia.Where(item => !item.IsKind(SyntaxKind.WhitespaceTrivia)
             && !item.IsKind(SyntaxKind.EndOfLineTrivia));
-
-    private static bool KeywordIsOnLine(SyntaxToken keyword, int line)
-    {
-        var span = keyword.GetLocation().GetLineSpan();
-        return span.StartLinePosition.Line + 1 == line;
-    }
 
 
     private static string BuildDescription(string scope, int count, string? typeName)

--- a/src/RoslynMcp.Core/Resolution/KeywordCoverage.cs
+++ b/src/RoslynMcp.Core/Resolution/KeywordCoverage.cs
@@ -10,6 +10,15 @@ namespace RoslynMcp.Core.Resolution;
 internal static class KeywordCoverage
 {
     /// <summary>
+    /// True when <paramref name="keyword"/> starts on 1-based <paramref name="line"/>.
+    /// </summary>
+    internal static bool KeywordIsOnLine(SyntaxToken keyword, int line)
+    {
+        var span = keyword.GetLocation().GetLineSpan();
+        return span.StartLinePosition.Line + 1 == line;
+    }
+
+    /// <summary>
     /// True when <paramref name="keyword"/>'s location covers
     /// <paramref name="line"/> / <paramref name="column"/> (exclusive-end
     /// column rules via <see cref="SpanCoverage.SpanCoversColumn"/>).

--- a/tests/RoslynMcp.Core.Tests/Resolution/KeywordCoverageTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Resolution/KeywordCoverageTests.cs
@@ -41,4 +41,30 @@ public class KeywordCoverageTests
         Assert.True(KeywordCoverage.KeywordCoversColumn(forKeyword, forLine, forStartCol));
         Assert.False(KeywordCoverage.KeywordCoversColumn(forKeyword, ifLine, ifStartCol));
     }
+
+    [Fact]
+    public void KeywordIsOnLine_True_OnKeywordLine_False_OnWrongLine()
+    {
+        var tree = CSharpSyntaxTree.ParseText("""
+            class C
+            {
+                void M()
+                {
+                    if (true) { }
+                    for (int i = 0; i < 1; i++) { }
+                }
+            }
+            """);
+        var root = tree.GetRoot();
+        var ifKeyword = root.DescendantNodes().OfType<IfStatementSyntax>().Single().IfKeyword;
+        var forKeyword = root.DescendantNodes().OfType<ForStatementSyntax>().Single().ForKeyword;
+
+        var ifLine = ifKeyword.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+        var forLine = forKeyword.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+
+        Assert.True(KeywordCoverage.KeywordIsOnLine(ifKeyword, ifLine));
+        Assert.False(KeywordCoverage.KeywordIsOnLine(ifKeyword, ifLine + 1));
+        Assert.True(KeywordCoverage.KeywordIsOnLine(forKeyword, forLine));
+        Assert.False(KeywordCoverage.KeywordIsOnLine(forKeyword, ifLine));
+    }
 }


### PR DESCRIPTION
## Summary
- Extracted shared `KeywordCoverage.KeywordIsOnLine` and deleted the identical AddBraces + RemoveBraces private copies.
- Retargeted InvertIf + ConvertForeachLinq statement-typed `KeywordIsOnLine` / `KeywordCoversColumn` wrappers onto `KeywordCoverage` on `IfKeyword` / `ForEachKeyword`.
- Extended `KeywordCoverageTests` for KeywordIsOnLine; CHANGELOG Unreleased/Changed one-liner.

## Test plan
- [x] `dotnet test tests/RoslynMcp.Core.Tests/RoslynMcp.Core.Tests.csproj --filter "FullyQualifiedName~KeywordCoverage|FullyQualifiedName~AddBraces|FullyQualifiedName~RemoveBraces|FullyQualifiedName~InvertIf|FullyQualifiedName~ConvertForeachLinq"` — 219 passed
- [ ] CI Build & Test + CodeQL green

Closes #1028