### PR TITLE
Extract PropertyCoverage.PropertyCoversColumn / IdentifierCoversColumn; replace ConvertPropertyOperation copies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- Extracted shared `PropertyCoverage.PropertyCoversColumn` / `IdentifierCoversColumn` and replaced ConvertPropertyOperation copies (`convert_property`) (#1032)
 - Extracted shared `KeywordCoverage.KeywordIsOnLine` and replaced AddBraces + RemoveBraces copies; retargeted InvertIf + ConvertForeachLinq KeywordCoverage wrappers (`add_braces` / `remove_braces` / `invert_if` / `convert_foreach_linq`) (#1028)
 - Extracted shared `KeywordCoverage.KeywordCoversColumn` and replaced 2 identical AddBraces + RemoveBraces copies (`add_braces` / `remove_braces`) (#1025)
 

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertPropertyOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertPropertyOperation.cs
@@ -496,8 +496,8 @@ public sealed class ConvertPropertyOperation : RefactoringOperationBase<ConvertP
             // property's identifier may live on a continuation line whose
             // declaration span still covers that column.
             return properties
-                .Where(p => PropertyCoversColumn(p, line!.Value, column.Value))
-                .OrderBy(p => IdentifierCoversColumn(p, line!.Value, column.Value) ? 0 : 1)
+                .Where(p => PropertyCoverage.PropertyCoversColumn(p, line!.Value, column.Value))
+                .OrderBy(p => PropertyCoverage.IdentifierCoversColumn(p, line!.Value, column.Value) ? 0 : 1)
                 .ThenBy(p => p.Span.Length)
                 .FirstOrDefault();
         }
@@ -510,13 +510,6 @@ public sealed class ConvertPropertyOperation : RefactoringOperationBase<ConvertP
 
     private static int StartLine(PropertyDeclarationSyntax property) =>
         property.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
-
-    private static bool PropertyCoversColumn(PropertyDeclarationSyntax property, int line, int column) =>
-        IdentifierCoversColumn(property, line, column) ||
-        SpanCoverage.SpanCoversColumn(property.GetLocation().GetLineSpan(), line, column);
-
-    private static bool IdentifierCoversColumn(PropertyDeclarationSyntax property, int line, int column) =>
-        SpanCoverage.SpanCoversColumn(property.Identifier.GetLocation().GetLineSpan(), line, column);
 
 
     /// <summary>

--- a/src/RoslynMcp.Core/Resolution/PropertyCoverage.cs
+++ b/src/RoslynMcp.Core/Resolution/PropertyCoverage.cs
@@ -1,0 +1,28 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace RoslynMcp.Core.Resolution;
+
+/// <summary>
+/// Shared property-declaration coverage helpers used when disambiguating
+/// same-named properties by optional 1-based line / column (identifier preferred,
+/// then containing property span via <see cref="SpanCoverage"/>).
+/// </summary>
+internal static class PropertyCoverage
+{
+    /// <summary>
+    /// True when the property's identifier or full declaration span covers
+    /// <paramref name="line"/> / <paramref name="column"/> (exclusive-end
+    /// column rules via <see cref="SpanCoverage.SpanCoversColumn"/>).
+    /// </summary>
+    internal static bool PropertyCoversColumn(PropertyDeclarationSyntax property, int line, int column) =>
+        IdentifierCoversColumn(property, line, column) ||
+        SpanCoverage.SpanCoversColumn(property.GetLocation().GetLineSpan(), line, column);
+
+    /// <summary>
+    /// True when the property's declaration identifier covers
+    /// <paramref name="line"/> / <paramref name="column"/>.
+    /// </summary>
+    internal static bool IdentifierCoversColumn(PropertyDeclarationSyntax property, int line, int column) =>
+        SpanCoverage.SpanCoversColumn(property.Identifier.GetLocation().GetLineSpan(), line, column);
+}

--- a/tests/RoslynMcp.Core.Tests/Resolution/PropertyCoverageTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Resolution/PropertyCoverageTests.cs
@@ -1,0 +1,34 @@
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using RoslynMcp.Core.Resolution;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Resolution;
+
+public class PropertyCoverageTests
+{
+    [Fact]
+    public void PropertyCoversColumn_True_OnIdentifier_False_AtExclusiveEnd()
+    {
+        var tree = CSharpSyntaxTree.ParseText("""
+            class C
+            {
+                int P { get; set; }
+            }
+            """);
+        var root = tree.GetRoot();
+        var property = root.DescendantNodes().OfType<PropertyDeclarationSyntax>().Single();
+        var idSpan = property.Identifier.GetLocation().GetLineSpan();
+        var line = idSpan.StartLinePosition.Line + 1;
+        var startCol = idSpan.StartLinePosition.Character + 1;
+        var endCol = idSpan.EndLinePosition.Character + 1;
+
+        Assert.True(PropertyCoverage.PropertyCoversColumn(property, line, startCol));
+        Assert.True(PropertyCoverage.IdentifierCoversColumn(property, line, startCol));
+        Assert.True(PropertyCoverage.IdentifierCoversColumn(property, line, endCol - 1));
+        Assert.False(PropertyCoverage.IdentifierCoversColumn(property, line, endCol));
+        // endCol is past the identifier exclusive end but still inside the property span.
+        Assert.True(PropertyCoverage.PropertyCoversColumn(property, line, endCol));
+        Assert.False(PropertyCoverage.IdentifierCoversColumn(property, line, startCol - 1));
+    }
+}


### PR DESCRIPTION
Closes #1032

## Summary
- Add shared `PropertyCoverage` (`PropertyCoversColumn` / `IdentifierCoversColumn` for `PropertyDeclarationSyntax`) under `RoslynMcp.Core.Resolution`, mirroring MethodCoverage.
- Delete ConvertPropertyOperation type-local copies; retarget column disambiguation call sites.
- Add PropertyCoverageTests (identifier true; exclusive-end false on id; still true on property span past id end).
- CHANGELOG Unreleased/Changed one-liner.

## Test plan
- [x] `dotnet test tests/RoslynMcp.Core.Tests/RoslynMcp.Core.Tests.csproj --filter "FullyQualifiedName~PropertyCoverage|FullyQualifiedName~ConvertProperty"` (58 passed locally)
- [ ] CI green