### PR TITLE
Retarget TypeSymbolResolver.FindCoveringType onto TypeCoverage; delete private copies (#1037)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- Retargeted `TypeSymbolResolver.FindCoveringType` onto shared `TypeCoverage`; deleted private TypeCoversColumn / IdentifierCoversColumn copies (#1037)
 - Extracted shared `PropertyCoverage.PropertyCoversColumn` / `IdentifierCoversColumn` and replaced ConvertPropertyOperation copies (`convert_property`) (#1032)
 - Extracted shared `KeywordCoverage.KeywordIsOnLine` and replaced AddBraces + RemoveBraces copies; retargeted InvertIf + ConvertForeachLinq KeywordCoverage wrappers (`add_braces` / `remove_braces` / `invert_if` / `convert_foreach_linq`) (#1028)
 - Extracted shared `KeywordCoverage.KeywordCoversColumn` and replaced 2 identical AddBraces + RemoveBraces copies (`add_braces` / `remove_braces`) (#1025)

--- a/src/RoslynMcp.Core/Resolution/TypeSymbolResolver.cs
+++ b/src/RoslynMcp.Core/Resolution/TypeSymbolResolver.cs
@@ -231,17 +231,10 @@ public sealed class TypeSymbolResolver
         int line,
         int column) =>
         matches
-            .Where(type => TypeCoversColumn(type, line, column))
-            .OrderBy(type => IdentifierCoversColumn(type, line, column) ? 0 : 1)
+            .Where(type => TypeCoverage.TypeCoversColumn(type, line, column))
+            .OrderBy(type => TypeCoverage.IdentifierCoversColumn(type, line, column) ? 0 : 1)
             .ThenBy(type => type.Span.Length)
             .FirstOrDefault();
-
-    private static bool TypeCoversColumn(TypeDeclarationSyntax type, int line, int column) =>
-        IdentifierCoversColumn(type, line, column) ||
-        SpanCoversColumn(type.GetLocation().GetLineSpan(), line, column);
-
-    private static bool IdentifierCoversColumn(TypeDeclarationSyntax type, int line, int column) =>
-        SpanCoversColumn(type.Identifier.GetLocation().GetLineSpan(), line, column);
 
     /// <summary>
     /// 1-based line/column coverage. Delegates to <see cref="SpanCoverage.SpanCoversColumn"/>.


### PR DESCRIPTION
## Summary
- Retarget `FindCoveringType` to shared `TypeCoverage.TypeCoversColumn` / `IdentifierCoversColumn`
- Delete private `TypeSymbolResolver` TypeCoversColumn / IdentifierCoversColumn copies
- Keep `TypeSymbolResolver.SpanCoversColumn` thin wrapper (existing MoveType tests)
- CHANGELOG Unreleased / Changed one-liner
- Closes #1037

## Test plan
- [x] `TypeCoverageTests` + MoveType `FindCoveringType` / SpanCovers filters (17 passed locally)
- [ ] CI Build and Test + Code Quality green
- [ ] Copilot/Codex review threads resolved