### PR TITLE
Extract MemberCoverage; replace ConvertExpressionBody + ConvertToBlockBody + AddNullChecks copies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- Extracted shared `MemberCoverage.MemberCoversColumn` / `IdentifierCoversColumn` and replaced ConvertExpressionBody + ConvertToBlockBody + AddNullChecks copies (`convert_expression_body` / `convert_to_block_body` / `add_null_checks`) (#1039)
 - Retargeted `TypeSymbolResolver.FindCoveringType` onto shared `TypeCoverage`; deleted private TypeCoversColumn / IdentifierCoversColumn copies (#1037)
 - Extracted shared `PropertyCoverage.PropertyCoversColumn` / `IdentifierCoversColumn` and replaced ConvertPropertyOperation copies (`convert_property`) (#1032)
 - Extracted shared `KeywordCoverage.KeywordIsOnLine` and replaced AddBraces + RemoveBraces copies; retargeted InvertIf + ConvertForeachLinq KeywordCoverage wrappers (`add_braces` / `remove_braces` / `invert_if` / `convert_foreach_linq`) (#1028)

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertExpressionBodyOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertExpressionBodyOperation.cs
@@ -279,8 +279,8 @@ public sealed class ConvertExpressionBodyOperation : RefactoringOperationBase<Co
             return members.FirstOrDefault();
 
         var atColumn = members
-            .Where(m => MemberCoversColumn(m, line ?? StartLine(m), column.Value))
-            .OrderBy(m => IdentifierCoversColumn(m, line ?? StartLine(m), column.Value) ? 0 : 1)
+            .Where(m => MemberCoverage.MemberCoversColumn(m, line ?? StartLine(m), column.Value))
+            .OrderBy(m => MemberCoverage.IdentifierCoversColumn(m, line ?? StartLine(m), column.Value) ? 0 : 1)
             .ThenBy(m => m.Span.Length)
             .ToList();
         return atColumn.FirstOrDefault();
@@ -288,27 +288,6 @@ public sealed class ConvertExpressionBodyOperation : RefactoringOperationBase<Co
 
     private static int StartLine(MemberDeclarationSyntax member) =>
         member.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
-
-    private static bool MemberCoversColumn(MemberDeclarationSyntax member, int line, int column) =>
-        IdentifierCoversColumn(member, line, column) ||
-        SpanCoverage.SpanCoversColumn(member.GetLocation().GetLineSpan(), line, column);
-
-    private static bool IdentifierCoversColumn(MemberDeclarationSyntax member, int line, int column)
-    {
-        var token = GetIdentifierToken(member);
-        return token != default && SpanCoverage.SpanCoversColumn(token.GetLocation().GetLineSpan(), line, column);
-    }
-
-    private static SyntaxToken GetIdentifierToken(MemberDeclarationSyntax member) => member switch
-    {
-        MethodDeclarationSyntax method => method.Identifier,
-        PropertyDeclarationSyntax property => property.Identifier,
-        IndexerDeclarationSyntax indexer => indexer.ThisKeyword,
-        OperatorDeclarationSyntax op => op.OperatorToken,
-        ConversionOperatorDeclarationSyntax conversion => conversion.Type.GetFirstToken(),
-        _ => default
-    };
-
 
     private static string? GetMemberName(MemberDeclarationSyntax member) => member switch
     {

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertToBlockBodyOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertToBlockBodyOperation.cs
@@ -186,8 +186,8 @@ public sealed class ConvertToBlockBodyOperation : RefactoringOperationBase<Conve
             // signature's identifier may live on a continuation line whose
             // declaration span still covers that column.
             return filtered
-                .Where(node => MemberCoversColumn(node, line!.Value, column.Value))
-                .OrderBy(node => IdentifierCoversColumn(node, line!.Value, column.Value) ? 0 : 1)
+                .Where(node => MemberCoverage.MemberCoversColumn(node, line!.Value, column.Value))
+                .OrderBy(node => MemberCoverage.IdentifierCoversColumn(node, line!.Value, column.Value) ? 0 : 1)
                 .ThenBy(node => node.Span.Length)
                 .FirstOrDefault();
         }
@@ -200,34 +200,6 @@ public sealed class ConvertToBlockBodyOperation : RefactoringOperationBase<Conve
 
         return filtered.FirstOrDefault();
     }
-
-    private static bool MemberCoversColumn(SyntaxNode member, int line, int column) =>
-        IdentifierCoversColumn(member, line, column) ||
-        SpanCoverage.SpanCoversColumn(member.GetLocation().GetLineSpan(), line, column);
-
-    private static bool IdentifierCoversColumn(SyntaxNode member, int line, int column)
-    {
-        var token = GetIdentifierToken(member);
-        return token != default && SpanCoverage.SpanCoversColumn(token.GetLocation().GetLineSpan(), line, column);
-    }
-
-    private static SyntaxToken GetIdentifierToken(SyntaxNode member) => member switch
-    {
-        MethodDeclarationSyntax method => method.Identifier,
-        PropertyDeclarationSyntax property => property.Identifier,
-        IndexerDeclarationSyntax indexer => indexer.ThisKeyword,
-        OperatorDeclarationSyntax op => op.OperatorToken,
-        ConversionOperatorDeclarationSyntax conversion => conversion.Type.GetFirstToken(),
-        ConstructorDeclarationSyntax constructor => constructor.Identifier,
-        DestructorDeclarationSyntax destructor => destructor.Identifier,
-        LocalFunctionStatementSyntax localFunction => localFunction.Identifier,
-        EventDeclarationSyntax @event => @event.Identifier,
-        FieldDeclarationSyntax field => field.Declaration.Variables.FirstOrDefault()?.Identifier ?? default,
-        EventFieldDeclarationSyntax eventField => eventField.Declaration.Variables.FirstOrDefault()?.Identifier ?? default,
-        TypeDeclarationSyntax type => type.Identifier,
-        _ => default
-    };
-
 
     /// <summary>
     /// 1-based line coverage. <see cref="FileLinePositionSpan.EndLinePosition"/>

--- a/src/RoslynMcp.Core/Refactoring/Generate/AddNullChecksOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/AddNullChecksOperation.cs
@@ -374,8 +374,8 @@ public sealed class AddNullChecksOperation : RefactoringOperationBase<AddNullChe
             // not start on `line`. If nothing covers this position, keep
             // today's not-found (null) rather than inventing a first-match.
             return candidates
-                .Where(n => MemberCoversColumn(n, line!.Value, column.Value))
-                .OrderBy(n => IdentifierCoversColumn(n, line!.Value, column.Value) ? 0 : 1)
+                .Where(n => MemberCoverage.MemberCoversColumn(n, line!.Value, column.Value))
+                .OrderBy(n => MemberCoverage.IdentifierCoversColumn(n, line!.Value, column.Value) ? 0 : 1)
                 .ThenBy(n => n.Span.Length)
                 .FirstOrDefault();
         }
@@ -391,24 +391,6 @@ public sealed class AddNullChecksOperation : RefactoringOperationBase<AddNullChe
 
     private static int StartLine(SyntaxNode node) =>
         node.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
-
-    private static bool MemberCoversColumn(SyntaxNode node, int line, int column) =>
-        IdentifierCoversColumn(node, line, column) ||
-        SpanCoverage.SpanCoversColumn(node.GetLocation().GetLineSpan(), line, column);
-
-    private static bool IdentifierCoversColumn(SyntaxNode node, int line, int column)
-    {
-        var identifier = GetIdentifier(node);
-        return identifier != default &&
-               SpanCoverage.SpanCoversColumn(identifier.GetLocation().GetLineSpan(), line, column);
-    }
-
-    private static SyntaxToken GetIdentifier(SyntaxNode node) => node switch
-    {
-        MethodDeclarationSyntax method => method.Identifier,
-        ConstructorDeclarationSyntax constructor => constructor.Identifier,
-        _ => default
-    };
 
     private static BlockSyntax? GetBody(SyntaxNode node) => node switch
     {

--- a/src/RoslynMcp.Core/Resolution/MemberCoverage.cs
+++ b/src/RoslynMcp.Core/Resolution/MemberCoverage.cs
@@ -1,0 +1,55 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace RoslynMcp.Core.Resolution;
+
+/// <summary>
+/// Shared member-declaration coverage helpers used when disambiguating
+/// members by optional 1-based line / column (identifier preferred,
+/// then containing member span via <see cref="SpanCoverage"/>).
+/// </summary>
+internal static class MemberCoverage
+{
+    /// <summary>
+    /// True when the member's identifier token or full declaration span covers
+    /// <paramref name="line"/> / <paramref name="column"/> (exclusive-end
+    /// column rules via <see cref="SpanCoverage.SpanCoversColumn"/>).
+    /// </summary>
+    internal static bool MemberCoversColumn(SyntaxNode member, int line, int column) =>
+        IdentifierCoversColumn(member, line, column) ||
+        SpanCoverage.SpanCoversColumn(member.GetLocation().GetLineSpan(), line, column);
+
+    /// <summary>
+    /// True when the member's declaration identifier (or equivalent name token)
+    /// covers <paramref name="line"/> / <paramref name="column"/>.
+    /// </summary>
+    internal static bool IdentifierCoversColumn(SyntaxNode member, int line, int column)
+    {
+        var token = GetMemberIdentifier(member);
+        return token != default &&
+               SpanCoverage.SpanCoversColumn(token.GetLocation().GetLineSpan(), line, column);
+    }
+
+    /// <summary>
+    /// Name token used for column disambiguation: method/property/event/type
+    /// identifier, indexer <c>this</c>, operator token, conversion return-type
+    /// first token, constructor/destructor/local-function identifier, or first
+    /// field/event-field variable identifier; otherwise default.
+    /// </summary>
+    internal static SyntaxToken GetMemberIdentifier(SyntaxNode member) => member switch
+    {
+        MethodDeclarationSyntax method => method.Identifier,
+        PropertyDeclarationSyntax property => property.Identifier,
+        IndexerDeclarationSyntax indexer => indexer.ThisKeyword,
+        OperatorDeclarationSyntax op => op.OperatorToken,
+        ConversionOperatorDeclarationSyntax conversion => conversion.Type.GetFirstToken(),
+        ConstructorDeclarationSyntax constructor => constructor.Identifier,
+        DestructorDeclarationSyntax destructor => destructor.Identifier,
+        LocalFunctionStatementSyntax localFunction => localFunction.Identifier,
+        EventDeclarationSyntax @event => @event.Identifier,
+        FieldDeclarationSyntax field => field.Declaration.Variables.FirstOrDefault()?.Identifier ?? default,
+        EventFieldDeclarationSyntax eventField => eventField.Declaration.Variables.FirstOrDefault()?.Identifier ?? default,
+        TypeDeclarationSyntax type => type.Identifier,
+        _ => default
+    };
+}

--- a/tests/RoslynMcp.Core.Tests/Resolution/MemberCoverageTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Resolution/MemberCoverageTests.cs
@@ -1,0 +1,58 @@
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using RoslynMcp.Core.Resolution;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Resolution;
+
+public class MemberCoverageTests
+{
+    [Fact]
+    public void MemberCoversColumn_Method_True_OnIdentifier_False_AtExclusiveEnd()
+    {
+        var tree = CSharpSyntaxTree.ParseText("""
+            class C
+            {
+                void M() { }
+            }
+            """);
+        var root = tree.GetRoot();
+        var method = root.DescendantNodes().OfType<MethodDeclarationSyntax>().Single();
+        var idSpan = method.Identifier.GetLocation().GetLineSpan();
+        var line = idSpan.StartLinePosition.Line + 1;
+        var startCol = idSpan.StartLinePosition.Character + 1;
+        var endCol = idSpan.EndLinePosition.Character + 1;
+
+        Assert.True(MemberCoverage.MemberCoversColumn(method, line, startCol));
+        Assert.True(MemberCoverage.IdentifierCoversColumn(method, line, startCol));
+        Assert.True(MemberCoverage.IdentifierCoversColumn(method, line, endCol - 1));
+        Assert.False(MemberCoverage.IdentifierCoversColumn(method, line, endCol));
+        // endCol is past the identifier exclusive end but still inside the method span.
+        Assert.True(MemberCoverage.MemberCoversColumn(method, line, endCol));
+        Assert.False(MemberCoverage.IdentifierCoversColumn(method, line, startCol - 1));
+    }
+
+    [Fact]
+    public void MemberCoversColumn_Constructor_True_OnIdentifier_False_AtExclusiveEnd()
+    {
+        var tree = CSharpSyntaxTree.ParseText("""
+            class C
+            {
+                public C() { }
+            }
+            """);
+        var root = tree.GetRoot();
+        var ctor = root.DescendantNodes().OfType<ConstructorDeclarationSyntax>().Single();
+        var idSpan = ctor.Identifier.GetLocation().GetLineSpan();
+        var line = idSpan.StartLinePosition.Line + 1;
+        var startCol = idSpan.StartLinePosition.Character + 1;
+        var endCol = idSpan.EndLinePosition.Character + 1;
+
+        Assert.True(MemberCoverage.MemberCoversColumn(ctor, line, startCol));
+        Assert.True(MemberCoverage.IdentifierCoversColumn(ctor, line, startCol));
+        Assert.True(MemberCoverage.IdentifierCoversColumn(ctor, line, endCol - 1));
+        Assert.False(MemberCoverage.IdentifierCoversColumn(ctor, line, endCol));
+        Assert.True(MemberCoverage.MemberCoversColumn(ctor, line, endCol));
+        Assert.False(MemberCoverage.IdentifierCoversColumn(ctor, line, startCol - 1));
+    }
+}


### PR DESCRIPTION
## Summary
Closes #1039.

Extract shared `MemberCoverage.MemberCoversColumn` / `IdentifierCoversColumn` / `GetMemberIdentifier` (union of the former GetIdentifier* switches) and replace the private copies in:
- `ConvertExpressionBodyOperation` (`convert_expression_body`)
- `ConvertToBlockBodyOperation` (`convert_to_block_body`)
- `AddNullChecksOperation` (`add_null_checks`)

Behavior-preserving refactor only. Leave Dependabot alone.

## Test plan
- [x] `MemberCoverageTests` (method + constructor exclusive-end)
- [x] Filtered Core.Tests for ConvertToBlockBody / ConvertExpressionBody / AddNullChecks / MemberCoverage (133 passed)
- [ ] CI Build and Test + Code Quality green