### PR TITLE
Extract SymbolResolver.GetPosition(SourceText); replace Extract + Rename copies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- Extracted shared `SymbolResolver.GetPosition(SourceText)` and replaced Extract + Rename private copies (`extract_method` / `extract_variable` / `extract_constant` / `rename_symbol`) (#1042)
 - Extracted shared `MemberCoverage.MemberCoversColumn` / `IdentifierCoversColumn` and replaced ConvertExpressionBody + ConvertToBlockBody + AddNullChecks copies (`convert_expression_body` / `convert_to_block_body` / `add_null_checks`) (#1039)
 - Retargeted `TypeSymbolResolver.FindCoveringType` onto shared `TypeCoverage`; deleted private TypeCoversColumn / IdentifierCoversColumn copies (#1037)
 - Extracted shared `PropertyCoverage.PropertyCoversColumn` / `IdentifierCoversColumn` and replaced ConvertPropertyOperation copies (`convert_property`) (#1032)

--- a/src/RoslynMcp.Core/Refactoring/Extract/ExtractConstantOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/ExtractConstantOperation.cs
@@ -8,6 +8,7 @@ using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
 using RoslynMcp.Core.Refactoring.Utilities;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 
 namespace RoslynMcp.Core.Refactoring.Extract;
@@ -81,8 +82,8 @@ public sealed class ExtractConstantOperation : RefactoringOperationBase<ExtractC
 
         // Get text span from line/column (bounds-checked like extract_method)
         var sourceText = await document.GetTextAsync(cancellationToken);
-        var startPosition = GetPosition(sourceText, @params.StartLine, @params.StartColumn);
-        var endPosition = GetPosition(sourceText, @params.EndLine, @params.EndColumn);
+        var startPosition = SymbolResolver.GetPosition(sourceText, @params.StartLine, @params.StartColumn);
+        var endPosition = SymbolResolver.GetPosition(sourceText, @params.EndLine, @params.EndColumn);
         var span = TextSpan.FromBounds(startPosition, endPosition);
 
         // Find literal at span
@@ -323,30 +324,5 @@ public sealed class ExtractConstantOperation : RefactoringOperationBase<ExtractC
         return RefactoringResult.PreviewResult(operationId, pendingChanges);
     }
 
-
-    private static int GetPosition(SourceText text, int line, int column)
-    {
-        var lineIndex = line - 1; // Convert to 0-based
-
-        if (lineIndex < 0 || lineIndex >= text.Lines.Count)
-        {
-            throw new RefactoringException(
-                ErrorCodes.InvalidLineNumber,
-                $"Line {line} is out of range. File has {text.Lines.Count} lines.");
-        }
-
-        var lineInfo = text.Lines[lineIndex];
-        var columnIndex = column - 1; // Convert to 0-based
-        var lineLength = lineInfo.End - lineInfo.Start;
-
-        if (columnIndex < 0 || columnIndex > lineLength)
-        {
-            throw new RefactoringException(
-                ErrorCodes.InvalidColumnNumber,
-                $"Column {column} is out of range for line {line} (line has {lineLength} characters).");
-        }
-
-        return lineInfo.Start + columnIndex;
-    }
 
 }

--- a/src/RoslynMcp.Core/Refactoring/Extract/ExtractMethodOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/ExtractMethodOperation.cs
@@ -7,6 +7,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 
 namespace RoslynMcp.Core.Refactoring.Extract;
@@ -88,8 +89,8 @@ public sealed class ExtractMethodOperation : RefactoringOperationBase<ExtractMet
 
         // Get the selection span
         var text = await document.GetTextAsync(cancellationToken);
-        var startPosition = GetPosition(text, @params.StartLine, @params.StartColumn);
-        var endPosition = GetPosition(text, @params.EndLine, @params.EndColumn);
+        var startPosition = SymbolResolver.GetPosition(text, @params.StartLine, @params.StartColumn);
+        var endPosition = SymbolResolver.GetPosition(text, @params.EndLine, @params.EndColumn);
         var selectionSpan = TextSpan.FromBounds(startPosition, endPosition);
 
         // Find nodes in selection
@@ -162,39 +163,6 @@ public sealed class ExtractMethodOperation : RefactoringOperationBase<ExtractMet
             },
             0,
             0);
-    }
-
-    /// <summary>
-    /// Converts 1-based line/column to absolute position with bounds validation.
-    /// </summary>
-    /// <param name="text">Source text to navigate.</param>
-    /// <param name="line">1-based line number.</param>
-    /// <param name="column">1-based column number.</param>
-    /// <returns>Absolute position in text.</returns>
-    /// <exception cref="RefactoringException">Thrown if line/column is out of bounds.</exception>
-    private static int GetPosition(SourceText text, int line, int column)
-    {
-        var lineIndex = line - 1; // Convert to 0-based
-
-        if (lineIndex < 0 || lineIndex >= text.Lines.Count)
-        {
-            throw new RefactoringException(
-                ErrorCodes.InvalidLineNumber,
-                $"Line {line} is out of range. File has {text.Lines.Count} lines.");
-        }
-
-        var lineInfo = text.Lines[lineIndex];
-        var columnIndex = column - 1; // Convert to 0-based
-        var lineLength = lineInfo.End - lineInfo.Start;
-
-        if (columnIndex < 0 || columnIndex > lineLength)
-        {
-            throw new RefactoringException(
-                ErrorCodes.InvalidColumnNumber,
-                $"Column {column} is out of range for line {line} (line has {lineLength} characters).");
-        }
-
-        return lineInfo.Start + columnIndex;
     }
 
     private static List<SyntaxNode> GetSelectedNodes(SyntaxNode root, TextSpan selection)

--- a/src/RoslynMcp.Core/Refactoring/Extract/ExtractVariableOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/ExtractVariableOperation.cs
@@ -8,6 +8,7 @@ using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
 using RoslynMcp.Core.Refactoring.Utilities;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 
 namespace RoslynMcp.Core.Refactoring.Extract;
@@ -73,8 +74,8 @@ public sealed class ExtractVariableOperation : RefactoringOperationBase<ExtractV
 
         // Get text span from line/column (bounds-checked like extract_method / extract_constant)
         var sourceText = await document.GetTextAsync(cancellationToken);
-        var startPosition = GetPosition(sourceText, @params.StartLine, @params.StartColumn);
-        var endPosition = GetPosition(sourceText, @params.EndLine, @params.EndColumn);
+        var startPosition = SymbolResolver.GetPosition(sourceText, @params.StartLine, @params.StartColumn);
+        var endPosition = SymbolResolver.GetPosition(sourceText, @params.EndLine, @params.EndColumn);
         var span = TextSpan.FromBounds(startPosition, endPosition);
 
         // Find expression at span
@@ -579,30 +580,5 @@ public sealed class ExtractVariableOperation : RefactoringOperationBase<ExtractV
         return RefactoringResult.PreviewResult(operationId, pendingChanges);
     }
 
-
-    private static int GetPosition(SourceText text, int line, int column)
-    {
-        var lineIndex = line - 1; // Convert to 0-based
-
-        if (lineIndex < 0 || lineIndex >= text.Lines.Count)
-        {
-            throw new RefactoringException(
-                ErrorCodes.InvalidLineNumber,
-                $"Line {line} is out of range. File has {text.Lines.Count} lines.");
-        }
-
-        var lineInfo = text.Lines[lineIndex];
-        var columnIndex = column - 1; // Convert to 0-based
-        var lineLength = lineInfo.End - lineInfo.Start;
-
-        if (columnIndex < 0 || columnIndex > lineLength)
-        {
-            throw new RefactoringException(
-                ErrorCodes.InvalidColumnNumber,
-                $"Column {column} is out of range for line {line} (line has {lineLength} characters).");
-        }
-
-        return lineInfo.Start + columnIndex;
-    }
 
 }

--- a/src/RoslynMcp.Core/Refactoring/Rename/RenameSymbolOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Rename/RenameSymbolOperation.cs
@@ -10,6 +10,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 
 namespace RoslynMcp.Core.Refactoring.Rename;
@@ -231,7 +232,7 @@ public sealed class RenameSymbolOperation : RefactoringOperationBase<RenameSymbo
         // If line/column provided, find symbol at position
         if (@params.Line.HasValue)
         {
-            var position = GetPosition(root, @params.Line.Value, @params.Column ?? 1);
+            var position = SymbolResolver.GetPosition(root, @params.Line.Value, @params.Column ?? 1);
             var token = root.FindToken(position);
 
             // Walk up to find the symbol declaration or reference
@@ -290,40 +291,6 @@ public sealed class RenameSymbolOperation : RefactoringOperationBase<RenameSymbo
         }
 
         return (candidates[0], document);
-    }
-
-    /// <summary>
-    /// Converts 1-based line/column to absolute position with bounds validation.
-    /// </summary>
-    /// <param name="root">Syntax root to get text from.</param>
-    /// <param name="line">1-based line number.</param>
-    /// <param name="column">1-based column number.</param>
-    /// <returns>Absolute position in text.</returns>
-    /// <exception cref="RefactoringException">Thrown if line/column is out of bounds.</exception>
-    private static int GetPosition(SyntaxNode root, int line, int column)
-    {
-        var text = root.GetText();
-        var lineIndex = line - 1; // Convert to 0-based
-
-        if (lineIndex < 0 || lineIndex >= text.Lines.Count)
-        {
-            throw new RefactoringException(
-                ErrorCodes.InvalidLineNumber,
-                $"Line {line} is out of range. File has {text.Lines.Count} lines.");
-        }
-
-        var lineInfo = text.Lines[lineIndex];
-        var columnIndex = column - 1; // Convert to 0-based
-        var lineLength = lineInfo.End - lineInfo.Start;
-
-        if (columnIndex < 0 || columnIndex > lineLength)
-        {
-            throw new RefactoringException(
-                ErrorCodes.InvalidColumnNumber,
-                $"Column {column} is out of range for line {line} (line has {lineLength} characters).");
-        }
-
-        return lineInfo.Start + columnIndex;
     }
 
     private static void ValidateRename(ISymbol symbol, RenameSymbolParams @params)

--- a/src/RoslynMcp.Core/Resolution/SymbolResolver.cs
+++ b/src/RoslynMcp.Core/Resolution/SymbolResolver.cs
@@ -2,6 +2,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Text;
 using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring;
@@ -216,9 +217,18 @@ public sealed class SymbolResolver
     /// <param name="line">1-based line number.</param>
     /// <param name="column">1-based column number.</param>
     /// <returns>Absolute position in text.</returns>
-    public static int GetPosition(SyntaxNode root, int line, int column)
+    public static int GetPosition(SyntaxNode root, int line, int column) =>
+        GetPosition(root.GetText(), line, column);
+
+    /// <summary>
+    /// Converts 1-based line/column to absolute position with bounds validation.
+    /// </summary>
+    /// <param name="text">Source text to index into.</param>
+    /// <param name="line">1-based line number.</param>
+    /// <param name="column">1-based column number.</param>
+    /// <returns>Absolute position in text.</returns>
+    public static int GetPosition(SourceText text, int line, int column)
     {
-        var text = root.GetText();
         var lineIndex = line - 1;
 
         if (lineIndex < 0 || lineIndex >= text.Lines.Count)

--- a/tests/RoslynMcp.Core.Tests/Resolution/SymbolResolverPositionTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Resolution/SymbolResolverPositionTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
 using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Core.Refactoring;
 using RoslynMcp.Core.Resolution;
@@ -72,5 +73,24 @@ public class SymbolResolverPositionTests
         // Column at end of line should work (column = length + 1 for EOL position)
         var position = SymbolResolver.GetPosition(root, line: 1, column: source.Length + 1);
         Assert.Equal(source.Length, position);
+    }
+
+    [Fact]
+    public void GetPosition_SourceText_FirstColumn_ReturnsZero()
+    {
+        var text = SourceText.From("class C { }");
+        var position = SymbolResolver.GetPosition(text, line: 1, column: 1);
+        Assert.Equal(0, position);
+    }
+
+    [Fact]
+    public void GetPosition_SourceText_LineOutOfRange_ThrowsException()
+    {
+        var text = SourceText.From("class C { }");
+
+        var ex = Assert.Throws<RefactoringException>(() =>
+            SymbolResolver.GetPosition(text, line: 100, column: 1));
+
+        Assert.Equal(ErrorCodes.InvalidLineNumber, ex.ErrorCode);
     }
 }


### PR DESCRIPTION
## Summary
- Add `SymbolResolver.GetPosition(SourceText, …)`; root overload delegates via `root.GetText()`.
- Replace private GetPosition copies in `extract_method` / `extract_variable` / `extract_constant` / `rename_symbol`.
- Extend `SymbolResolverPositionTests` with SourceText overload coverage.
- CHANGELOG Unreleased/Changed one-liner.

Closes #1042.

## Test plan
- [x] `dotnet test` filter `SymbolResolverPosition` (8 passed)
- [x] Params validation + RenameSymbolOperation focused filter (42 passed)
- [ ] CI Build and Test + Code Quality green
- [ ] Copilot/Codex threads resolved (GitHub PM merges — do not auto-merge)