### PR TITLE
Extract LocalCoverage; replace IntroduceParameter copies; share Identifier with InlineVariable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- Extracted shared `LocalCoverage` (FieldCoverage twin) and replaced IntroduceParameter copies; shared `IdentifierCoversColumn` with InlineVariable (`introduce_parameter` / `inline_variable`) (#1045)
 - Extracted shared `SymbolResolver.GetPosition(SourceText)` and replaced Extract + Rename private copies (`extract_method` / `extract_variable` / `extract_constant` / `rename_symbol`) (#1042)
 - Extracted shared `MemberCoverage.MemberCoversColumn` / `IdentifierCoversColumn` and replaced ConvertExpressionBody + ConvertToBlockBody + AddNullChecks copies (`convert_expression_body` / `convert_to_block_body` / `add_null_checks`) (#1039)
 - Retargeted `TypeSymbolResolver.FindCoveringType` onto shared `TypeCoverage`; deleted private TypeCoversColumn / IdentifierCoversColumn copies (#1037)

--- a/src/RoslynMcp.Core/Refactoring/Extract/IntroduceParameterOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/IntroduceParameterOperation.cs
@@ -254,9 +254,9 @@ public sealed class IntroduceParameterOperation : RefactoringOperationBase<Intro
         var covering = root.DescendantNodes()
             .OfType<VariableDeclaratorSyntax>()
             .Where(declarator => declarator.Parent?.Parent is LocalDeclarationStatementSyntax)
-            .Where(declarator => DeclaratorCoversColumn(declarator, line, column.Value))
-            .OrderBy(declarator => IdentifierCoversColumn(declarator, line, column.Value) ? 0 : 1)
-            .ThenBy(declarator => SmallestCoveringSpanLength(declarator, line, column.Value))
+            .Where(declarator => LocalCoverage.LocalCoversColumn(declarator, line, column.Value))
+            .OrderBy(declarator => LocalCoverage.IdentifierCoversColumn(declarator, line, column.Value) ? 0 : 1)
+            .ThenBy(declarator => LocalCoverage.SmallestCoveringSpanLength(declarator, line, column.Value))
             .FirstOrDefault();
 
         if (covering == null || covering.Identifier.Text != variableName)
@@ -264,32 +264,5 @@ public sealed class IntroduceParameterOperation : RefactoringOperationBase<Intro
 
         return covering;
     }
-
-    private static bool DeclaratorCoversColumn(VariableDeclaratorSyntax declarator, int line, int column) =>
-        IdentifierCoversColumn(declarator, line, column) ||
-        SpanCoverage.SpanCoversColumn(declarator.GetLocation().GetLineSpan(), line, column) ||
-        (GetLocalDeclaration(declarator) is { } local &&
-         SpanCoverage.SpanCoversColumn(local.GetLocation().GetLineSpan(), line, column));
-
-    private static bool IdentifierCoversColumn(VariableDeclaratorSyntax declarator, int line, int column) =>
-        SpanCoverage.SpanCoversColumn(declarator.Identifier.GetLocation().GetLineSpan(), line, column);
-
-    private static int SmallestCoveringSpanLength(VariableDeclaratorSyntax declarator, int line, int column)
-    {
-        var smallest = int.MaxValue;
-        if (SpanCoverage.SpanCoversColumn(declarator.GetLocation().GetLineSpan(), line, column))
-            smallest = Math.Min(smallest, declarator.Span.Length);
-
-        if (GetLocalDeclaration(declarator) is { } local &&
-            SpanCoverage.SpanCoversColumn(local.GetLocation().GetLineSpan(), line, column))
-        {
-            smallest = Math.Min(smallest, local.Span.Length);
-        }
-
-        return smallest;
-    }
-
-    private static LocalDeclarationStatementSyntax? GetLocalDeclaration(VariableDeclaratorSyntax declarator) =>
-        declarator.Parent?.Parent as LocalDeclarationStatementSyntax;
 
 }

--- a/src/RoslynMcp.Core/Refactoring/Inline/InlineVariableOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Inline/InlineVariableOperation.cs
@@ -301,7 +301,7 @@ public sealed class InlineVariableOperation : RefactoringOperationBase<InlineVar
             // column.
             return declarators
                 .Where(d => DeclaratorCoversColumn(d, line ?? StartLine(d), column.Value))
-                .OrderBy(d => IdentifierCoversColumn(d, line ?? StartLine(d), column.Value) ? 0 : 1)
+                .OrderBy(d => LocalCoverage.IdentifierCoversColumn(d, line ?? StartLine(d), column.Value) ? 0 : 1)
                 .ThenBy(d => d.Span.Length)
                 .FirstOrDefault();
         }
@@ -323,11 +323,8 @@ public sealed class InlineVariableOperation : RefactoringOperationBase<InlineVar
         declarator.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
 
     private static bool DeclaratorCoversColumn(VariableDeclaratorSyntax declarator, int line, int column) =>
-        IdentifierCoversColumn(declarator, line, column) ||
+        LocalCoverage.IdentifierCoversColumn(declarator, line, column) ||
         SpanCoverage.SpanCoversColumn(DeclarationSpan(declarator), line, column);
-
-    private static bool IdentifierCoversColumn(VariableDeclaratorSyntax declarator, int line, int column) =>
-        SpanCoverage.SpanCoversColumn(declarator.Identifier.GetLocation().GetLineSpan(), line, column);
 
     private static FileLinePositionSpan DeclarationSpan(VariableDeclaratorSyntax declarator) =>
         declarator.Parent is VariableDeclarationSyntax declaration

--- a/src/RoslynMcp.Core/Resolution/LocalCoverage.cs
+++ b/src/RoslynMcp.Core/Resolution/LocalCoverage.cs
@@ -1,0 +1,92 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace RoslynMcp.Core.Resolution;
+
+/// <summary>
+/// Shared local-declarator coverage helpers used when disambiguating
+/// same-named locals by optional 1-based line / column (identifier preferred,
+/// then declarator / containing local declaration span via <see cref="SpanCoverage"/>).
+/// </summary>
+internal static class LocalCoverage
+{
+    /// <summary>
+    /// True when the declarator's identifier, declarator span, or containing
+    /// local declaration covers <paramref name="line"/> (exclusive-end line
+    /// rules via <see cref="SpanCoverage.SpanCoversLine(FileLinePositionSpan, int)"/>).
+    /// </summary>
+    internal static bool LocalCoversLine(VariableDeclaratorSyntax declarator, int line) =>
+        IdentifierCoversLine(declarator, line) ||
+        SpanCoverage.SpanCoversLine(declarator.GetLocation().GetLineSpan(), line) ||
+        (GetLocalDeclaration(declarator) is { } local &&
+         SpanCoverage.SpanCoversLine(local.GetLocation().GetLineSpan(), line));
+
+    /// <summary>
+    /// True when the declarator's identifier covers <paramref name="line"/>.
+    /// </summary>
+    internal static bool IdentifierCoversLine(VariableDeclaratorSyntax declarator, int line) =>
+        SpanCoverage.SpanCoversLine(declarator.Identifier.GetLocation().GetLineSpan(), line);
+
+    /// <summary>
+    /// True when the declarator's identifier, declarator span, or containing
+    /// local declaration covers <paramref name="line"/> / <paramref name="column"/>
+    /// (exclusive-end column rules via <see cref="SpanCoverage.SpanCoversColumn"/>).
+    /// </summary>
+    internal static bool LocalCoversColumn(VariableDeclaratorSyntax declarator, int line, int column) =>
+        IdentifierCoversColumn(declarator, line, column) ||
+        SpanCoverage.SpanCoversColumn(declarator.GetLocation().GetLineSpan(), line, column) ||
+        (GetLocalDeclaration(declarator) is { } local &&
+         SpanCoverage.SpanCoversColumn(local.GetLocation().GetLineSpan(), line, column));
+
+    /// <summary>
+    /// True when the declarator's identifier covers
+    /// <paramref name="line"/> / <paramref name="column"/>.
+    /// </summary>
+    internal static bool IdentifierCoversColumn(VariableDeclaratorSyntax declarator, int line, int column) =>
+        SpanCoverage.SpanCoversColumn(declarator.Identifier.GetLocation().GetLineSpan(), line, column);
+
+    /// <summary>
+    /// Smallest spanning length among the declarator and containing local declaration that
+    /// cover <paramref name="line"/>; <see cref="int.MaxValue"/> if none cover.
+    /// </summary>
+    internal static int SmallestCoveringSpanLength(VariableDeclaratorSyntax declarator, int line)
+    {
+        var smallest = int.MaxValue;
+        if (SpanCoverage.SpanCoversLine(declarator.GetLocation().GetLineSpan(), line))
+            smallest = Math.Min(smallest, declarator.Span.Length);
+
+        if (GetLocalDeclaration(declarator) is { } local &&
+            SpanCoverage.SpanCoversLine(local.GetLocation().GetLineSpan(), line))
+        {
+            smallest = Math.Min(smallest, local.Span.Length);
+        }
+
+        return smallest;
+    }
+
+    /// <summary>
+    /// Smallest spanning length among the declarator and containing local declaration that
+    /// cover <paramref name="line"/> / <paramref name="column"/>;
+    /// <see cref="int.MaxValue"/> if none cover.
+    /// </summary>
+    internal static int SmallestCoveringSpanLength(VariableDeclaratorSyntax declarator, int line, int column)
+    {
+        var smallest = int.MaxValue;
+        if (SpanCoverage.SpanCoversColumn(declarator.GetLocation().GetLineSpan(), line, column))
+            smallest = Math.Min(smallest, declarator.Span.Length);
+
+        if (GetLocalDeclaration(declarator) is { } local &&
+            SpanCoverage.SpanCoversColumn(local.GetLocation().GetLineSpan(), line, column))
+        {
+            smallest = Math.Min(smallest, local.Span.Length);
+        }
+
+        return smallest;
+    }
+
+    /// <summary>
+    /// Containing <see cref="LocalDeclarationStatementSyntax"/> for a local declarator, if any.
+    /// </summary>
+    internal static LocalDeclarationStatementSyntax? GetLocalDeclaration(VariableDeclaratorSyntax declarator) =>
+        declarator.Parent?.Parent as LocalDeclarationStatementSyntax;
+}

--- a/tests/RoslynMcp.Core.Tests/Resolution/LocalCoverageTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Resolution/LocalCoverageTests.cs
@@ -1,0 +1,133 @@
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using RoslynMcp.Core.Resolution;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Resolution;
+
+public class LocalCoverageTests
+{
+    [Fact]
+    public void GetLocalDeclaration_ReturnsLocal_NullForField()
+    {
+        var tree = CSharpSyntaxTree.ParseText("""
+            class C
+            {
+                int _x = 1;
+                void M() { int y = 2; }
+            }
+            """);
+        var root = tree.GetRoot();
+        var fieldDecl = root.DescendantNodes().OfType<VariableDeclaratorSyntax>()
+            .Single(d => d.Identifier.ValueText == "_x");
+        var localDecl = root.DescendantNodes().OfType<VariableDeclaratorSyntax>()
+            .Single(d => d.Identifier.ValueText == "y");
+
+        Assert.NotNull(LocalCoverage.GetLocalDeclaration(localDecl));
+        Assert.IsType<LocalDeclarationStatementSyntax>(LocalCoverage.GetLocalDeclaration(localDecl));
+        Assert.Null(LocalCoverage.GetLocalDeclaration(fieldDecl));
+    }
+
+    [Fact]
+    public void IdentifierCoversLine_True_OnIdentifierLine_False_OnOtherLocalLine()
+    {
+        var tree = CSharpSyntaxTree.ParseText("""
+            class C
+            {
+                void M()
+                {
+                    int a = 1;
+
+                    int b = 2;
+                }
+            }
+            """);
+        var root = tree.GetRoot();
+        var a = root.DescendantNodes().OfType<VariableDeclaratorSyntax>()
+            .Single(d => d.Identifier.ValueText == "a");
+        var b = root.DescendantNodes().OfType<VariableDeclaratorSyntax>()
+            .Single(d => d.Identifier.ValueText == "b");
+        var aLine = a.Identifier.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+        var bLine = b.Identifier.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+
+        Assert.True(LocalCoverage.IdentifierCoversLine(a, aLine));
+        Assert.True(LocalCoverage.LocalCoversLine(a, aLine));
+        Assert.False(LocalCoverage.IdentifierCoversLine(a, bLine));
+        Assert.False(LocalCoverage.LocalCoversLine(a, bLine));
+        Assert.False(LocalCoverage.LocalCoversLine(a, 0));
+    }
+
+    [Fact]
+    public void LocalCoversColumn_True_OnIdentifier_False_AtExclusiveEnd()
+    {
+        var tree = CSharpSyntaxTree.ParseText("""
+            class C
+            {
+                void M() { int x = 1; }
+            }
+            """);
+        var root = tree.GetRoot();
+        var decl = root.DescendantNodes().OfType<VariableDeclaratorSyntax>().Single();
+        var idSpan = decl.Identifier.GetLocation().GetLineSpan();
+        var line = idSpan.StartLinePosition.Line + 1;
+        var startCol = idSpan.StartLinePosition.Character + 1;
+        var endCol = idSpan.EndLinePosition.Character + 1;
+
+        Assert.True(LocalCoverage.LocalCoversColumn(decl, line, startCol));
+        Assert.True(LocalCoverage.IdentifierCoversColumn(decl, line, startCol));
+        Assert.True(LocalCoverage.IdentifierCoversColumn(decl, line, endCol - 1));
+        Assert.False(LocalCoverage.IdentifierCoversColumn(decl, line, endCol));
+        // endCol is past the identifier exclusive end but still inside the local span.
+        Assert.True(LocalCoverage.LocalCoversColumn(decl, line, endCol));
+        Assert.False(LocalCoverage.IdentifierCoversColumn(decl, line, startCol - 1));
+    }
+
+    [Fact]
+    public void LocalCoversLine_True_OnLocalSpanFallback_WhenPastIdentifier()
+    {
+        // Multi-line local: type on first line; identifier on continuation.
+        var tree = CSharpSyntaxTree.ParseText("""
+            class C
+            {
+                void M()
+                {
+                    int
+                        LongName = 1;
+                }
+            }
+            """);
+        var root = tree.GetRoot();
+        var decl = root.DescendantNodes().OfType<VariableDeclaratorSyntax>().Single();
+        var local = LocalCoverage.GetLocalDeclaration(decl)!;
+        var localStartLine = local.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+        var idLine = decl.Identifier.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+
+        Assert.NotEqual(localStartLine, idLine);
+        Assert.False(LocalCoverage.IdentifierCoversLine(decl, localStartLine));
+        Assert.True(LocalCoverage.LocalCoversLine(decl, localStartLine));
+        Assert.True(LocalCoverage.LocalCoversLine(decl, idLine));
+    }
+
+    [Fact]
+    public void SmallestCoveringSpanLength_PrefersDeclaratorOverLocal()
+    {
+        var tree = CSharpSyntaxTree.ParseText("""
+            class C
+            {
+                void M() { int x = 1, y = 2; }
+            }
+            """);
+        var root = tree.GetRoot();
+        var x = root.DescendantNodes().OfType<VariableDeclaratorSyntax>()
+            .Single(d => d.Identifier.ValueText == "x");
+        var line = x.Identifier.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+        var local = LocalCoverage.GetLocalDeclaration(x)!;
+
+        var smallest = LocalCoverage.SmallestCoveringSpanLength(x, line);
+        Assert.True(smallest < local.Span.Length);
+        Assert.Equal(x.Span.Length, smallest);
+
+        var col = x.Identifier.GetLocation().GetLineSpan().StartLinePosition.Character + 1;
+        Assert.Equal(x.Span.Length, LocalCoverage.SmallestCoveringSpanLength(x, line, col));
+    }
+}


### PR DESCRIPTION
## Summary
- Extract shared `LocalCoverage` (FieldCoverage twin for `LocalDeclarationStatementSyntax`).
- Replace IntroduceParameter private coverage helpers; keep `FindLocalDeclarator` selection logic.
- Share `IdentifierCoversColumn` with InlineVariable; leave VariableDeclaration-shaped `DeclaratorCoversColumn` private.
- Add `LocalCoverageTests`; CHANGELOG Unreleased note.

Closes #1045

## Test plan
- [x] `dotnet test` filter LocalCoverage|IntroduceParameter|InlineVariable (61 passed)
- [ ] CI Build and Test + Code Quality green