### PR TITLE
refactor: extract TypePartRematch SameSyntaxTree + RematchTypeDeclaration (#1048)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- Extracted shared `TypePartRematch` (SameSyntaxTree + RematchTypeDeclaration) and replaced 7 Generate + Pull/Push/ExtractBaseClass copies (#1048)
 - Extracted shared `LocalCoverage` (FieldCoverage twin) and replaced IntroduceParameter copies; shared `IdentifierCoversColumn` with InlineVariable (`introduce_parameter` / `inline_variable`) (#1045)
 - Extracted shared `SymbolResolver.GetPosition(SourceText)` and replaced Extract + Rename private copies (`extract_method` / `extract_variable` / `extract_constant` / `rename_symbol`) (#1042)
 - Extracted shared `MemberCoverage.MemberCoversColumn` / `IdentifierCoversColumn` and replaced ConvertExpressionBody + ConvertToBlockBody + AddNullChecks copies (`convert_expression_body` / `convert_to_block_body` / `add_null_checks`) (#1039)

--- a/src/RoslynMcp.Core/Refactoring/Extract/ExtractBaseClassOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/ExtractBaseClassOperation.cs
@@ -1225,7 +1225,5 @@ public sealed class ExtractBaseClassOperation : RefactoringOperationBase<Extract
     private static ClassDeclarationSyntax? RematchTypeDeclaration(
         SyntaxNode root,
         ClassDeclarationSyntax original) =>
-        root.DescendantNodes()
-            .OfType<ClassDeclarationSyntax>()
-            .FirstOrDefault(t => t.SpanStart == original.SpanStart && t.Identifier.Text == original.Identifier.Text);
+        TypePartRematch.RematchTypeDeclaration(root, original) as ClassDeclarationSyntax;
 }

--- a/src/RoslynMcp.Core/Refactoring/Generate/GenerateConstructorOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GenerateConstructorOperation.cs
@@ -7,6 +7,7 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Refactoring.Utilities;
 using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
 
@@ -1164,7 +1165,7 @@ public sealed class GenerateConstructorOperation : RefactoringOperationBase<Gene
             var replacements = new Dictionary<TypeDeclarationSyntax, TypeDeclarationSyntax>();
             foreach (var reference in typeSymbol.DeclaringSyntaxReferences)
             {
-                if (!SameSyntaxTree(reference.SyntaxTree, tree))
+                if (!TypePartRematch.SameSyntaxTree(reference.SyntaxTree, tree))
                     continue;
                 if (await reference.GetSyntaxAsync(cancellationToken) is not TypeDeclarationSyntax originalPart)
                     continue;
@@ -1172,7 +1173,7 @@ public sealed class GenerateConstructorOperation : RefactoringOperationBase<Gene
                 // annotation (new tree). Rematch by span — annotation does
                 // not change SpanStart — so ReplaceNodes sees nodes from
                 // this root and keeps the annotation on the selected type.
-                var part = RematchTypeDeclaration(root, originalPart);
+                var part = TypePartRematch.RematchTypeDeclaration(root, originalPart);
                 if (part == null)
                     continue;
                 if (!byPart.TryGetValue(part.SpanStart, out var keys) || keys.Count == 0)
@@ -1215,15 +1216,6 @@ public sealed class GenerateConstructorOperation : RefactoringOperationBase<Gene
             $"Could not locate a declaring document for type '{typeName}'.");
     }
 
-    private static bool SameSyntaxTree(SyntaxTree left, SyntaxTree right) =>
-        left == right
-        || (!string.IsNullOrEmpty(left.FilePath)
-            && string.Equals(left.FilePath, right.FilePath, StringComparison.OrdinalIgnoreCase));
-
-    private static TypeDeclarationSyntax? RematchTypeDeclaration(SyntaxNode root, TypeDeclarationSyntax original) =>
-        root.DescendantNodes()
-            .OfType<TypeDeclarationSyntax>()
-            .FirstOrDefault(t => t.SpanStart == original.SpanStart && t.Identifier.Text == original.Identifier.Text);
 
     /// <summary>
     /// Finds a type by <paramref name="typeName"/>. Omitted

--- a/src/RoslynMcp.Core/Refactoring/Generate/GenerateEqualsHashCodeOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GenerateEqualsHashCodeOperation.cs
@@ -805,7 +805,7 @@ public sealed class GenerateEqualsHashCodeOperation : RefactoringOperationBase<G
             var replacements = new Dictionary<TypeDeclarationSyntax, TypeDeclarationSyntax>();
             foreach (var reference in typeSymbol.DeclaringSyntaxReferences)
             {
-                if (!SameSyntaxTree(reference.SyntaxTree, tree))
+                if (!TypePartRematch.SameSyntaxTree(reference.SyntaxTree, tree))
                     continue;
                 if (await reference.GetSyntaxAsync(cancellationToken) is not TypeDeclarationSyntax originalPart)
                     continue;
@@ -813,7 +813,7 @@ public sealed class GenerateEqualsHashCodeOperation : RefactoringOperationBase<G
                 // annotation (new tree). Rematch by span — annotation does
                 // not change SpanStart — so ReplaceNodes sees nodes from
                 // this root and keeps the annotation on the selected type.
-                var part = RematchTypeDeclaration(root, originalPart);
+                var part = TypePartRematch.RematchTypeDeclaration(root, originalPart);
                 if (part == null)
                     continue;
 
@@ -914,15 +914,6 @@ public sealed class GenerateEqualsHashCodeOperation : RefactoringOperationBase<G
             $"Could not locate a declaring document for type '{typeName}'.");
     }
 
-    private static bool SameSyntaxTree(SyntaxTree left, SyntaxTree right) =>
-        left == right
-        || (!string.IsNullOrEmpty(left.FilePath)
-            && string.Equals(left.FilePath, right.FilePath, StringComparison.OrdinalIgnoreCase));
-
-    private static TypeDeclarationSyntax? RematchTypeDeclaration(SyntaxNode root, TypeDeclarationSyntax original) =>
-        root.DescendantNodes()
-            .OfType<TypeDeclarationSyntax>()
-            .FirstOrDefault(t => t.SpanStart == original.SpanStart && t.Identifier.Text == original.Identifier.Text);
 
     /// <summary>
     /// Finds a type by <paramref name="typeName"/>. Omitted

--- a/src/RoslynMcp.Core/Refactoring/Generate/GenerateOverridesOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GenerateOverridesOperation.cs
@@ -1075,7 +1075,7 @@ public sealed class GenerateOverridesOperation : RefactoringOperationBase<Genera
             var replacements = new Dictionary<TypeDeclarationSyntax, TypeDeclarationSyntax>();
             foreach (var reference in typeSymbol.DeclaringSyntaxReferences)
             {
-                if (!SameSyntaxTree(reference.SyntaxTree, tree))
+                if (!TypePartRematch.SameSyntaxTree(reference.SyntaxTree, tree))
                     continue;
                 if (await reference.GetSyntaxAsync(cancellationToken) is not TypeDeclarationSyntax originalPart)
                     continue;
@@ -1083,7 +1083,7 @@ public sealed class GenerateOverridesOperation : RefactoringOperationBase<Genera
                 // annotation (new tree). Rematch by span — annotation does
                 // not change SpanStart — so ReplaceNodes sees nodes from
                 // this root and keeps the annotation on the selected type.
-                var part = RematchTypeDeclaration(root, originalPart);
+                var part = TypePartRematch.RematchTypeDeclaration(root, originalPart);
                 if (part == null)
                     continue;
 
@@ -1158,15 +1158,6 @@ public sealed class GenerateOverridesOperation : RefactoringOperationBase<Genera
             $"Could not locate a declaring document for type '{typeName}'.");
     }
 
-    private static bool SameSyntaxTree(SyntaxTree left, SyntaxTree right) =>
-        left == right
-        || (!string.IsNullOrEmpty(left.FilePath)
-            && string.Equals(left.FilePath, right.FilePath, StringComparison.OrdinalIgnoreCase));
-
-    private static TypeDeclarationSyntax? RematchTypeDeclaration(SyntaxNode root, TypeDeclarationSyntax original) =>
-        root.DescendantNodes()
-            .OfType<TypeDeclarationSyntax>()
-            .FirstOrDefault(t => t.SpanStart == original.SpanStart && t.Identifier.Text == original.Identifier.Text);
 
     private static void AddKeyed<T>(
         Dictionary<SyntaxTree, Dictionary<int, HashSet<T>>> map,

--- a/src/RoslynMcp.Core/Refactoring/Generate/GeneratePropertyOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GeneratePropertyOperation.cs
@@ -647,7 +647,7 @@ public sealed class GeneratePropertyOperation : RefactoringOperationBase<Generat
             var toRemove = new List<MemberDeclarationSyntax>();
             foreach (var reference in typeSymbol.DeclaringSyntaxReferences)
             {
-                if (!SameSyntaxTree(reference.SyntaxTree, tree))
+                if (!TypePartRematch.SameSyntaxTree(reference.SyntaxTree, tree))
                     continue;
                 if (await reference.GetSyntaxAsync(cancellationToken) is not TypeDeclarationSyntax originalPart)
                     continue;
@@ -655,7 +655,7 @@ public sealed class GeneratePropertyOperation : RefactoringOperationBase<Generat
                 // annotation (new tree). Rematch by span — annotation does
                 // not change SpanStart — so RemoveNodes sees nodes from
                 // this root and keeps the annotation on the selected type.
-                var part = RematchTypeDeclaration(treeRoot, originalPart);
+                var part = TypePartRematch.RematchTypeDeclaration(treeRoot, originalPart);
                 if (part == null)
                     continue;
                 if (!byPart.TryGetValue(part.SpanStart, out var keys) || keys.Count == 0)
@@ -704,15 +704,6 @@ public sealed class GeneratePropertyOperation : RefactoringOperationBase<Generat
             $"Could not locate a declaring document for type '{typeName}'.");
     }
 
-    private static bool SameSyntaxTree(SyntaxTree left, SyntaxTree right) =>
-        left == right
-        || (!string.IsNullOrEmpty(left.FilePath)
-            && string.Equals(left.FilePath, right.FilePath, StringComparison.OrdinalIgnoreCase));
-
-    private static TypeDeclarationSyntax? RematchTypeDeclaration(SyntaxNode root, TypeDeclarationSyntax original) =>
-        root.DescendantNodes()
-            .OfType<TypeDeclarationSyntax>()
-            .FirstOrDefault(t => t.SpanStart == original.SpanStart && t.Identifier.Text == original.Identifier.Text);
 
     /// <summary>
     /// Finds a type by <paramref name="typeName"/>. Omitted

--- a/src/RoslynMcp.Core/Refactoring/Generate/GenerateToStringOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GenerateToStringOperation.cs
@@ -712,7 +712,7 @@ public sealed class GenerateToStringOperation : RefactoringOperationBase<Generat
             var replacements = new Dictionary<TypeDeclarationSyntax, TypeDeclarationSyntax>();
             foreach (var reference in typeSymbol.DeclaringSyntaxReferences)
             {
-                if (!SameSyntaxTree(reference.SyntaxTree, tree))
+                if (!TypePartRematch.SameSyntaxTree(reference.SyntaxTree, tree))
                     continue;
                 if (await reference.GetSyntaxAsync(cancellationToken) is not TypeDeclarationSyntax originalPart)
                     continue;
@@ -720,7 +720,7 @@ public sealed class GenerateToStringOperation : RefactoringOperationBase<Generat
                 // annotation (new tree). Rematch by span — annotation does
                 // not change SpanStart — so ReplaceNodes sees nodes from
                 // this root and keeps the annotation on the selected type.
-                var part = RematchTypeDeclaration(root, originalPart);
+                var part = TypePartRematch.RematchTypeDeclaration(root, originalPart);
                 if (part == null)
                     continue;
                 if (!byPart.TryGetValue(part.SpanStart, out var keys) || keys.Count == 0)
@@ -774,15 +774,6 @@ public sealed class GenerateToStringOperation : RefactoringOperationBase<Generat
             $"Could not locate a declaring document for type '{typeName}'.");
     }
 
-    private static bool SameSyntaxTree(SyntaxTree left, SyntaxTree right) =>
-        left == right
-        || (!string.IsNullOrEmpty(left.FilePath)
-            && string.Equals(left.FilePath, right.FilePath, StringComparison.OrdinalIgnoreCase));
-
-    private static TypeDeclarationSyntax? RematchTypeDeclaration(SyntaxNode root, TypeDeclarationSyntax original) =>
-        root.DescendantNodes()
-            .OfType<TypeDeclarationSyntax>()
-            .FirstOrDefault(t => t.SpanStart == original.SpanStart && t.Identifier.Text == original.Identifier.Text);
 
     /// <summary>
     /// Finds a type by <paramref name="typeName"/>. Omitted

--- a/src/RoslynMcp.Core/Refactoring/Generate/ImplementAbstractOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/ImplementAbstractOperation.cs
@@ -1455,7 +1455,7 @@ public sealed class ImplementAbstractOperation : RefactoringOperationBase<Implem
             var eventFieldRewrites = new Dictionary<EventFieldDeclarationSyntax, EventFieldDeclarationSyntax>();
             foreach (var reference in typeSymbol.DeclaringSyntaxReferences)
             {
-                if (!SameSyntaxTree(reference.SyntaxTree, tree))
+                if (!TypePartRematch.SameSyntaxTree(reference.SyntaxTree, tree))
                     continue;
                 if (await reference.GetSyntaxAsync(cancellationToken) is not TypeDeclarationSyntax originalPart)
                     continue;
@@ -1463,7 +1463,7 @@ public sealed class ImplementAbstractOperation : RefactoringOperationBase<Implem
                 // annotation (new tree). Rematch by span — annotation does
                 // not change SpanStart — so RemoveNodes sees nodes from
                 // this root and keeps the annotation on the selected type.
-                var part = RematchTypeDeclaration(treeRoot, originalPart);
+                var part = TypePartRematch.RematchTypeDeclaration(treeRoot, originalPart);
                 if (part == null)
                     continue;
 
@@ -1557,15 +1557,6 @@ public sealed class ImplementAbstractOperation : RefactoringOperationBase<Implem
             $"Could not locate a declaring document for type '{typeName}'.");
     }
 
-    private static bool SameSyntaxTree(SyntaxTree left, SyntaxTree right) =>
-        left == right
-        || (!string.IsNullOrEmpty(left.FilePath)
-            && string.Equals(left.FilePath, right.FilePath, StringComparison.OrdinalIgnoreCase));
-
-    private static TypeDeclarationSyntax? RematchTypeDeclaration(SyntaxNode root, TypeDeclarationSyntax original) =>
-        root.DescendantNodes()
-            .OfType<TypeDeclarationSyntax>()
-            .FirstOrDefault(t => t.SpanStart == original.SpanStart && t.Identifier.Text == original.Identifier.Text);
 
     private static void AddKeyed<T>(
         Dictionary<SyntaxTree, Dictionary<int, HashSet<T>>> map,

--- a/src/RoslynMcp.Core/Refactoring/Generate/ImplementInterfaceOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/ImplementInterfaceOperation.cs
@@ -1201,7 +1201,7 @@ public sealed class ImplementInterfaceOperation : RefactoringOperationBase<Imple
             var eventFieldRewrites = new Dictionary<EventFieldDeclarationSyntax, EventFieldDeclarationSyntax>();
             foreach (var reference in typeSymbol.DeclaringSyntaxReferences)
             {
-                if (!SameSyntaxTree(reference.SyntaxTree, tree))
+                if (!TypePartRematch.SameSyntaxTree(reference.SyntaxTree, tree))
                     continue;
                 if (await reference.GetSyntaxAsync(cancellationToken) is not TypeDeclarationSyntax originalPart)
                     continue;
@@ -1209,7 +1209,7 @@ public sealed class ImplementInterfaceOperation : RefactoringOperationBase<Imple
                 // annotation (new tree). Rematch by span — annotation does
                 // not change SpanStart — so RemoveNodes sees nodes from
                 // this root and keeps the annotation on the selected type.
-                var part = RematchTypeDeclaration(treeRoot, originalPart);
+                var part = TypePartRematch.RematchTypeDeclaration(treeRoot, originalPart);
                 if (part == null)
                     continue;
 
@@ -1303,15 +1303,6 @@ public sealed class ImplementInterfaceOperation : RefactoringOperationBase<Imple
             $"Could not locate a declaring document for type '{typeName}'.");
     }
 
-    private static bool SameSyntaxTree(SyntaxTree left, SyntaxTree right) =>
-        left == right
-        || (!string.IsNullOrEmpty(left.FilePath)
-            && string.Equals(left.FilePath, right.FilePath, StringComparison.OrdinalIgnoreCase));
-
-    private static TypeDeclarationSyntax? RematchTypeDeclaration(SyntaxNode root, TypeDeclarationSyntax original) =>
-        root.DescendantNodes()
-            .OfType<TypeDeclarationSyntax>()
-            .FirstOrDefault(t => t.SpanStart == original.SpanStart && t.Identifier.Text == original.Identifier.Text);
 
     private static void AddKeyed<T>(
         Dictionary<SyntaxTree, Dictionary<int, HashSet<T>>> map,

--- a/src/RoslynMcp.Core/Refactoring/Hierarchy/PullMembersUpOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Hierarchy/PullMembersUpOperation.cs
@@ -323,7 +323,7 @@ public sealed class PullMembersUpOperation : RefactoringOperationBase<PullMember
         if (annotated != null)
             return annotated;
 
-        return RematchTypeDeclaration(root, original)
+        return TypePartRematch.RematchTypeDeclaration(root, original)
             ?? throw new RefactoringException(
                 ErrorCodes.TypeNotFound,
                 $"Type '{typeName}' not found in file.");
@@ -350,12 +350,6 @@ public sealed class PullMembersUpOperation : RefactoringOperationBase<PullMember
             $"Could not locate a declaring document for type '{typeName}'.");
     }
 
-    private static TypeDeclarationSyntax? RematchTypeDeclaration(
-        SyntaxNode root,
-        TypeDeclarationSyntax original) =>
-        root.DescendantNodes()
-            .OfType<TypeDeclarationSyntax>()
-            .FirstOrDefault(t => t.SpanStart == original.SpanStart && t.Identifier.Text == original.Identifier.Text);
 
     internal static INamedTypeSymbol GetTargetBaseType(INamedTypeSymbol derived, string? targetTypeName)
     {

--- a/src/RoslynMcp.Core/Refactoring/Hierarchy/PushMembersDownOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Hierarchy/PushMembersDownOperation.cs
@@ -345,7 +345,7 @@ public sealed class PushMembersDownOperation : RefactoringOperationBase<PushMemb
         if (annotated != null)
             return annotated;
 
-        return RematchTypeDeclaration(root, original)
+        return TypePartRematch.RematchTypeDeclaration(root, original)
             ?? throw new RefactoringException(
                 ErrorCodes.TypeNotFound,
                 $"Type '{typeName}' not found in file.");
@@ -387,12 +387,6 @@ public sealed class PushMembersDownOperation : RefactoringOperationBase<PushMemb
         return null;
     }
 
-    private static TypeDeclarationSyntax? RematchTypeDeclaration(
-        SyntaxNode root,
-        TypeDeclarationSyntax original) =>
-        root.DescendantNodes()
-            .OfType<TypeDeclarationSyntax>()
-            .FirstOrDefault(t => t.SpanStart == original.SpanStart && t.Identifier.Text == original.Identifier.Text);
 
     /// <summary>
     /// Folds descendant derived-type replacements that
@@ -430,7 +424,7 @@ public sealed class PushMembersDownOperation : RefactoringOperationBase<PushMemb
             if (inReplacement == null || transplants.ContainsKey(inReplacement))
                 continue;
 
-            var updated = RematchTypeDeclaration(rewrittenAncestor, nestedOriginal)
+            var updated = TypePartRematch.RematchTypeDeclaration(rewrittenAncestor, nestedOriginal)
                 ?? FindMatchingNestedType(rewrittenAncestor, nestedOriginal)
                 ?? map[nestedOriginal] as TypeDeclarationSyntax;
             if (updated != null)
@@ -449,7 +443,7 @@ public sealed class PushMembersDownOperation : RefactoringOperationBase<PushMemb
         TypeDeclarationSyntax container,
         TypeDeclarationSyntax original)
     {
-        var bySpan = RematchTypeDeclaration(container, original);
+        var bySpan = TypePartRematch.RematchTypeDeclaration(container, original);
         if (bySpan != null)
             return bySpan;
 
@@ -481,7 +475,7 @@ public sealed class PushMembersDownOperation : RefactoringOperationBase<PushMemb
                 ?? GetDocumentByFilePath(sourceDocument.Project.Solution, update.Original.SyntaxTree);
             if (updateDocument != null && updateDocument.Id == sourceDocument.Id)
             {
-                var rematchedOriginal = RematchTypeDeclaration(sourceRoot, update.Original)
+                var rematchedOriginal = TypePartRematch.RematchTypeDeclaration(sourceRoot, update.Original)
                     ?? throw new RefactoringException(
                         ErrorCodes.RoslynError,
                         $"Could not locate declaration for '{update.Type.Name}'.");

--- a/src/RoslynMcp.Core/Refactoring/Utilities/TypePartRematch.cs
+++ b/src/RoslynMcp.Core/Refactoring/Utilities/TypePartRematch.cs
@@ -1,0 +1,33 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace RoslynMcp.Core.Refactoring.Utilities;
+
+/// <summary>
+/// Shared partial-type rematch helpers used when applying Generate / Hierarchy /
+/// ExtractBaseClass rewrites across syntax trees (SameSyntaxTree by reference or
+/// case-insensitive FilePath; RematchTypeDeclaration by SpanStart + Identifier).
+/// </summary>
+internal static class TypePartRematch
+{
+    /// <summary>
+    /// True when <paramref name="left"/> and <paramref name="right"/> are the
+    /// same tree by reference, or share a non-empty FilePath compared
+    /// ordinal-ignore-case (same body as the Generate-family copies).
+    /// </summary>
+    internal static bool SameSyntaxTree(SyntaxTree left, SyntaxTree right) =>
+        left == right
+        || (!string.IsNullOrEmpty(left.FilePath)
+            && string.Equals(left.FilePath, right.FilePath, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// Rematches a type declaration in <paramref name="root"/> by SpanStart +
+    /// Identifier.Text (same body as the Generate / Pull / Push copies).
+    /// </summary>
+    internal static TypeDeclarationSyntax? RematchTypeDeclaration(
+        SyntaxNode root,
+        TypeDeclarationSyntax original) =>
+        root.DescendantNodes()
+            .OfType<TypeDeclarationSyntax>()
+            .FirstOrDefault(t => t.SpanStart == original.SpanStart && t.Identifier.Text == original.Identifier.Text);
+}

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Utilities/TypePartRematchTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Utilities/TypePartRematchTests.cs
@@ -1,0 +1,83 @@
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using RoslynMcp.Core.Refactoring.Utilities;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Refactoring.Utilities;
+
+public class TypePartRematchTests
+{
+    [Fact]
+    public void SameSyntaxTree_True_ForSameReference()
+    {
+        var tree = CSharpSyntaxTree.ParseText("class C { }");
+        Assert.True(TypePartRematch.SameSyntaxTree(tree, tree));
+    }
+
+    [Fact]
+    public void SameSyntaxTree_True_ForMatchingFilePathIgnoreCase()
+    {
+        var left = CSharpSyntaxTree.ParseText("class C { }", path: "A.cs");
+        var right = CSharpSyntaxTree.ParseText("class C { }", path: "a.cs");
+        Assert.True(TypePartRematch.SameSyntaxTree(left, right));
+    }
+
+    [Fact]
+    public void SameSyntaxTree_False_ForDifferentPaths()
+    {
+        var left = CSharpSyntaxTree.ParseText("class C { }", path: "A.cs");
+        var right = CSharpSyntaxTree.ParseText("class C { }", path: "B.cs");
+        Assert.False(TypePartRematch.SameSyntaxTree(left, right));
+    }
+
+    [Fact]
+    public void RematchTypeDeclaration_FindsBySpanStartAndName()
+    {
+        var tree = CSharpSyntaxTree.ParseText("""
+            class A { }
+            class B { }
+            """);
+        var root = tree.GetRoot();
+        var original = root.DescendantNodes().OfType<TypeDeclarationSyntax>()
+            .Single(t => t.Identifier.Text == "A");
+
+        var rematched = TypePartRematch.RematchTypeDeclaration(root, original);
+
+        Assert.NotNull(rematched);
+        Assert.Same(original, rematched);
+        Assert.Equal("A", rematched!.Identifier.Text);
+    }
+
+    [Fact]
+    public void RematchTypeDeclaration_Null_WhenNameMismatch()
+    {
+        var originalTree = CSharpSyntaxTree.ParseText("class A { } class B { }");
+        var original = originalTree.GetRoot().DescendantNodes().OfType<TypeDeclarationSyntax>()
+            .Single(t => t.Identifier.Text == "A");
+
+        var otherRoot = CSharpSyntaxTree.ParseText("class B { }").GetRoot();
+
+        Assert.Null(TypePartRematch.RematchTypeDeclaration(otherRoot, original));
+    }
+
+    [Fact]
+    public void RematchTypeDeclaration_PrefersMatchingSpanStartAndName()
+    {
+        var tree = CSharpSyntaxTree.ParseText("""
+            class Outer
+            {
+                class Inner { }
+            }
+            class Inner { }
+            """);
+        var root = tree.GetRoot();
+        var nested = root.DescendantNodes().OfType<TypeDeclarationSyntax>()
+            .Single(t => t.Identifier.Text == "Inner" && t.Parent is TypeDeclarationSyntax);
+        var topLevel = root.DescendantNodes().OfType<TypeDeclarationSyntax>()
+            .Single(t => t.Identifier.Text == "Inner" && t.Parent is not TypeDeclarationSyntax);
+
+        Assert.Same(nested, TypePartRematch.RematchTypeDeclaration(root, nested));
+        Assert.Same(topLevel, TypePartRematch.RematchTypeDeclaration(root, topLevel));
+        Assert.NotSame(nested, topLevel);
+    }
+}


### PR DESCRIPTION
## Summary
- Extracted shared `TypePartRematch` (`SameSyntaxTree` + `RematchTypeDeclaration`) under `Refactoring/Utilities`
- Deleted private copies from 7 Generate ops (`GenerateConstructor` / `EqualsHashCode` / `Overrides` / `Property` / `ToString` / `ImplementAbstract` / `ImplementInterface`) and retargeted call sites
- Retargeted `PullMembersUp` / `PushMembersDown` `RematchTypeDeclaration`; `ExtractBaseClass` keeps `ClassDeclarationSyntax?` wrapper via cast onto shared helper
- Added `TypePartRematchTests`; CHANGELOG Unreleased / Changed one-liner

Closes #1048

## Test plan
- [x] `dotnet test tests/RoslynMcp.Core.Tests/RoslynMcp.Core.Tests.csproj --filter "FullyQualifiedName~TypePartRematch"` — 6 passed
- [x] `dotnet build RoslynMcp.sln -c Release` — 0 warnings / 0 errors
- [ ] CI green (Build & Test + CodeQL)