### PR TITLE
Extract SignatureOverrideHelpers; replace 4 Signature HasSource/ShareOverrideRoot/GetOverrideRoot copies (#1050)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- Extracted shared `SignatureOverrideHelpers` (HasSourceDeclaration + ShareOverrideRoot + GetOverrideRoot) and replaced 4 Signature-family copies (`add_parameter` / `remove_parameter` / `reorder_parameters` / `change_return_type`) (#1050)
 - Extracted shared `TypePartRematch` (SameSyntaxTree + RematchTypeDeclaration) and replaced 7 Generate + Pull/Push/ExtractBaseClass copies (#1048)
 - Extracted shared `LocalCoverage` (FieldCoverage twin) and replaced IntroduceParameter copies; shared `IdentifierCoversColumn` with InlineVariable (`introduce_parameter` / `inline_variable`) (#1045)
 - Extracted shared `SymbolResolver.GetPosition(SourceText)` and replaced Extract + Rename private copies (`extract_method` / `extract_variable` / `extract_constant` / `rename_symbol`) (#1042)

--- a/src/RoslynMcp.Core/Refactoring/Signature/AddParameterOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Signature/AddParameterOperation.cs
@@ -471,7 +471,7 @@ public sealed class AddParameterOperation : RefactoringOperationBase<AddParamete
                     {
                         var impl = candidate.ContainingType.FindImplementationForInterfaceMember(ifaceMethod);
                         if (impl is not IMethodSymbol implMethod ||
-                            !ShareOverrideRoot(implMethod, candidate))
+                            !SignatureOverrideHelpers.ShareOverrideRoot(implMethod, candidate))
                         {
                             continue;
                         }
@@ -488,7 +488,7 @@ public sealed class AddParameterOperation : RefactoringOperationBase<AddParamete
             }
         }
 
-        return results.Where(HasSourceDeclaration).ToList();
+        return results.Where(SignatureOverrideHelpers.HasSourceDeclaration).ToList();
     }
 
     private async Task<List<DeclarationTarget>> CollectDeclarationTargetsAsync(
@@ -877,20 +877,6 @@ public sealed class AddParameterOperation : RefactoringOperationBase<AddParamete
     private static bool IsOptional(ParameterSyntax parameter) =>
         parameter.Default != null;
 
-    private static bool HasSourceDeclaration(IMethodSymbol method) =>
-        method.DeclaringSyntaxReferences.Length > 0 &&
-        method.Locations.Any(l => l.IsInSource);
-
-    private static bool ShareOverrideRoot(IMethodSymbol left, IMethodSymbol right) =>
-        SymbolEqualityComparer.Default.Equals(GetOverrideRoot(left), GetOverrideRoot(right));
-
-    private static IMethodSymbol GetOverrideRoot(IMethodSymbol method)
-    {
-        var current = method;
-        while (current.OverriddenMethod != null)
-            current = current.OverriddenMethod;
-        return current;
-    }
 
     private static string NormalizeIdentifier(string name) =>
         name.StartsWith('@') && name.Length > 1 ? name[1..] : name;

--- a/src/RoslynMcp.Core/Refactoring/Signature/ChangeReturnTypeOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Signature/ChangeReturnTypeOperation.cs
@@ -138,7 +138,7 @@ public sealed class ChangeReturnTypeOperation : RefactoringOperationBase<ChangeR
                 @params.UpdateOverrides,
                 @params.UpdateImplementations,
                 cancellationToken))
-            .Where(HasSourceDeclaration)
+            .Where(SignatureOverrideHelpers.HasSourceDeclaration)
             .ToList();
 
         foreach (var related in relatedMethods)
@@ -510,7 +510,7 @@ public sealed class ChangeReturnTypeOperation : RefactoringOperationBase<ChangeR
                     {
                         var impl = candidate.ContainingType.FindImplementationForInterfaceMember(ifaceMethod);
                         if (impl is not IMethodSymbol implMethod ||
-                            !ShareOverrideRoot(implMethod, candidate))
+                            !SignatureOverrideHelpers.ShareOverrideRoot(implMethod, candidate))
                         {
                             continue;
                         }
@@ -559,7 +559,7 @@ public sealed class ChangeReturnTypeOperation : RefactoringOperationBase<ChangeR
     {
         foreach (var method in methods)
         {
-            if (HasSourceDeclaration(method))
+            if (SignatureOverrideHelpers.HasSourceDeclaration(method))
                 continue;
 
             if (IsCompatibleWithUneditableContract(method.ReturnType, newReturnType, compilation))
@@ -1168,20 +1168,6 @@ public sealed class ChangeReturnTypeOperation : RefactoringOperationBase<ChangeR
         return RefactoringResult.PreviewResult(operationId, pendingChanges);
     }
 
-    private static bool HasSourceDeclaration(IMethodSymbol method) =>
-        method.DeclaringSyntaxReferences.Length > 0 &&
-        method.Locations.Any(l => l.IsInSource);
-
-    private static bool ShareOverrideRoot(IMethodSymbol left, IMethodSymbol right) =>
-        SymbolEqualityComparer.Default.Equals(GetOverrideRoot(left), GetOverrideRoot(right));
-
-    private static IMethodSymbol GetOverrideRoot(IMethodSymbol method)
-    {
-        var current = method;
-        while (current.OverriddenMethod != null)
-            current = current.OverriddenMethod;
-        return current;
-    }
 
     internal readonly record struct ReturnRewritePlan(
         ReturnRewriteKind Kind,

--- a/src/RoslynMcp.Core/Refactoring/Signature/RemoveParameterOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Signature/RemoveParameterOperation.cs
@@ -386,7 +386,7 @@ public sealed class RemoveParameterOperation : RefactoringOperationBase<RemovePa
                     {
                         var impl = candidate.ContainingType.FindImplementationForInterfaceMember(ifaceMethod);
                         if (impl is not IMethodSymbol implMethod ||
-                            !ShareOverrideRoot(implMethod, candidate))
+                            !SignatureOverrideHelpers.ShareOverrideRoot(implMethod, candidate))
                         {
                             continue;
                         }
@@ -403,7 +403,7 @@ public sealed class RemoveParameterOperation : RefactoringOperationBase<RemovePa
             }
         }
 
-        return results.Where(HasSourceDeclaration).ToList();
+        return results.Where(SignatureOverrideHelpers.HasSourceDeclaration).ToList();
     }
 
     private async Task<List<DeclarationTarget>> CollectDeclarationTargetsAsync(
@@ -788,20 +788,6 @@ public sealed class RemoveParameterOperation : RefactoringOperationBase<RemovePa
         return true;
     }
 
-    private static bool HasSourceDeclaration(IMethodSymbol method) =>
-        method.DeclaringSyntaxReferences.Length > 0 &&
-        method.Locations.Any(l => l.IsInSource);
-
-    private static bool ShareOverrideRoot(IMethodSymbol left, IMethodSymbol right) =>
-        SymbolEqualityComparer.Default.Equals(GetOverrideRoot(left), GetOverrideRoot(right));
-
-    private static IMethodSymbol GetOverrideRoot(IMethodSymbol method)
-    {
-        var current = method;
-        while (current.OverriddenMethod != null)
-            current = current.OverriddenMethod;
-        return current;
-    }
 
     private static string NormalizeIdentifier(string name) =>
         name.StartsWith('@') && name.Length > 1 ? name[1..] : name;

--- a/src/RoslynMcp.Core/Refactoring/Signature/ReorderParametersOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Signature/ReorderParametersOperation.cs
@@ -513,7 +513,7 @@ public sealed class ReorderParametersOperation : RefactoringOperationBase<Reorde
                     {
                         var impl = candidate.ContainingType.FindImplementationForInterfaceMember(ifaceMethod);
                         if (impl is not IMethodSymbol implMethod ||
-                            !ShareOverrideRoot(implMethod, candidate))
+                            !SignatureOverrideHelpers.ShareOverrideRoot(implMethod, candidate))
                         {
                             continue;
                         }
@@ -530,7 +530,7 @@ public sealed class ReorderParametersOperation : RefactoringOperationBase<Reorde
             }
         }
 
-        return results.Where(HasSourceDeclaration).ToList();
+        return results.Where(SignatureOverrideHelpers.HasSourceDeclaration).ToList();
     }
 
     private async Task<List<DeclarationTarget>> CollectDeclarationTargetsAsync(
@@ -846,20 +846,6 @@ public sealed class ReorderParametersOperation : RefactoringOperationBase<Reorde
         return RefactoringResult.PreviewResult(operationId, pendingChanges);
     }
 
-    private static bool HasSourceDeclaration(IMethodSymbol method) =>
-        method.DeclaringSyntaxReferences.Length > 0 &&
-        method.Locations.Any(l => l.IsInSource);
-
-    private static bool ShareOverrideRoot(IMethodSymbol left, IMethodSymbol right) =>
-        SymbolEqualityComparer.Default.Equals(GetOverrideRoot(left), GetOverrideRoot(right));
-
-    private static IMethodSymbol GetOverrideRoot(IMethodSymbol method)
-    {
-        var current = method;
-        while (current.OverriddenMethod != null)
-            current = current.OverriddenMethod;
-        return current;
-    }
 
     private static bool IsParams(ParameterSyntax parameter) =>
         parameter.Modifiers.Any(m => m.IsKind(SyntaxKind.ParamsKeyword));

--- a/src/RoslynMcp.Core/Refactoring/Signature/SignatureOverrideHelpers.cs
+++ b/src/RoslynMcp.Core/Refactoring/Signature/SignatureOverrideHelpers.cs
@@ -1,0 +1,38 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace RoslynMcp.Core.Refactoring.Signature;
+
+/// <summary>
+/// Shared Signature-family helpers for source-declared methods and
+/// override-root identity (add/remove/reorder parameter + change return type).
+/// </summary>
+internal static class SignatureOverrideHelpers
+{
+    /// <summary>
+    /// True when <paramref name="method"/> has at least one declaring syntax
+    /// reference and at least one in-source location.
+    /// </summary>
+    internal static bool HasSourceDeclaration(IMethodSymbol method) =>
+        method.DeclaringSyntaxReferences.Length > 0 &&
+        method.Locations.Any(l => l.IsInSource);
+
+    /// <summary>
+    /// True when <paramref name="left"/> and <paramref name="right"/> share the
+    /// same override root (walk <see cref="IMethodSymbol.OverriddenMethod"/>).
+    /// </summary>
+    internal static bool ShareOverrideRoot(IMethodSymbol left, IMethodSymbol right) =>
+        SymbolEqualityComparer.Default.Equals(GetOverrideRoot(left), GetOverrideRoot(right));
+
+    /// <summary>
+    /// Walks <see cref="IMethodSymbol.OverriddenMethod"/> until null and returns
+    /// that root method symbol.
+    /// </summary>
+    internal static IMethodSymbol GetOverrideRoot(IMethodSymbol method)
+    {
+        var current = method;
+        while (current.OverriddenMethod != null)
+            current = current.OverriddenMethod;
+        return current;
+    }
+}

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Signature/SignatureOverrideHelpersTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Signature/SignatureOverrideHelpersTests.cs
@@ -1,0 +1,92 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using RoslynMcp.Core.Refactoring.Signature;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Refactoring.Signature;
+
+public class SignatureOverrideHelpersTests
+{
+    private static CSharpCompilation CreateCompilation(string source)
+    {
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var refs = new[]
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+        };
+        return CSharpCompilation.Create(
+            "SignatureOverrideHelpersTests",
+            new[] { tree },
+            refs,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+    }
+
+    [Fact]
+    public void HasSourceDeclaration_True_ForSourceMethod_False_ForMetadata()
+    {
+        var compilation = CreateCompilation("""
+            class C
+            {
+                public void M() { }
+            }
+            """);
+        var c = compilation.GetTypeByMetadataName("C")!;
+        var m = c.GetMembers("M").OfType<IMethodSymbol>().Single();
+        Assert.True(SignatureOverrideHelpers.HasSourceDeclaration(m));
+
+        var objectToString = compilation.GetSpecialType(SpecialType.System_Object)
+            .GetMembers("ToString")
+            .OfType<IMethodSymbol>()
+            .Single();
+        Assert.False(SignatureOverrideHelpers.HasSourceDeclaration(objectToString));
+    }
+
+    [Fact]
+    public void GetOverrideRoot_WalksOverrideChain()
+    {
+        var compilation = CreateCompilation("""
+            class A
+            {
+                public virtual void M() { }
+            }
+            class B : A
+            {
+                public override void M() { }
+            }
+            class C : B
+            {
+                public override void M() { }
+            }
+            """);
+        var a = compilation.GetTypeByMetadataName("A")!.GetMembers("M").OfType<IMethodSymbol>().Single();
+        var b = compilation.GetTypeByMetadataName("B")!.GetMembers("M").OfType<IMethodSymbol>().Single();
+        var c = compilation.GetTypeByMetadataName("C")!.GetMembers("M").OfType<IMethodSymbol>().Single();
+
+        Assert.True(SymbolEqualityComparer.Default.Equals(a, SignatureOverrideHelpers.GetOverrideRoot(a)));
+        Assert.True(SymbolEqualityComparer.Default.Equals(a, SignatureOverrideHelpers.GetOverrideRoot(b)));
+        Assert.True(SymbolEqualityComparer.Default.Equals(a, SignatureOverrideHelpers.GetOverrideRoot(c)));
+    }
+
+    [Fact]
+    public void ShareOverrideRoot_True_WhenSameRoot_False_Otherwise()
+    {
+        var compilation = CreateCompilation("""
+            class A
+            {
+                public virtual void M() { }
+                public virtual void N() { }
+            }
+            class B : A
+            {
+                public override void M() { }
+                public override void N() { }
+            }
+            """);
+        var aM = compilation.GetTypeByMetadataName("A")!.GetMembers("M").OfType<IMethodSymbol>().Single();
+        var bM = compilation.GetTypeByMetadataName("B")!.GetMembers("M").OfType<IMethodSymbol>().Single();
+        var bN = compilation.GetTypeByMetadataName("B")!.GetMembers("N").OfType<IMethodSymbol>().Single();
+
+        Assert.True(SignatureOverrideHelpers.ShareOverrideRoot(aM, bM));
+        Assert.False(SignatureOverrideHelpers.ShareOverrideRoot(bM, bN));
+    }
+}


### PR DESCRIPTION
## Summary
- Extract shared `SignatureOverrideHelpers` (`HasSourceDeclaration`, `ShareOverrideRoot`, `GetOverrideRoot`)
- Replace identical private copies in Add/Remove/Reorder parameter + ChangeReturnType
- Add focused `SignatureOverrideHelpersTests`; CHANGELOG under Unreleased

Closes #1050

## Test plan
- [x] `SignatureOverrideHelpersTests` + SignatureReferenceHelpers + Add/Remove/Reorder/ChangeReturnType operation tests locally
- [ ] CI Build and Test + Code Quality green
- [ ] Copilot/Codex review threads resolved