### PR TITLE
Extract TypeWalkKeyHelpers.TypeWalkKey; replace 5 identical 3-overload copies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- Extracted shared `TypeWalkKeyHelpers.TypeWalkKey` (3 overloads) and replaced 5 identical copies (`implement_abstract` / `implement_interface` / `generate_tostring` / `generate_overrides` / `generate_equals_hashcode`) (#1065)
 - Extracted shared `DocumentSourceFileFilter.FilterDocumentsBySourceFile` and replaced 9 identical copies (`make_static` / `make_non_static` / `generate_overrides` / `generate_equals_hashcode` / `generate_constructor` / `generate_tostring` / `implement_interface` / `implement_abstract` / `inline_constant`) (#1062)
 - Extracted shared `DocumentForTreeHelpers.GetDocumentForTree` and replaced 10 identical copies (`extract_base_class` / `generate_overrides` / `generate_equals_hashcode` / `generate_property` / `generate_constructor` / `generate_tostring` / `implement_interface` / `implement_abstract` / `push_members_down` / `pull_members_up`) (#1059)
 - Extracted shared `DocumentEditableHelpers.ValidateDocumentIsEditable` and replaced 21 identical copies (`add_braces` / `convert_anonymous_to_class` / `convert_to_block_body` / `convert_tuple_to_struct` / `invert_if` / `remove_braces` / `simplify_name` / `introduce_field` / `make_non_static` / `make_static` / `safe_delete` / `generate_method_stub` / `generate_property` / `implement_abstract` / `use_base_type` / `inline_constant` / `rename_namespace` / `add_parameter` / `change_return_type` / `remove_parameter` / `reorder_parameters`) (#1056)

--- a/src/RoslynMcp.Core/Refactoring/Generate/GenerateEqualsHashCodeOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GenerateEqualsHashCodeOperation.cs
@@ -303,7 +303,7 @@ public sealed class GenerateEqualsHashCodeOperation : RefactoringOperationBase<G
                     if (typeSymbol == null)
                         continue;
 
-                    var typeKey = TypeWalkKey(currentDocument.Project.Id, typeSymbol);
+                    var typeKey = TypeWalkKeyHelpers.TypeWalkKey(currentDocument.Project.Id, typeSymbol);
                     if (!processedTypes.Add(typeKey))
                         continue;
 
@@ -410,63 +410,6 @@ public sealed class GenerateEqualsHashCodeOperation : RefactoringOperationBase<G
             null, 0, 0);
     }
 
-    /// <summary>
-    /// De-dupes types within one project across rematches and partials.
-    /// Includes <paramref name="projectId"/> so two projects that both
-    /// declare <c>TestApp.Widget</c> are not collapsed onto one walk key.
-    /// File-local types (<see cref="INamedTypeSymbol.IsFileLocal"/>) also
-    /// include a file-local marker and declaring file so two
-    /// <c>file class Worker</c> hosts that share
-    /// <see cref="SymbolDisplayFormat.FullyQualifiedFormat"/> are not
-    /// skipped as if they were one partial. Genuine partials
-    /// (<c>IsFileLocal</c> false, multiple declaring syntax refs) still
-    /// collapse to one walk.
-    /// </summary>
-    internal static string TypeWalkKey(ProjectId projectId, INamedTypeSymbol typeSymbol)
-    {
-        var fqn = typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-        if (!typeSymbol.IsFileLocal)
-            return TypeWalkKey(projectId, fqn);
-
-        var declaringFile = typeSymbol.DeclaringSyntaxReferences
-            .Select(reference => reference.SyntaxTree.FilePath)
-            .FirstOrDefault(path => !string.IsNullOrWhiteSpace(path));
-
-        return TypeWalkKey(projectId, fqn, declaringFile);
-    }
-
-    /// <summary>
-    /// Same key shape as a non-file-local
-    /// <see cref="TypeWalkKey(ProjectId, INamedTypeSymbol)"/> for tests
-    /// that do not have a compilation symbol.
-    /// </summary>
-    internal static string TypeWalkKey(ProjectId projectId, string fullyQualifiedTypeName) =>
-        $"{projectId.Id:D}\0{fullyQualifiedTypeName}";
-
-    /// <summary>
-    /// File-local walk key: project id + FQN plus a <c>file</c> marker and
-    /// declaring path so same-named file-local types in different files
-    /// stay distinct. Ordinary (non-file-local) callers should use
-    /// <see cref="TypeWalkKey(ProjectId, string)"/>.
-    /// </summary>
-    internal static string TypeWalkKey(ProjectId projectId, string fullyQualifiedTypeName, string? fileLocalDeclaringPath)
-    {
-        var key = TypeWalkKey(projectId, fullyQualifiedTypeName);
-        if (string.IsNullOrWhiteSpace(fileLocalDeclaringPath))
-            return $"{key}\0file";
-
-        string normalized;
-        try
-        {
-            normalized = PathResolver.NormalizePath(fileLocalDeclaringPath);
-        }
-        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
-        {
-            normalized = fileLocalDeclaringPath;
-        }
-
-        return $"{key}\0file\0{normalized}";
-    }
 
     /// <summary>
     /// Preview description for a file that generated Equals/GetHashCode

--- a/src/RoslynMcp.Core/Refactoring/Generate/GenerateOverridesOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GenerateOverridesOperation.cs
@@ -269,7 +269,7 @@ public sealed class GenerateOverridesOperation : RefactoringOperationBase<Genera
                     if (typeSymbol == null)
                         continue;
 
-                    var typeKey = TypeWalkKey(currentDocument.Project.Id, typeSymbol);
+                    var typeKey = TypeWalkKeyHelpers.TypeWalkKey(currentDocument.Project.Id, typeSymbol);
                     if (!processedTypes.Add(typeKey))
                         continue;
 
@@ -374,63 +374,6 @@ public sealed class GenerateOverridesOperation : RefactoringOperationBase<Genera
             null, 0, 0);
     }
 
-    /// <summary>
-    /// De-dupes types within one project across rematches and partials.
-    /// Includes <paramref name="projectId"/> so two projects that both
-    /// declare <c>TestApp.Widget</c> are not collapsed onto one walk key.
-    /// File-local types (<see cref="INamedTypeSymbol.IsFileLocal"/>) also
-    /// include a file-local marker and declaring file so two
-    /// <c>file class Worker</c> hosts that share
-    /// <see cref="SymbolDisplayFormat.FullyQualifiedFormat"/> are not
-    /// skipped as if they were one partial. Genuine partials
-    /// (<c>IsFileLocal</c> false, multiple declaring syntax refs) still
-    /// collapse to one walk.
-    /// </summary>
-    internal static string TypeWalkKey(ProjectId projectId, INamedTypeSymbol typeSymbol)
-    {
-        var fqn = typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-        if (!typeSymbol.IsFileLocal)
-            return TypeWalkKey(projectId, fqn);
-
-        var declaringFile = typeSymbol.DeclaringSyntaxReferences
-            .Select(reference => reference.SyntaxTree.FilePath)
-            .FirstOrDefault(path => !string.IsNullOrWhiteSpace(path));
-
-        return TypeWalkKey(projectId, fqn, declaringFile);
-    }
-
-    /// <summary>
-    /// Same key shape as a non-file-local
-    /// <see cref="TypeWalkKey(ProjectId, INamedTypeSymbol)"/> for tests
-    /// that do not have a compilation symbol.
-    /// </summary>
-    internal static string TypeWalkKey(ProjectId projectId, string fullyQualifiedTypeName) =>
-        $"{projectId.Id:D}\0{fullyQualifiedTypeName}";
-
-    /// <summary>
-    /// File-local walk key: project id + FQN plus a <c>file</c> marker and
-    /// declaring path so same-named file-local types in different files
-    /// stay distinct. Ordinary (non-file-local) callers should use
-    /// <see cref="TypeWalkKey(ProjectId, string)"/>.
-    /// </summary>
-    internal static string TypeWalkKey(ProjectId projectId, string fullyQualifiedTypeName, string? fileLocalDeclaringPath)
-    {
-        var key = TypeWalkKey(projectId, fullyQualifiedTypeName);
-        if (string.IsNullOrWhiteSpace(fileLocalDeclaringPath))
-            return $"{key}\0file";
-
-        string normalized;
-        try
-        {
-            normalized = PathResolver.NormalizePath(fileLocalDeclaringPath);
-        }
-        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
-        {
-            normalized = fileLocalDeclaringPath;
-        }
-
-        return $"{key}\0file\0{normalized}";
-    }
 
     /// <summary>
     /// Preview description for a file that generated overrides on

--- a/src/RoslynMcp.Core/Refactoring/Generate/GenerateToStringOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GenerateToStringOperation.cs
@@ -269,7 +269,7 @@ public sealed class GenerateToStringOperation : RefactoringOperationBase<Generat
                     if (typeSymbol == null)
                         continue;
 
-                    var typeKey = TypeWalkKey(currentDocument.Project.Id, typeSymbol);
+                    var typeKey = TypeWalkKeyHelpers.TypeWalkKey(currentDocument.Project.Id, typeSymbol);
                     if (!processedTypes.Add(typeKey))
                         continue;
 
@@ -375,63 +375,6 @@ public sealed class GenerateToStringOperation : RefactoringOperationBase<Generat
             null, 0, 0);
     }
 
-    /// <summary>
-    /// De-dupes types within one project across rematches and partials.
-    /// Includes <paramref name="projectId"/> so two projects that both
-    /// declare <c>TestApp.Widget</c> are not collapsed onto one walk key.
-    /// File-local types (<see cref="INamedTypeSymbol.IsFileLocal"/>) also
-    /// include a file-local marker and declaring file so two
-    /// <c>file class Worker</c> hosts that share
-    /// <see cref="SymbolDisplayFormat.FullyQualifiedFormat"/> are not
-    /// skipped as if they were one partial. Genuine partials
-    /// (<c>IsFileLocal</c> false, multiple declaring syntax refs) still
-    /// collapse to one walk.
-    /// </summary>
-    internal static string TypeWalkKey(ProjectId projectId, INamedTypeSymbol typeSymbol)
-    {
-        var fqn = typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-        if (!typeSymbol.IsFileLocal)
-            return TypeWalkKey(projectId, fqn);
-
-        var declaringFile = typeSymbol.DeclaringSyntaxReferences
-            .Select(reference => reference.SyntaxTree.FilePath)
-            .FirstOrDefault(path => !string.IsNullOrWhiteSpace(path));
-
-        return TypeWalkKey(projectId, fqn, declaringFile);
-    }
-
-    /// <summary>
-    /// Same key shape as a non-file-local
-    /// <see cref="TypeWalkKey(ProjectId, INamedTypeSymbol)"/> for tests
-    /// that do not have a compilation symbol.
-    /// </summary>
-    internal static string TypeWalkKey(ProjectId projectId, string fullyQualifiedTypeName) =>
-        $"{projectId.Id:D}\0{fullyQualifiedTypeName}";
-
-    /// <summary>
-    /// File-local walk key: project id + FQN plus a <c>file</c> marker and
-    /// declaring path so same-named file-local types in different files
-    /// stay distinct. Ordinary (non-file-local) callers should use
-    /// <see cref="TypeWalkKey(ProjectId, string)"/>.
-    /// </summary>
-    internal static string TypeWalkKey(ProjectId projectId, string fullyQualifiedTypeName, string? fileLocalDeclaringPath)
-    {
-        var key = TypeWalkKey(projectId, fullyQualifiedTypeName);
-        if (string.IsNullOrWhiteSpace(fileLocalDeclaringPath))
-            return $"{key}\0file";
-
-        string normalized;
-        try
-        {
-            normalized = PathResolver.NormalizePath(fileLocalDeclaringPath);
-        }
-        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
-        {
-            normalized = fileLocalDeclaringPath;
-        }
-
-        return $"{key}\0file\0{normalized}";
-    }
 
     /// <summary>
     /// Preview description for a file that generated ToString on

--- a/src/RoslynMcp.Core/Refactoring/Generate/ImplementAbstractOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/ImplementAbstractOperation.cs
@@ -290,7 +290,7 @@ public sealed class ImplementAbstractOperation : RefactoringOperationBase<Implem
                     if (typeSymbol == null)
                         continue;
 
-                    var typeKey = TypeWalkKey(currentDocument.Project.Id, typeSymbol);
+                    var typeKey = TypeWalkKeyHelpers.TypeWalkKey(currentDocument.Project.Id, typeSymbol);
                     if (!processedTypes.Add(typeKey))
                         continue;
 
@@ -396,63 +396,6 @@ public sealed class ImplementAbstractOperation : RefactoringOperationBase<Implem
             null, 0, 0);
     }
 
-    /// <summary>
-    /// De-dupes types within one project across rematches and partials.
-    /// Includes <paramref name="projectId"/> so two projects that both
-    /// declare <c>TestApp.Widget</c> are not collapsed onto one walk key.
-    /// File-local types (<see cref="INamedTypeSymbol.IsFileLocal"/>) also
-    /// include a file-local marker and declaring file so two
-    /// <c>file class Worker</c> hosts that share
-    /// <see cref="SymbolDisplayFormat.FullyQualifiedFormat"/> are not
-    /// skipped as if they were one partial. Genuine partials
-    /// (<c>IsFileLocal</c> false, multiple declaring syntax refs) still
-    /// collapse to one walk.
-    /// </summary>
-    internal static string TypeWalkKey(ProjectId projectId, INamedTypeSymbol typeSymbol)
-    {
-        var fqn = typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-        if (!typeSymbol.IsFileLocal)
-            return TypeWalkKey(projectId, fqn);
-
-        var declaringFile = typeSymbol.DeclaringSyntaxReferences
-            .Select(reference => reference.SyntaxTree.FilePath)
-            .FirstOrDefault(path => !string.IsNullOrWhiteSpace(path));
-
-        return TypeWalkKey(projectId, fqn, declaringFile);
-    }
-
-    /// <summary>
-    /// Same key shape as a non-file-local
-    /// <see cref="TypeWalkKey(ProjectId, INamedTypeSymbol)"/> for tests
-    /// that do not have a compilation symbol.
-    /// </summary>
-    internal static string TypeWalkKey(ProjectId projectId, string fullyQualifiedTypeName) =>
-        $"{projectId.Id:D}\0{fullyQualifiedTypeName}";
-
-    /// <summary>
-    /// File-local walk key: project id + FQN plus a <c>file</c> marker and
-    /// declaring path so same-named file-local types in different files
-    /// stay distinct. Ordinary (non-file-local) callers should use
-    /// <see cref="TypeWalkKey(ProjectId, string)"/>.
-    /// </summary>
-    internal static string TypeWalkKey(ProjectId projectId, string fullyQualifiedTypeName, string? fileLocalDeclaringPath)
-    {
-        var key = TypeWalkKey(projectId, fullyQualifiedTypeName);
-        if (string.IsNullOrWhiteSpace(fileLocalDeclaringPath))
-            return $"{key}\0file";
-
-        string normalized;
-        try
-        {
-            normalized = PathResolver.NormalizePath(fileLocalDeclaringPath);
-        }
-        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
-        {
-            normalized = fileLocalDeclaringPath;
-        }
-
-        return $"{key}\0file\0{normalized}";
-    }
 
     /// <summary>
     /// Preview description for a file that implemented abstract members

--- a/src/RoslynMcp.Core/Refactoring/Generate/ImplementInterfaceOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/ImplementInterfaceOperation.cs
@@ -291,7 +291,7 @@ public sealed class ImplementInterfaceOperation : RefactoringOperationBase<Imple
                     if (typeSymbol == null)
                         continue;
 
-                    var typeKey = TypeWalkKey(currentDocument.Project.Id, typeSymbol);
+                    var typeKey = TypeWalkKeyHelpers.TypeWalkKey(currentDocument.Project.Id, typeSymbol);
                     if (!processedTypes.Add(typeKey))
                         continue;
 
@@ -396,63 +396,6 @@ public sealed class ImplementInterfaceOperation : RefactoringOperationBase<Imple
             null, 0, 0);
     }
 
-    /// <summary>
-    /// De-dupes types within one project across rematches and partials.
-    /// Includes <paramref name="projectId"/> so two projects that both
-    /// declare <c>TestApp.Widget</c> are not collapsed onto one walk key.
-    /// File-local types (<see cref="INamedTypeSymbol.IsFileLocal"/>) also
-    /// include a file-local marker and declaring file so two
-    /// <c>file class Worker</c> hosts that share
-    /// <see cref="SymbolDisplayFormat.FullyQualifiedFormat"/> are not
-    /// skipped as if they were one partial. Genuine partials
-    /// (<c>IsFileLocal</c> false, multiple declaring syntax refs) still
-    /// collapse to one walk.
-    /// </summary>
-    internal static string TypeWalkKey(ProjectId projectId, INamedTypeSymbol typeSymbol)
-    {
-        var fqn = typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-        if (!typeSymbol.IsFileLocal)
-            return TypeWalkKey(projectId, fqn);
-
-        var declaringFile = typeSymbol.DeclaringSyntaxReferences
-            .Select(reference => reference.SyntaxTree.FilePath)
-            .FirstOrDefault(path => !string.IsNullOrWhiteSpace(path));
-
-        return TypeWalkKey(projectId, fqn, declaringFile);
-    }
-
-    /// <summary>
-    /// Same key shape as a non-file-local
-    /// <see cref="TypeWalkKey(ProjectId, INamedTypeSymbol)"/> for tests
-    /// that do not have a compilation symbol.
-    /// </summary>
-    internal static string TypeWalkKey(ProjectId projectId, string fullyQualifiedTypeName) =>
-        $"{projectId.Id:D}\0{fullyQualifiedTypeName}";
-
-    /// <summary>
-    /// File-local walk key: project id + FQN plus a <c>file</c> marker and
-    /// declaring path so same-named file-local types in different files
-    /// stay distinct. Ordinary (non-file-local) callers should use
-    /// <see cref="TypeWalkKey(ProjectId, string)"/>.
-    /// </summary>
-    internal static string TypeWalkKey(ProjectId projectId, string fullyQualifiedTypeName, string? fileLocalDeclaringPath)
-    {
-        var key = TypeWalkKey(projectId, fullyQualifiedTypeName);
-        if (string.IsNullOrWhiteSpace(fileLocalDeclaringPath))
-            return $"{key}\0file";
-
-        string normalized;
-        try
-        {
-            normalized = PathResolver.NormalizePath(fileLocalDeclaringPath);
-        }
-        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
-        {
-            normalized = fileLocalDeclaringPath;
-        }
-
-        return $"{key}\0file\0{normalized}";
-    }
 
     /// <summary>
     /// Preview description for a file that implemented interface members

--- a/src/RoslynMcp.Core/Refactoring/Utilities/TypeWalkKeyHelpers.cs
+++ b/src/RoslynMcp.Core/Refactoring/Utilities/TypeWalkKeyHelpers.cs
@@ -1,0 +1,71 @@
+using Microsoft.CodeAnalysis;
+using RoslynMcp.Core.FileSystem;
+
+namespace RoslynMcp.Core.Refactoring.Utilities;
+
+/// <summary>
+/// Shared type-walk de-dupe key used by Generate AllFiles paths that collapse
+/// rematches and partials within one project (3-overload form with file-local
+/// identity). Same body as the ImplementAbstract / ImplementInterface /
+/// GenerateToString / GenerateOverrides / GenerateEqualsHashCode copies.
+/// </summary>
+internal static class TypeWalkKeyHelpers
+{
+    /// <summary>
+    /// De-dupes types within one project across rematches and partials.
+    /// Includes <paramref name="projectId"/> so two projects that both
+    /// declare <c>TestApp.Widget</c> are not collapsed onto one walk key.
+    /// File-local types (<see cref="INamedTypeSymbol.IsFileLocal"/>) also
+    /// include a file-local marker and declaring file so two
+    /// <c>file class Worker</c> hosts that share
+    /// <see cref="SymbolDisplayFormat.FullyQualifiedFormat"/> are not
+    /// skipped as if they were one partial. Genuine partials
+    /// (<c>IsFileLocal</c> false, multiple declaring syntax refs) still
+    /// collapse to one walk.
+    /// </summary>
+    internal static string TypeWalkKey(ProjectId projectId, INamedTypeSymbol typeSymbol)
+    {
+        var fqn = typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        if (!typeSymbol.IsFileLocal)
+            return TypeWalkKey(projectId, fqn);
+
+        var declaringFile = typeSymbol.DeclaringSyntaxReferences
+            .Select(reference => reference.SyntaxTree.FilePath)
+            .FirstOrDefault(path => !string.IsNullOrWhiteSpace(path));
+
+        return TypeWalkKey(projectId, fqn, declaringFile);
+    }
+
+    /// <summary>
+    /// Same key shape as a non-file-local
+    /// <see cref="TypeWalkKey(ProjectId, INamedTypeSymbol)"/> for tests
+    /// that do not have a compilation symbol.
+    /// </summary>
+    internal static string TypeWalkKey(ProjectId projectId, string fullyQualifiedTypeName) =>
+        $"{projectId.Id:D}\0{fullyQualifiedTypeName}";
+
+    /// <summary>
+    /// File-local walk key: project id + FQN plus a <c>file</c> marker and
+    /// declaring path so same-named file-local types in different files
+    /// stay distinct. Ordinary (non-file-local) callers should use
+    /// <see cref="TypeWalkKey(ProjectId, string)"/>.
+    /// </summary>
+    internal static string TypeWalkKey(ProjectId projectId, string fullyQualifiedTypeName, string? fileLocalDeclaringPath)
+    {
+        var key = TypeWalkKey(projectId, fullyQualifiedTypeName);
+        if (string.IsNullOrWhiteSpace(fileLocalDeclaringPath))
+            return $"{key}\0file";
+
+        string normalized;
+        try
+        {
+            normalized = PathResolver.NormalizePath(fileLocalDeclaringPath);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            normalized = fileLocalDeclaringPath;
+        }
+
+        return $"{key}\0file\0{normalized}";
+    }
+}

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GenerateEqualsHashCodeOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GenerateEqualsHashCodeOperationTests.cs
@@ -3171,37 +3171,6 @@ public class GenerateEqualsHashCodeOperationTests
         Assert.Contains("fields", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
-    [Fact]
-    public void TypeWalkKey_IncludesProjectIdentity()
-    {
-        var projectA = ProjectId.CreateNewId();
-        var projectB = ProjectId.CreateNewId();
-        const string fqn = "global::TestApp.Widget";
-
-        var keyA = GenerateEqualsHashCodeOperation.TypeWalkKey(projectA, fqn);
-        var keyB = GenerateEqualsHashCodeOperation.TypeWalkKey(projectB, fqn);
-
-        Assert.NotEqual(keyA, keyB);
-        Assert.Equal(keyA, GenerateEqualsHashCodeOperation.TypeWalkKey(projectA, fqn));
-        Assert.NotEqual(keyA, GenerateEqualsHashCodeOperation.TypeWalkKey(projectA, "global::TestApp.Other"));
-    }
-
-    [Fact]
-    public void TypeWalkKey_FileLocalIdentity_DistinguishesSameFqn()
-    {
-        var project = ProjectId.CreateNewId();
-        const string fqn = "global::TestApp.Worker";
-
-        var ordinary = GenerateEqualsHashCodeOperation.TypeWalkKey(project, fqn);
-        var fileA = GenerateEqualsHashCodeOperation.TypeWalkKey(project, fqn, "/tmp/FileA.cs");
-        var fileB = GenerateEqualsHashCodeOperation.TypeWalkKey(project, fqn, "/tmp/FileB.cs");
-
-        Assert.NotEqual(ordinary, fileA);
-        Assert.NotEqual(ordinary, fileB);
-        Assert.NotEqual(fileA, fileB);
-        Assert.Equal(fileA, GenerateEqualsHashCodeOperation.TypeWalkKey(project, fqn, "/tmp/FileA.cs"));
-        Assert.Equal(ordinary, GenerateEqualsHashCodeOperation.TypeWalkKey(project, fqn));
-    }
 
     [Fact]
     public void Validate_AllFilesTrue_WithLine_Throws()

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GenerateOverridesOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GenerateOverridesOperationTests.cs
@@ -3358,37 +3358,6 @@ public class GenerateOverridesOperationTests
         Assert.Contains("members", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
-    [Fact]
-    public void TypeWalkKey_IncludesProjectIdentity()
-    {
-        var projectA = ProjectId.CreateNewId();
-        var projectB = ProjectId.CreateNewId();
-        const string fqn = "global::TestApp.Widget";
-
-        var keyA = GenerateOverridesOperation.TypeWalkKey(projectA, fqn);
-        var keyB = GenerateOverridesOperation.TypeWalkKey(projectB, fqn);
-
-        Assert.NotEqual(keyA, keyB);
-        Assert.Equal(keyA, GenerateOverridesOperation.TypeWalkKey(projectA, fqn));
-        Assert.NotEqual(keyA, GenerateOverridesOperation.TypeWalkKey(projectA, "global::TestApp.Other"));
-    }
-
-    [Fact]
-    public void TypeWalkKey_FileLocalIdentity_DistinguishesSameFqn()
-    {
-        var project = ProjectId.CreateNewId();
-        const string fqn = "global::TestApp.Worker";
-
-        var ordinary = GenerateOverridesOperation.TypeWalkKey(project, fqn);
-        var fileA = GenerateOverridesOperation.TypeWalkKey(project, fqn, "/tmp/FileA.cs");
-        var fileB = GenerateOverridesOperation.TypeWalkKey(project, fqn, "/tmp/FileB.cs");
-
-        Assert.NotEqual(ordinary, fileA);
-        Assert.NotEqual(ordinary, fileB);
-        Assert.NotEqual(fileA, fileB);
-        Assert.Equal(fileA, GenerateOverridesOperation.TypeWalkKey(project, fqn, "/tmp/FileA.cs"));
-        Assert.Equal(ordinary, GenerateOverridesOperation.TypeWalkKey(project, fqn));
-    }
 
     [Fact]
     public void Validate_AllFilesTrue_WithLine_Throws()

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GenerateToStringOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Generate/GenerateToStringOperationTests.cs
@@ -3150,37 +3150,6 @@ public class GenerateToStringOperationTests
         Assert.Contains("fields", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
-    [Fact]
-    public void TypeWalkKey_IncludesProjectIdentity()
-    {
-        var projectA = ProjectId.CreateNewId();
-        var projectB = ProjectId.CreateNewId();
-        const string fqn = "global::TestApp.Widget";
-
-        var keyA = GenerateToStringOperation.TypeWalkKey(projectA, fqn);
-        var keyB = GenerateToStringOperation.TypeWalkKey(projectB, fqn);
-
-        Assert.NotEqual(keyA, keyB);
-        Assert.Equal(keyA, GenerateToStringOperation.TypeWalkKey(projectA, fqn));
-        Assert.NotEqual(keyA, GenerateToStringOperation.TypeWalkKey(projectA, "global::TestApp.Other"));
-    }
-
-    [Fact]
-    public void TypeWalkKey_FileLocalIdentity_DistinguishesSameFqn()
-    {
-        var project = ProjectId.CreateNewId();
-        const string fqn = "global::TestApp.Worker";
-
-        var ordinary = GenerateToStringOperation.TypeWalkKey(project, fqn);
-        var fileA = GenerateToStringOperation.TypeWalkKey(project, fqn, "/tmp/FileA.cs");
-        var fileB = GenerateToStringOperation.TypeWalkKey(project, fqn, "/tmp/FileB.cs");
-
-        Assert.NotEqual(ordinary, fileA);
-        Assert.NotEqual(ordinary, fileB);
-        Assert.NotEqual(fileA, fileB);
-        Assert.Equal(fileA, GenerateToStringOperation.TypeWalkKey(project, fqn, "/tmp/FileA.cs"));
-        Assert.Equal(ordinary, GenerateToStringOperation.TypeWalkKey(project, fqn));
-    }
 
     [Fact]
     public void Validate_AllFilesTrue_WithLine_Throws()

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Generate/ImplementAbstractOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Generate/ImplementAbstractOperationTests.cs
@@ -3947,37 +3947,6 @@ public class ImplementAbstractOperationTests
         Assert.Contains("members", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
-    [Fact]
-    public void TypeWalkKey_IncludesProjectIdentity()
-    {
-        var projectA = ProjectId.CreateNewId();
-        var projectB = ProjectId.CreateNewId();
-        const string fqn = "global::TestApp.Widget";
-
-        var keyA = ImplementAbstractOperation.TypeWalkKey(projectA, fqn);
-        var keyB = ImplementAbstractOperation.TypeWalkKey(projectB, fqn);
-
-        Assert.NotEqual(keyA, keyB);
-        Assert.Equal(keyA, ImplementAbstractOperation.TypeWalkKey(projectA, fqn));
-        Assert.NotEqual(keyA, ImplementAbstractOperation.TypeWalkKey(projectA, "global::TestApp.Other"));
-    }
-
-    [Fact]
-    public void TypeWalkKey_FileLocalIdentity_DistinguishesSameFqn()
-    {
-        var project = ProjectId.CreateNewId();
-        const string fqn = "global::TestApp.Worker";
-
-        var ordinary = ImplementAbstractOperation.TypeWalkKey(project, fqn);
-        var fileA = ImplementAbstractOperation.TypeWalkKey(project, fqn, "/tmp/FileA.cs");
-        var fileB = ImplementAbstractOperation.TypeWalkKey(project, fqn, "/tmp/FileB.cs");
-
-        Assert.NotEqual(ordinary, fileA);
-        Assert.NotEqual(ordinary, fileB);
-        Assert.NotEqual(fileA, fileB);
-        Assert.Equal(fileA, ImplementAbstractOperation.TypeWalkKey(project, fqn, "/tmp/FileA.cs"));
-        Assert.Equal(ordinary, ImplementAbstractOperation.TypeWalkKey(project, fqn));
-    }
 
     [Fact]
     public void Validate_AllFilesTrue_WithLine_Throws()

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Generate/ImplementInterfaceOperationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Generate/ImplementInterfaceOperationTests.cs
@@ -2503,37 +2503,6 @@ public class ImplementInterfaceOperationTests
         Assert.Contains("members", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
-    [Fact]
-    public void TypeWalkKey_IncludesProjectIdentity()
-    {
-        var projectA = ProjectId.CreateNewId();
-        var projectB = ProjectId.CreateNewId();
-        const string fqn = "global::TestApp.Widget";
-
-        var keyA = ImplementInterfaceOperation.TypeWalkKey(projectA, fqn);
-        var keyB = ImplementInterfaceOperation.TypeWalkKey(projectB, fqn);
-
-        Assert.NotEqual(keyA, keyB);
-        Assert.Equal(keyA, ImplementInterfaceOperation.TypeWalkKey(projectA, fqn));
-        Assert.NotEqual(keyA, ImplementInterfaceOperation.TypeWalkKey(projectA, "global::TestApp.Other"));
-    }
-
-    [Fact]
-    public void TypeWalkKey_FileLocalIdentity_DistinguishesSameFqn()
-    {
-        var project = ProjectId.CreateNewId();
-        const string fqn = "global::TestApp.Worker";
-
-        var ordinary = ImplementInterfaceOperation.TypeWalkKey(project, fqn);
-        var fileA = ImplementInterfaceOperation.TypeWalkKey(project, fqn, "/tmp/FileA.cs");
-        var fileB = ImplementInterfaceOperation.TypeWalkKey(project, fqn, "/tmp/FileB.cs");
-
-        Assert.NotEqual(ordinary, fileA);
-        Assert.NotEqual(ordinary, fileB);
-        Assert.NotEqual(fileA, fileB);
-        Assert.Equal(fileA, ImplementInterfaceOperation.TypeWalkKey(project, fqn, "/tmp/FileA.cs"));
-        Assert.Equal(ordinary, ImplementInterfaceOperation.TypeWalkKey(project, fqn));
-    }
 
     [Fact]
     public void Validate_AllFilesTrue_WithLine_Throws()

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Utilities/TypeWalkKeyHelpersTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Utilities/TypeWalkKeyHelpersTests.cs
@@ -1,0 +1,40 @@
+using Microsoft.CodeAnalysis;
+using RoslynMcp.Core.Refactoring.Utilities;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Refactoring.Utilities;
+
+public class TypeWalkKeyHelpersTests
+{
+    [Fact]
+    public void TypeWalkKey_IncludesProjectIdentity()
+    {
+        var projectA = ProjectId.CreateNewId();
+        var projectB = ProjectId.CreateNewId();
+        const string fqn = "global::TestApp.Widget";
+
+        var keyA = TypeWalkKeyHelpers.TypeWalkKey(projectA, fqn);
+        var keyB = TypeWalkKeyHelpers.TypeWalkKey(projectB, fqn);
+
+        Assert.NotEqual(keyA, keyB);
+        Assert.Equal(keyA, TypeWalkKeyHelpers.TypeWalkKey(projectA, fqn));
+        Assert.NotEqual(keyA, TypeWalkKeyHelpers.TypeWalkKey(projectA, "global::TestApp.Other"));
+    }
+
+    [Fact]
+    public void TypeWalkKey_FileLocalIdentity_DistinguishesSameFqn()
+    {
+        var project = ProjectId.CreateNewId();
+        const string fqn = "global::TestApp.Worker";
+
+        var ordinary = TypeWalkKeyHelpers.TypeWalkKey(project, fqn);
+        var fileA = TypeWalkKeyHelpers.TypeWalkKey(project, fqn, "/tmp/FileA.cs");
+        var fileB = TypeWalkKeyHelpers.TypeWalkKey(project, fqn, "/tmp/FileB.cs");
+
+        Assert.NotEqual(ordinary, fileA);
+        Assert.NotEqual(ordinary, fileB);
+        Assert.NotEqual(fileA, fileB);
+        Assert.Equal(fileA, TypeWalkKeyHelpers.TypeWalkKey(project, fqn, "/tmp/FileA.cs"));
+        Assert.Equal(ordinary, TypeWalkKeyHelpers.TypeWalkKey(project, fqn));
+    }
+}


### PR DESCRIPTION
## Summary
Extract shared `TypeWalkKeyHelpers.TypeWalkKey` (3 overloads: symbol / FQN / FQN+fileLocalDeclaringPath) into `RoslynMcp.Core.Refactoring.Utilities` and replace 5 byte-identical copies. Leave `GenerateConstructorOperation.TypeWalkKey` alone (simpler 2-overload, no file-local path).

Closes #1065

## Changes
- Add `TypeWalkKeyHelpers` with the three overloads (same docs/behavior as ImplementAbstract)
- Retarget call sites in ImplementAbstract / ImplementInterface / GenerateToString / GenerateOverrides / GenerateEqualsHashCode
- Add `TypeWalkKeyHelpersTests` (project identity + file-local distinction); remove duplicate TypeWalkKey facts from the five operation test files
- CHANGELOG Unreleased/Changed (#1065)
- `GenerateConstructorOperation` TypeWalkKey and its tests untouched

## Test plan
- [x] `dotnet test` focused filter: TypeWalkKeyHelpersTests + five Generate op test classes — Passed 735, Failed 0
- [ ] CI green on PR
- [ ] Confirm GenerateConstructor TypeWalkKey still present and Dependabot untouched