### PR TITLE
Extract ProjectXmlHelpers.SerializeProjectXml; replace 4 identical copies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- Extracted shared `ProjectXmlHelpers.SerializeProjectXml` and replaced 4 identical copies (`move_type_to_namespace` / `rename_file_to_match_type` / `rename_namespace` / `extract_base_class`) (#1069)
 - Extracted shared `TypeWalkKeyHelpers.TypeWalkKey` (3 overloads) and replaced 5 identical copies (`implement_abstract` / `implement_interface` / `generate_tostring` / `generate_overrides` / `generate_equals_hashcode`) (#1065)
 - Extracted shared `DocumentSourceFileFilter.FilterDocumentsBySourceFile` and replaced 9 identical copies (`make_static` / `make_non_static` / `generate_overrides` / `generate_equals_hashcode` / `generate_constructor` / `generate_tostring` / `implement_interface` / `implement_abstract` / `inline_constant`) (#1062)
 - Extracted shared `DocumentForTreeHelpers.GetDocumentForTree` and replaced 10 identical copies (`extract_base_class` / `generate_overrides` / `generate_equals_hashcode` / `generate_property` / `generate_constructor` / `generate_tostring` / `implement_interface` / `implement_abstract` / `push_members_down` / `pull_members_up`) (#1059)

--- a/src/RoslynMcp.Core/Refactoring/Extract/ExtractBaseClassOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/ExtractBaseClassOperation.cs
@@ -875,7 +875,7 @@ public sealed class ExtractBaseClassOperation : RefactoringOperationBase<Extract
                 "Project file has no root element; cannot add an explicit Compile item.");
         }
 
-        return SerializeProjectXml(document, projectXml);
+        return ProjectXmlHelpers.SerializeProjectXml(document, projectXml);
     }
 
     internal static string GetCompileIncludePath(string projectDirectory, string filePath)
@@ -993,27 +993,6 @@ public sealed class ExtractBaseClassOperation : RefactoringOperationBase<Extract
         return false;
     }
 
-    private static string SerializeProjectXml(XDocument document, string originalXml)
-    {
-        var writerSettings = new XmlWriterSettings
-        {
-            OmitXmlDeclaration = !originalXml.Contains("<?xml", StringComparison.OrdinalIgnoreCase),
-            NewLineHandling = NewLineHandling.Replace,
-            NewLineChars = originalXml.Contains("\r\n", StringComparison.Ordinal) ? "\r\n" : "\n",
-            Indent = false
-        };
-
-        using var writer = new StringWriter();
-        using (var xmlWriter = XmlWriter.Create(writer, writerSettings))
-        {
-            document.Save(xmlWriter);
-        }
-
-        var serialized = writer.ToString();
-        if (originalXml.EndsWith('\n') && !serialized.EndsWith('\n'))
-            serialized += writerSettings.NewLineChars;
-        return serialized;
-    }
 
     private static RefactoringResult CreatePreviewResult(
         Guid operationId,

--- a/src/RoslynMcp.Core/Refactoring/MoveTypeToNamespaceOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/MoveTypeToNamespaceOperation.cs
@@ -1214,7 +1214,7 @@ public sealed class MoveTypeToNamespaceOperation
         if (!changed)
             return projectXml;
 
-        return SerializeProjectXml(document, projectXml);
+        return ProjectXmlHelpers.SerializeProjectXml(document, projectXml);
     }
 
     private static bool TryUpdateGlobOrListAttribute(
@@ -1349,27 +1349,6 @@ public sealed class MoveTypeToNamespaceOperation
         return sb.ToString();
     }
 
-    private static string SerializeProjectXml(XDocument document, string originalXml)
-    {
-        var writerSettings = new System.Xml.XmlWriterSettings
-        {
-            OmitXmlDeclaration = !originalXml.Contains("<?xml", StringComparison.OrdinalIgnoreCase),
-            NewLineHandling = System.Xml.NewLineHandling.Replace,
-            NewLineChars = originalXml.Contains("\r\n", StringComparison.Ordinal) ? "\r\n" : "\n",
-            Indent = false
-        };
-
-        using var writer = new StringWriter();
-        using (var xmlWriter = System.Xml.XmlWriter.Create(writer, writerSettings))
-        {
-            document.Save(xmlWriter);
-        }
-
-        var serialized = writer.ToString();
-        if (originalXml.EndsWith('\n') && !serialized.EndsWith('\n'))
-            serialized += writerSettings.NewLineChars;
-        return serialized;
-    }
 
     private Contracts.Models.SymbolInfo CreateSymbolInfo(
         SymbolResolutionResult resolution,

--- a/src/RoslynMcp.Core/Refactoring/Rename/RenameFileToMatchTypeOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Rename/RenameFileToMatchTypeOperation.cs
@@ -8,6 +8,7 @@ using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
 using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
+using RoslynMcp.Core.Refactoring.Utilities;
 
 namespace RoslynMcp.Core.Refactoring.Rename;
 
@@ -667,7 +668,7 @@ public sealed class RenameFileToMatchTypeOperation : RefactoringOperationBase<Re
         if (!changed)
             return projectXml;
 
-        return SerializeProjectXml(document, projectXml);
+        return ProjectXmlHelpers.SerializeProjectXml(document, projectXml);
     }
 
     /// <summary>
@@ -771,27 +772,6 @@ public sealed class RenameFileToMatchTypeOperation : RefactoringOperationBase<Re
         return true;
     }
 
-    private static string SerializeProjectXml(XDocument document, string originalXml)
-    {
-        var writerSettings = new System.Xml.XmlWriterSettings
-        {
-            OmitXmlDeclaration = !originalXml.Contains("<?xml", StringComparison.OrdinalIgnoreCase),
-            NewLineHandling = System.Xml.NewLineHandling.Replace,
-            NewLineChars = originalXml.Contains("\r\n", StringComparison.Ordinal) ? "\r\n" : "\n",
-            Indent = false
-        };
-
-        using var writer = new StringWriter();
-        using (var xmlWriter = System.Xml.XmlWriter.Create(writer, writerSettings))
-        {
-            document.Save(xmlWriter);
-        }
-
-        var serialized = writer.ToString();
-        if (originalXml.EndsWith('\n') && !serialized.EndsWith('\n'))
-            serialized += writerSettings.NewLineChars;
-        return serialized;
-    }
 
     private static Dictionary<string, string> CollectProjectUpdates(IReadOnlyList<FileRenamePlan> plans)
     {

--- a/src/RoslynMcp.Core/Refactoring/Rename/RenameFileToMatchTypeOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Rename/RenameFileToMatchTypeOperation.cs
@@ -6,9 +6,9 @@ using RoslynMcp.Contracts.Errors;
 using RoslynMcp.Contracts.Models;
 using RoslynMcp.Core.FileSystem;
 using RoslynMcp.Core.Refactoring.Base;
+using RoslynMcp.Core.Refactoring.Utilities;
 using RoslynMcp.Core.Resolution;
 using RoslynMcp.Core.Workspace;
-using RoslynMcp.Core.Refactoring.Utilities;
 
 namespace RoslynMcp.Core.Refactoring.Rename;
 

--- a/src/RoslynMcp.Core/Refactoring/Rename/RenameNamespaceOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Rename/RenameNamespaceOperation.cs
@@ -1128,7 +1128,7 @@ public sealed class RenameNamespaceOperation : RefactoringOperationBase<RenameNa
         if (!changed)
             return projectXml;
 
-        return SerializeProjectXml(document, projectXml);
+        return ProjectXmlHelpers.SerializeProjectXml(document, projectXml);
     }
 
     /// <summary>
@@ -1578,27 +1578,6 @@ public sealed class RenameNamespaceOperation : RefactoringOperationBase<RenameNa
         return false;
     }
 
-    private static string SerializeProjectXml(XDocument document, string originalXml)
-    {
-        var writerSettings = new System.Xml.XmlWriterSettings
-        {
-            OmitXmlDeclaration = !originalXml.Contains("<?xml", StringComparison.OrdinalIgnoreCase),
-            NewLineHandling = System.Xml.NewLineHandling.Replace,
-            NewLineChars = originalXml.Contains("\r\n", StringComparison.Ordinal) ? "\r\n" : "\n",
-            Indent = false
-        };
-
-        using var writer = new StringWriter();
-        using (var xmlWriter = System.Xml.XmlWriter.Create(writer, writerSettings))
-        {
-            document.Save(xmlWriter);
-        }
-
-        var serialized = writer.ToString();
-        if (originalXml.EndsWith('\n') && !serialized.EndsWith('\n'))
-            serialized += writerSettings.NewLineChars;
-        return serialized;
-    }
 
     private sealed record FolderMove(string SourceFolder, string DestinationFolder);
 

--- a/src/RoslynMcp.Core/Refactoring/Utilities/ProjectXmlHelpers.cs
+++ b/src/RoslynMcp.Core/Refactoring/Utilities/ProjectXmlHelpers.cs
@@ -1,0 +1,43 @@
+using System.Xml;
+using System.Xml.Linq;
+
+namespace RoslynMcp.Core.Refactoring.Utilities;
+
+/// <summary>
+/// Shared .csproj XDocument re-serialization used by Move / Rename / Extract
+/// operations that rewrite project XML while preserving the original XML
+/// declaration and newline style. Same body as the four
+/// MoveTypeToNamespace / RenameFileToMatchType / RenameNamespace /
+/// ExtractBaseClass copies.
+/// </summary>
+internal static class ProjectXmlHelpers
+{
+    /// <summary>
+    /// Serializes <paramref name="document"/> with XmlWriterSettings matching
+    /// <paramref name="originalXml"/>: omit declaration when the original has
+    /// no <c>&lt;?xml</c>, Replace newline handling, LF vs CRLF from the
+    /// original, no indent, and restore a trailing newline when the original
+    /// ended with <c>\n</c> but the writer omitted it.
+    /// </summary>
+    internal static string SerializeProjectXml(XDocument document, string originalXml)
+    {
+        var writerSettings = new XmlWriterSettings
+        {
+            OmitXmlDeclaration = !originalXml.Contains("<?xml", StringComparison.OrdinalIgnoreCase),
+            NewLineHandling = NewLineHandling.Replace,
+            NewLineChars = originalXml.Contains("\r\n", StringComparison.Ordinal) ? "\r\n" : "\n",
+            Indent = false
+        };
+
+        using var writer = new StringWriter();
+        using (var xmlWriter = XmlWriter.Create(writer, writerSettings))
+        {
+            document.Save(xmlWriter);
+        }
+
+        var serialized = writer.ToString();
+        if (originalXml.EndsWith('\n') && !serialized.EndsWith('\n'))
+            serialized += writerSettings.NewLineChars;
+        return serialized;
+    }
+}

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Utilities/ProjectXmlHelpersTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Utilities/ProjectXmlHelpersTests.cs
@@ -1,0 +1,69 @@
+using System.Xml.Linq;
+using RoslynMcp.Core.Refactoring.Utilities;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Refactoring.Utilities;
+
+public class ProjectXmlHelpersTests
+{
+    private static readonly XDocument Sample = XDocument.Parse(
+        """
+        <Project Sdk="Microsoft.NET.Sdk">
+          <PropertyGroup>
+            <TargetFramework>net8.0</TargetFramework>
+          </PropertyGroup>
+        </Project>
+        """,
+        LoadOptions.PreserveWhitespace);
+
+    [Fact]
+    public void SerializeProjectXml_OmitsDeclaration_WhenOriginalLacksXmlHeader()
+    {
+        const string original =
+            "<Project Sdk=\"Microsoft.NET.Sdk\">\n  <PropertyGroup>\n    <TargetFramework>net8.0</TargetFramework>\n  </PropertyGroup>\n</Project>\n";
+
+        var serialized = ProjectXmlHelpers.SerializeProjectXml(Sample, original);
+
+        Assert.DoesNotContain("<?xml", serialized, StringComparison.OrdinalIgnoreCase);
+        Assert.StartsWith("<Project", serialized, StringComparison.Ordinal);
+        Assert.EndsWith("\n", serialized);
+        Assert.DoesNotContain("\r\n", serialized, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SerializeProjectXml_KeepsDeclaration_WhenOriginalHasXmlHeader()
+    {
+        const string original =
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<Project Sdk=\"Microsoft.NET.Sdk\">\n</Project>\n";
+
+        var serialized = ProjectXmlHelpers.SerializeProjectXml(Sample, original);
+
+        Assert.StartsWith("<?xml", serialized, StringComparison.OrdinalIgnoreCase);
+        Assert.EndsWith("\n", serialized);
+    }
+
+    [Fact]
+    public void SerializeProjectXml_UsesCrlf_WhenOriginalContainsCrlf()
+    {
+        const string original =
+            "<Project Sdk=\"Microsoft.NET.Sdk\">\r\n  <PropertyGroup>\r\n    <TargetFramework>net8.0</TargetFramework>\r\n  </PropertyGroup>\r\n</Project>\r\n";
+
+        var serialized = ProjectXmlHelpers.SerializeProjectXml(Sample, original);
+
+        Assert.Contains("\r\n", serialized, StringComparison.Ordinal);
+        Assert.EndsWith("\r\n", serialized);
+        Assert.DoesNotContain("<?xml", serialized, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void SerializeProjectXml_RestoresTrailingNewline_WhenWriterOmitsIt()
+    {
+        // Original ends with LF; ensure helper restores trailing newline when needed.
+        const string original = "<Project Sdk=\"Microsoft.NET.Sdk\"></Project>\n";
+
+        var serialized = ProjectXmlHelpers.SerializeProjectXml(Sample, original);
+
+        Assert.EndsWith("\n", serialized);
+        Assert.False(serialized.EndsWith("\r\n", StringComparison.Ordinal));
+    }
+}


### PR DESCRIPTION
## Summary

Extract shared `ProjectXmlHelpers.SerializeProjectXml` into `RoslynMcp.Core.Refactoring.Utilities` and replace 4 byte-identical `.csproj` re-serialization copies.

Closes #1069

## Changes

- Add `ProjectXmlHelpers.SerializeProjectXml` (omit/keep XML declaration, LF vs CRLF, trailing newline restore)
- Retarget `MoveTypeToNamespaceOperation`, `RenameFileToMatchTypeOperation`, `RenameNamespaceOperation`, `ExtractBaseClassOperation`
- Add `ProjectXmlHelpersTests` (declaration, CRLF, trailing newline)
- CHANGELOG Unreleased entry

## Behavior

No product behavior change — pure extract of identical private helpers.

## Test plan

- [x] `dotnet test --filter FullyQualifiedName~ProjectXmlHelpersTests` (4 passed)
- [ ] CI Build and Test + Code Quality green
- [ ] Copilot / Codex review clean