### PR TITLE
Extract DocumentForTreeHelpers.GetDocumentByFilePath; replace 2 identical copies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- Extracted shared `DocumentForTreeHelpers.GetDocumentByFilePath` and replaced 2 identical copies (`pull_members_up` / `push_members_down`) (#1071)
 - Extracted shared `ProjectXmlHelpers.SerializeProjectXml` and replaced 4 identical copies (`move_type_to_namespace` / `rename_file_to_match_type` / `rename_namespace` / `extract_base_class`) (#1069)
 - Extracted shared `TypeWalkKeyHelpers.TypeWalkKey` (3 overloads) and replaced 5 identical copies (`implement_abstract` / `implement_interface` / `generate_tostring` / `generate_overrides` / `generate_equals_hashcode`) (#1065)
 - Extracted shared `DocumentSourceFileFilter.FilterDocumentsBySourceFile` and replaced 9 identical copies (`make_static` / `make_non_static` / `generate_overrides` / `generate_equals_hashcode` / `generate_constructor` / `generate_tostring` / `implement_interface` / `implement_abstract` / `inline_constant`) (#1062)

--- a/src/RoslynMcp.Core/Refactoring/Hierarchy/PullMembersUpOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Hierarchy/PullMembersUpOperation.cs
@@ -1099,7 +1099,7 @@ public sealed class PullMembersUpOperation : RefactoringOperationBase<PullMember
         // when the target lives in the same file. Look up by file path
         // rather than treating the miss as a non-editable base.
         var targetDocument = solution.GetDocument(syntaxRef.SyntaxTree)
-            ?? GetDocumentByFilePath(solution, syntaxRef.SyntaxTree);
+            ?? DocumentForTreeHelpers.GetDocumentByFilePath(solution, syntaxRef.SyntaxTree);
         if (targetDocument == null)
         {
             throw new RefactoringException(
@@ -1137,20 +1137,6 @@ public sealed class PullMembersUpOperation : RefactoringOperationBase<PullMember
         return targetDocument.WithSyntaxRoot(targetRoot.ReplaceNode(currentTarget, newTarget)).Project.Solution;
     }
 
-    private static Document? GetDocumentByFilePath(Solution solution, SyntaxTree tree)
-    {
-        if (string.IsNullOrEmpty(tree.FilePath))
-            return null;
-
-        foreach (var id in solution.GetDocumentIdsWithFilePath(tree.FilePath))
-        {
-            var document = solution.GetDocument(id);
-            if (document != null)
-                return document;
-        }
-
-        return null;
-    }
 
     private static TypeDeclarationSyntax FindTypeInRoot(SyntaxNode root, string typeName, Microsoft.CodeAnalysis.Text.TextSpan preferredSpan)
     {

--- a/src/RoslynMcp.Core/Refactoring/Hierarchy/PushMembersDownOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Hierarchy/PushMembersDownOperation.cs
@@ -352,20 +352,6 @@ public sealed class PushMembersDownOperation : RefactoringOperationBase<PushMemb
     }
 
 
-    private static Document? GetDocumentByFilePath(Solution solution, SyntaxTree tree)
-    {
-        if (string.IsNullOrEmpty(tree.FilePath))
-            return null;
-
-        foreach (var id in solution.GetDocumentIdsWithFilePath(tree.FilePath))
-        {
-            var document = solution.GetDocument(id);
-            if (document != null)
-                return document;
-        }
-
-        return null;
-    }
 
 
     /// <summary>
@@ -452,7 +438,7 @@ public sealed class PushMembersDownOperation : RefactoringOperationBase<PushMemb
             }
 
             var updateDocument = sourceDocument.Project.Solution.GetDocument(update.Original.SyntaxTree)
-                ?? GetDocumentByFilePath(sourceDocument.Project.Solution, update.Original.SyntaxTree);
+                ?? DocumentForTreeHelpers.GetDocumentByFilePath(sourceDocument.Project.Solution, update.Original.SyntaxTree);
             if (updateDocument != null && updateDocument.Id == sourceDocument.Id)
             {
                 var rematchedOriginal = TypePartRematch.RematchTypeDeclaration(sourceRoot, update.Original)
@@ -1886,7 +1872,7 @@ public sealed class PushMembersDownOperation : RefactoringOperationBase<PushMemb
             // when a derived type lives in the same file. Look up by file path
             // rather than treating the miss as a non-editable target.
             var document = solution.GetDocument(group.Key)
-                ?? GetDocumentByFilePath(solution, group.Key);
+                ?? DocumentForTreeHelpers.GetDocumentByFilePath(solution, group.Key);
             if (document == null)
             {
                 throw new RefactoringException(

--- a/src/RoslynMcp.Core/Refactoring/Utilities/DocumentForTreeHelpers.cs
+++ b/src/RoslynMcp.Core/Refactoring/Utilities/DocumentForTreeHelpers.cs
@@ -6,8 +6,9 @@ namespace RoslynMcp.Core.Refactoring.Utilities;
 /// <summary>
 /// Shared SyntaxTree → Document lookup used by Generate / Hierarchy / Extract
 /// operations that need a declaring document for a type (GetDocument(tree), then
-/// FilePath fallback). Excludes GenerateMethodStub's nullable overload, which
-/// returns null instead of throwing.
+/// FilePath fallback), plus a nullable FilePath-only fallback used when
+/// GetDocument(tree) already missed. Excludes GenerateMethodStub's nullable
+/// overload, which returns null instead of throwing.
 /// </summary>
 internal static class DocumentForTreeHelpers
 {
@@ -38,5 +39,26 @@ internal static class DocumentForTreeHelpers
         throw new RefactoringException(
             ErrorCodes.DocumentNotEditable,
             $"Could not locate a declaring document for type '{typeName}'.");
+    }
+
+    /// <summary>
+    /// FilePath-only fallback: returns the first solution document whose path
+    /// matches <paramref name="tree"/>.FilePath, or null when FilePath is empty
+    /// or no document matches. Same body as the PullMembersUp / PushMembersDown
+    /// private copies (does not call GetDocument(tree)).
+    /// </summary>
+    internal static Document? GetDocumentByFilePath(Solution solution, SyntaxTree tree)
+    {
+        if (string.IsNullOrEmpty(tree.FilePath))
+            return null;
+
+        foreach (var id in solution.GetDocumentIdsWithFilePath(tree.FilePath))
+        {
+            var document = solution.GetDocument(id);
+            if (document != null)
+                return document;
+        }
+
+        return null;
     }
 }

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Utilities/DocumentForTreeHelpersTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Utilities/DocumentForTreeHelpersTests.cs
@@ -93,4 +93,70 @@ public class DocumentForTreeHelpersTests
         Assert.Equal(ErrorCodes.DocumentNotEditable, ex.ErrorCode);
         Assert.Contains("Ghost", ex.Message);
     }
+
+    [Fact]
+    public void GetDocumentByFilePath_ReturnsDocument_WhenFilePathMatches()
+    {
+        using var workspace = new AdhocWorkspace();
+        var project = workspace.AddProject("P", LanguageNames.CSharp);
+        var path = Path.Combine(Path.GetTempPath(), "roslyn-mcp-dbfp-" + Path.GetRandomFileName() + ".cs");
+        File.WriteAllText(path, "class C {}");
+        try
+        {
+            var document = workspace.AddDocument(project.Id, Path.GetFileName(path), SourceText.From("class C {}"))
+                .WithFilePath(path);
+            Assert.True(workspace.TryApplyChanges(document.Project.Solution));
+            document = workspace.CurrentSolution.GetDocument(document.Id)!;
+            Assert.Equal(path, document.FilePath);
+
+            // Separate parse tree with same FilePath — not the document's tree instance
+            var orphanTree = CSharpSyntaxTree.ParseText("class C {}", path: path);
+            Assert.Null(workspace.CurrentSolution.GetDocument(orphanTree));
+
+            var result = DocumentForTreeHelpers.GetDocumentByFilePath(
+                workspace.CurrentSolution, orphanTree);
+
+            Assert.NotNull(result);
+            Assert.Equal(document.Id, result!.Id);
+        }
+        finally
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void GetDocumentByFilePath_ReturnsNull_WhenFilePathEmpty()
+    {
+        using var workspace = new AdhocWorkspace();
+        _ = workspace.AddProject("P", LanguageNames.CSharp);
+
+        var orphanTree = CSharpSyntaxTree.ParseText("class Missing {}");
+        Assert.True(string.IsNullOrEmpty(orphanTree.FilePath));
+
+        var result = DocumentForTreeHelpers.GetDocumentByFilePath(
+            workspace.CurrentSolution, orphanTree);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetDocumentByFilePath_ReturnsNull_WhenFilePathHasNoMatchingDocument()
+    {
+        using var workspace = new AdhocWorkspace();
+        _ = workspace.AddProject("P", LanguageNames.CSharp);
+
+        var missingPath = Path.Combine(Path.GetTempPath(), "roslyn-mcp-dbfp-missing-" + Path.GetRandomFileName() + ".cs");
+        Assert.False(File.Exists(missingPath));
+        var orphanTree = CSharpSyntaxTree.ParseText("class Ghost {}", path: missingPath);
+        Assert.Null(workspace.CurrentSolution.GetDocument(orphanTree));
+        Assert.Empty(workspace.CurrentSolution.GetDocumentIdsWithFilePath(missingPath));
+
+        var result = DocumentForTreeHelpers.GetDocumentByFilePath(
+            workspace.CurrentSolution, orphanTree);
+
+        Assert.Null(result);
+    }
+
 }


### PR DESCRIPTION
## Summary

Extract shared `DocumentForTreeHelpers.GetDocumentByFilePath` into `RoslynMcp.Core.Refactoring.Utilities` and replace 2 byte-identical private copies.

Closes #1071

## Changes

- Add `DocumentForTreeHelpers.GetDocumentByFilePath` (nullable FilePath-only fallback)
- Retarget `PullMembersUpOperation`, `PushMembersDownOperation`
- Extend `DocumentForTreeHelpersTests` (match / empty / unmatched)
- CHANGELOG Unreleased entry

## Behavior

No product behavior change — pure extract of identical private helpers.

## Test plan

- [x] `dotnet test --filter FullyQualifiedName~DocumentForTreeHelpersTests` (7 passed)
- [ ] CI Build and Test + Code Quality green
- [ ] Copilot / Codex review clean
