### PR TITLE
Extract MemberDisplayHelpers.FormatIndexerParameterDisplay + DescribeMemberKind; replace 2 identical copies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- Extracted shared `MemberDisplayHelpers.FormatIndexerParameterDisplay` + `DescribeMemberKind` and replaced 2 identical copies (`implement_abstract` / `implement_interface`) (#1076)
 - Extracted shared `DocumentForTreeHelpers.GetDocumentByFilePath` and replaced 2 identical copies (`pull_members_up` / `push_members_down`) (#1071)
 - Extracted shared `ProjectXmlHelpers.SerializeProjectXml` and replaced 4 identical copies (`move_type_to_namespace` / `rename_file_to_match_type` / `rename_namespace` / `extract_base_class`) (#1069)
 - Extracted shared `TypeWalkKeyHelpers.TypeWalkKey` (3 overloads) and replaced 5 identical copies (`implement_abstract` / `implement_interface` / `generate_tostring` / `generate_overrides` / `generate_equals_hashcode`) (#1065)

--- a/src/RoslynMcp.Core/Refactoring/Generate/ImplementAbstractOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/ImplementAbstractOperation.cs
@@ -927,7 +927,7 @@ public sealed class ImplementAbstractOperation : RefactoringOperationBase<Implem
         if (member is not IPropertySymbol { IsIndexer: true } indexer)
             return false;
 
-        var withNames = $"this[{string.Join(", ", indexer.Parameters.Select(FormatIndexerParameterDisplay))}]";
+        var withNames = $"this[{string.Join(", ", indexer.Parameters.Select(MemberDisplayHelpers.FormatIndexerParameterDisplay))}]";
         var typesOnly = $"this[{string.Join(",", indexer.Parameters.Select(p => p.Type.ToDisplayString()))}]";
         var typesOnlySpaced = $"this[{string.Join(", ", indexer.Parameters.Select(p => p.Type.ToDisplayString()))}]";
         return requested.Contains(indexer.MetadataName)
@@ -936,18 +936,6 @@ public sealed class ImplementAbstractOperation : RefactoringOperationBase<Implem
             || requested.Contains(typesOnlySpaced);
     }
 
-    private static string FormatIndexerParameterDisplay(IParameterSymbol parameter)
-    {
-        var type = parameter.Type.ToDisplayString();
-        return parameter.RefKind switch
-        {
-            RefKind.Ref => $"ref {type} {parameter.Name}",
-            RefKind.Out => $"out {type} {parameter.Name}",
-            RefKind.In => $"in {type} {parameter.Name}",
-            RefKind.RefReadOnlyParameter => $"ref readonly {type} {parameter.Name}",
-            _ => $"{type} {parameter.Name}"
-        };
-    }
 
     private static List<MemberDeclarationSyntax> GenerateImplementations(
         List<ISymbol> members,
@@ -1646,9 +1634,9 @@ public sealed class ImplementAbstractOperation : RefactoringOperationBase<Implem
                     {
                         File = filePath,
                         ChangeType = ChangeKind.Modify,
-                        Description = $"Remove existing {DescribeMemberKind(existing)} '{existing.Name}' from {@params.TypeName}",
+                        Description = $"Remove existing {MemberDisplayHelpers.DescribeMemberKind(existing)} '{existing.Name}' from {@params.TypeName}",
                         BeforeSnippet = memberSyntax.NormalizeWhitespace().ToFullString(),
-                        AfterSnippet = $"// {DescribeMemberKind(existing)} removed"
+                        AfterSnippet = $"// {MemberDisplayHelpers.DescribeMemberKind(existing)} removed"
                     });
                 }
             }
@@ -1671,12 +1659,4 @@ public sealed class ImplementAbstractOperation : RefactoringOperationBase<Implem
         return $"Generate abstract members: {generated}; replace existing abstract members: {replaced}";
     }
 
-    private static string DescribeMemberKind(ISymbol member) => member switch
-    {
-        IMethodSymbol => "method",
-        IPropertySymbol { IsIndexer: true } => "indexer",
-        IPropertySymbol => "property",
-        IEventSymbol => "event",
-        _ => "member"
-    };
 }

--- a/src/RoslynMcp.Core/Refactoring/Generate/ImplementInterfaceOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/ImplementInterfaceOperation.cs
@@ -1021,7 +1021,7 @@ public sealed class ImplementInterfaceOperation : RefactoringOperationBase<Imple
         if (member is not IPropertySymbol { IsIndexer: true } indexer)
             return false;
 
-        var withNames = $"this[{string.Join(", ", indexer.Parameters.Select(FormatIndexerParameterDisplay))}]";
+        var withNames = $"this[{string.Join(", ", indexer.Parameters.Select(MemberDisplayHelpers.FormatIndexerParameterDisplay))}]";
         var typesOnly = $"this[{string.Join(",", indexer.Parameters.Select(p => p.Type.ToDisplayString()))}]";
         var typesOnlySpaced = $"this[{string.Join(", ", indexer.Parameters.Select(p => p.Type.ToDisplayString()))}]";
         return requested.Contains(indexer.MetadataName)
@@ -1030,18 +1030,6 @@ public sealed class ImplementInterfaceOperation : RefactoringOperationBase<Imple
             || requested.Contains(typesOnlySpaced);
     }
 
-    private static string FormatIndexerParameterDisplay(IParameterSymbol parameter)
-    {
-        var type = parameter.Type.ToDisplayString();
-        return parameter.RefKind switch
-        {
-            RefKind.Ref => $"ref {type} {parameter.Name}",
-            RefKind.Out => $"out {type} {parameter.Name}",
-            RefKind.In => $"in {type} {parameter.Name}",
-            RefKind.RefReadOnlyParameter => $"ref readonly {type} {parameter.Name}",
-            _ => $"{type} {parameter.Name}"
-        };
-    }
 
     /// <summary>
     /// Removes matched implementation declarations from every partial that
@@ -1371,9 +1359,9 @@ public sealed class ImplementInterfaceOperation : RefactoringOperationBase<Imple
                     {
                         File = filePath,
                         ChangeType = ChangeKind.Modify,
-                        Description = $"Remove existing {DescribeMemberKind(existing)} '{existing.Name}' from {@params.TypeName}",
+                        Description = $"Remove existing {MemberDisplayHelpers.DescribeMemberKind(existing)} '{existing.Name}' from {@params.TypeName}",
                         BeforeSnippet = memberSyntax.NormalizeWhitespace().ToFullString(),
-                        AfterSnippet = $"// {DescribeMemberKind(existing)} removed"
+                        AfterSnippet = $"// {MemberDisplayHelpers.DescribeMemberKind(existing)} removed"
                     });
                 }
             }
@@ -1397,12 +1385,4 @@ public sealed class ImplementInterfaceOperation : RefactoringOperationBase<Imple
         return $"Generate {interfaceName} members: {generated}; replace existing {interfaceName} members: {replaced}";
     }
 
-    private static string DescribeMemberKind(ISymbol member) => member switch
-    {
-        IMethodSymbol => "method",
-        IPropertySymbol { IsIndexer: true } => "indexer",
-        IPropertySymbol => "property",
-        IEventSymbol => "event",
-        _ => "member"
-    };
 }

--- a/src/RoslynMcp.Core/Refactoring/Utilities/MemberDisplayHelpers.cs
+++ b/src/RoslynMcp.Core/Refactoring/Utilities/MemberDisplayHelpers.cs
@@ -1,0 +1,41 @@
+using Microsoft.CodeAnalysis;
+
+namespace RoslynMcp.Core.Refactoring.Utilities;
+
+/// <summary>
+/// Shared member display strings used by ImplementAbstract /
+/// ImplementInterface for indexer parameter labels and pending-change
+/// member-kind wording. Same bodies as the two private copies.
+/// </summary>
+internal static class MemberDisplayHelpers
+{
+    /// <summary>
+    /// Formats an indexer parameter as <c>ref/out/in/ref readonly type name</c>
+    /// (or bare <c>type name</c>) for member-request matching display.
+    /// </summary>
+    internal static string FormatIndexerParameterDisplay(IParameterSymbol parameter)
+    {
+        var type = parameter.Type.ToDisplayString();
+        return parameter.RefKind switch
+        {
+            RefKind.Ref => $"ref {type} {parameter.Name}",
+            RefKind.Out => $"out {type} {parameter.Name}",
+            RefKind.In => $"in {type} {parameter.Name}",
+            RefKind.RefReadOnlyParameter => $"ref readonly {type} {parameter.Name}",
+            _ => $"{type} {parameter.Name}"
+        };
+    }
+
+    /// <summary>
+    /// Human-readable kind label for preview / pending-change descriptions:
+    /// method, indexer, property, event, or member.
+    /// </summary>
+    internal static string DescribeMemberKind(ISymbol member) => member switch
+    {
+        IMethodSymbol => "method",
+        IPropertySymbol { IsIndexer: true } => "indexer",
+        IPropertySymbol => "property",
+        IEventSymbol => "event",
+        _ => "member"
+    };
+}

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Utilities/MemberDisplayHelpersTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Utilities/MemberDisplayHelpersTests.cs
@@ -1,0 +1,72 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using RoslynMcp.Core.Refactoring.Utilities;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Refactoring.Utilities;
+
+public class MemberDisplayHelpersTests
+{
+    [Fact]
+    public void FormatIndexerParameterDisplay_FormatsRefKinds()
+    {
+        var compilation = Compile("""
+            class C
+            {
+                public void M(int x, ref int r, out int o, in int i, ref readonly int rr) { o = 0; }
+            }
+            """);
+        var type = compilation.GetTypeByMetadataName("C")!;
+        var method = type.GetMembers("M").OfType<IMethodSymbol>().Single();
+        var texts = method.Parameters.Select(MemberDisplayHelpers.FormatIndexerParameterDisplay).ToArray();
+
+        Assert.Equal("int x", texts[0]);
+        Assert.Equal("ref int r", texts[1]);
+        Assert.Equal("out int o", texts[2]);
+        Assert.Equal("in int i", texts[3]);
+        Assert.Equal("ref readonly int rr", texts[4]);
+    }
+
+    [Fact]
+    public void DescribeMemberKind_MapsKnownKinds()
+    {
+        var compilation = Compile("""
+            class C
+            {
+                public void M() { }
+                public int P { get; set; }
+                public int this[int i] => i;
+                public event System.Action E;
+            }
+            """);
+        var type = compilation.GetTypeByMetadataName("C")!;
+        var method = type.GetMembers("M").OfType<IMethodSymbol>().Single();
+        var property = type.GetMembers("P").OfType<IPropertySymbol>().Single();
+        var indexer = type.GetMembers().OfType<IPropertySymbol>().Single(p => p.IsIndexer);
+        var evt = type.GetMembers("E").OfType<IEventSymbol>().Single();
+
+        Assert.Equal("method", MemberDisplayHelpers.DescribeMemberKind(method));
+        Assert.Equal("property", MemberDisplayHelpers.DescribeMemberKind(property));
+        Assert.Equal("indexer", MemberDisplayHelpers.DescribeMemberKind(indexer));
+        Assert.Equal("event", MemberDisplayHelpers.DescribeMemberKind(evt));
+        Assert.Equal("member", MemberDisplayHelpers.DescribeMemberKind(type));
+    }
+
+    private static Compilation Compile(string source)
+    {
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var refs = new[]
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location),
+        };
+        var compilation = CSharpCompilation.Create(
+            "MemberDisplayHelpersTests",
+            new[] { tree },
+            refs,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        var diagnostics = compilation.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.True(diagnostics.Length == 0, string.Join("\n", diagnostics.Select(d => d.ToString())));
+        return compilation;
+    }
+}


### PR DESCRIPTION
## Summary
Extract shared `MemberDisplayHelpers.FormatIndexerParameterDisplay` + `MemberDisplayHelpers.DescribeMemberKind` into `RoslynMcp.Core.Refactoring.Utilities` and replace 2 identical private copies each in `ImplementAbstractOperation` / `ImplementInterfaceOperation`.

Closes #1076

## Changes
- New `MemberDisplayHelpers` (RefKind-aware indexer param display + member-kind labels)
- Retarget call sites; delete private copies
- Unit tests for RefKind prefixes and kind mapping
- CHANGELOG Unreleased / Changed

## Test plan
- [x] `dotnet test` filter `MemberDisplayHelpersTests`
- [ ] CI Build and Test + Code quality
- Dependabot untouched