### PR TITLE
Extract HierarchyConflictHelpers.HasConflict + SignaturesMatch + IndexerSignaturesMatch; replace 2 identical copies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- Extracted shared `HierarchyConflictHelpers.HasConflict` + `SignaturesMatch` + `IndexerSignaturesMatch` and replaced 2 identical copies (`pull_members_up` / `push_members_down`) (#1078)
 - Extracted shared `MemberDisplayHelpers.FormatIndexerParameterDisplay` + `DescribeMemberKind` and replaced 2 identical copies (`implement_abstract` / `implement_interface`) (#1076)
 - Extracted shared `DocumentForTreeHelpers.GetDocumentByFilePath` and replaced 2 identical copies (`pull_members_up` / `push_members_down`) (#1071)
 - Extracted shared `ProjectXmlHelpers.SerializeProjectXml` and replaced 4 identical copies (`move_type_to_namespace` / `rename_file_to_match_type` / `rename_namespace` / `extract_base_class`) (#1069)

--- a/src/RoslynMcp.Core/Refactoring/Hierarchy/PullMembersUpOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Hierarchy/PullMembersUpOperation.cs
@@ -547,7 +547,7 @@ public sealed class PullMembersUpOperation : RefactoringOperationBase<PullMember
                             : "Only methods, properties, indexers, and events can be pulled up as abstract members.");
             }
 
-            if (HasConflict(target, member.Symbol))
+            if (HierarchyConflictHelpers.HasConflict(target, member.Symbol))
             {
                 throw new RefactoringException(
                     ErrorCodes.ConflictsWithExistingMember,
@@ -569,69 +569,6 @@ public sealed class PullMembersUpOperation : RefactoringOperationBase<PullMember
                     $"Member '{member.Name}' depends on '{dependency}' which is not accessible from '{target.Name}'.");
             }
         }
-    }
-
-    private static bool HasConflict(INamedTypeSymbol target, ISymbol member)
-    {
-        foreach (var existing in target.GetMembers(member.Name))
-        {
-            if (existing.IsImplicitlyDeclared)
-                continue;
-
-            if (member is IMethodSymbol method && existing is IMethodSymbol existingMethod)
-            {
-                if (SignaturesMatch(method, existingMethod))
-                    return true;
-                continue;
-            }
-
-            if (member is IPropertySymbol { IsIndexer: true } indexer
-                && existing is IPropertySymbol { IsIndexer: true } existingIndexer)
-            {
-                if (IndexerSignaturesMatch(indexer, existingIndexer))
-                    return true;
-                continue;
-            }
-
-            return true;
-        }
-
-        return false;
-    }
-
-    private static bool SignaturesMatch(IMethodSymbol left, IMethodSymbol right)
-    {
-        if (left.Parameters.Length != right.Parameters.Length)
-            return false;
-
-        if (left.TypeParameters.Length != right.TypeParameters.Length)
-            return false;
-
-        for (var i = 0; i < left.Parameters.Length; i++)
-        {
-            if (!SymbolEqualityComparer.Default.Equals(left.Parameters[i].Type, right.Parameters[i].Type))
-                return false;
-            if (left.Parameters[i].RefKind != right.Parameters[i].RefKind)
-                return false;
-        }
-
-        return true;
-    }
-
-    private static bool IndexerSignaturesMatch(IPropertySymbol left, IPropertySymbol right)
-    {
-        if (left.Parameters.Length != right.Parameters.Length)
-            return false;
-
-        for (var i = 0; i < left.Parameters.Length; i++)
-        {
-            if (!SymbolEqualityComparer.Default.Equals(left.Parameters[i].Type, right.Parameters[i].Type))
-                return false;
-            if (left.Parameters[i].RefKind != right.Parameters[i].RefKind)
-                return false;
-        }
-
-        return true;
     }
 
     private static bool IsExplicitInterfaceIndexer(IPropertySymbol indexer, MemberDeclarationSyntax syntax) =>
@@ -738,7 +675,7 @@ public sealed class PullMembersUpOperation : RefactoringOperationBase<PullMember
 
             if (referenced is IMethodSymbol referencedMethod &&
                 member.Symbol is IMethodSymbol memberMethod &&
-                SignaturesMatch(referencedMethod, memberMethod) &&
+                HierarchyConflictHelpers.SignaturesMatch(referencedMethod, memberMethod) &&
                 referenced.Name == member.Name)
             {
                 continue;

--- a/src/RoslynMcp.Core/Refactoring/Hierarchy/PushMembersDownOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Hierarchy/PushMembersDownOperation.cs
@@ -975,7 +975,7 @@ public sealed class PushMembersDownOperation : RefactoringOperationBase<PushMemb
     /// </summary>
     internal static bool CanMoveMember(ISymbol member, INamedTypeSymbol target)
     {
-        if (HasConflict(target, member))
+        if (HierarchyConflictHelpers.HasConflict(target, member))
             return false;
 
         if (target.TypeKind == TypeKind.Interface && !IsInterfaceCompatible(member))
@@ -1051,69 +1051,6 @@ public sealed class PushMembersDownOperation : RefactoringOperationBase<PushMemb
         }
 
         return false;
-    }
-
-    private static bool HasConflict(INamedTypeSymbol target, ISymbol member)
-    {
-        foreach (var existing in target.GetMembers(member.Name))
-        {
-            if (existing.IsImplicitlyDeclared)
-                continue;
-
-            if (member is IMethodSymbol method && existing is IMethodSymbol existingMethod)
-            {
-                if (SignaturesMatch(method, existingMethod))
-                    return true;
-                continue;
-            }
-
-            if (member is IPropertySymbol { IsIndexer: true } indexer
-                && existing is IPropertySymbol { IsIndexer: true } existingIndexer)
-            {
-                if (IndexerSignaturesMatch(indexer, existingIndexer))
-                    return true;
-                continue;
-            }
-
-            return true;
-        }
-
-        return false;
-    }
-
-    private static bool SignaturesMatch(IMethodSymbol left, IMethodSymbol right)
-    {
-        if (left.Parameters.Length != right.Parameters.Length)
-            return false;
-
-        if (left.TypeParameters.Length != right.TypeParameters.Length)
-            return false;
-
-        for (var i = 0; i < left.Parameters.Length; i++)
-        {
-            if (!SymbolEqualityComparer.Default.Equals(left.Parameters[i].Type, right.Parameters[i].Type))
-                return false;
-            if (left.Parameters[i].RefKind != right.Parameters[i].RefKind)
-                return false;
-        }
-
-        return true;
-    }
-
-    private static bool IndexerSignaturesMatch(IPropertySymbol left, IPropertySymbol right)
-    {
-        if (left.Parameters.Length != right.Parameters.Length)
-            return false;
-
-        for (var i = 0; i < left.Parameters.Length; i++)
-        {
-            if (!SymbolEqualityComparer.Default.Equals(left.Parameters[i].Type, right.Parameters[i].Type))
-                return false;
-            if (left.Parameters[i].RefKind != right.Parameters[i].RefKind)
-                return false;
-        }
-
-        return true;
     }
 
     private static bool IsInterfaceCompatible(ISymbol member)

--- a/src/RoslynMcp.Core/Refactoring/Utilities/HierarchyConflictHelpers.cs
+++ b/src/RoslynMcp.Core/Refactoring/Utilities/HierarchyConflictHelpers.cs
@@ -1,0 +1,86 @@
+using Microsoft.CodeAnalysis;
+
+namespace RoslynMcp.Core.Refactoring.Utilities;
+
+/// <summary>
+/// Shared hierarchy member-conflict checks used by PullMembersUp /
+/// PushMembersDown. Same bodies as the two private copies.
+/// </summary>
+internal static class HierarchyConflictHelpers
+{
+    /// <summary>
+    /// True when <paramref name="target"/> already declares a non-implicit
+    /// member that conflicts with <paramref name="member"/> (same name;
+    /// methods/indexers only when signatures match; other kinds on name alone).
+    /// </summary>
+    internal static bool HasConflict(INamedTypeSymbol target, ISymbol member)
+    {
+        foreach (var existing in target.GetMembers(member.Name))
+        {
+            if (existing.IsImplicitlyDeclared)
+                continue;
+
+            if (member is IMethodSymbol method && existing is IMethodSymbol existingMethod)
+            {
+                if (SignaturesMatch(method, existingMethod))
+                    return true;
+                continue;
+            }
+
+            if (member is IPropertySymbol { IsIndexer: true } indexer
+                && existing is IPropertySymbol { IsIndexer: true } existingIndexer)
+            {
+                if (IndexerSignaturesMatch(indexer, existingIndexer))
+                    return true;
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// True when two methods share parameter count, type-parameter count,
+    /// parameter types, and <see cref="RefKind"/>.
+    /// </summary>
+    internal static bool SignaturesMatch(IMethodSymbol left, IMethodSymbol right)
+    {
+        if (left.Parameters.Length != right.Parameters.Length)
+            return false;
+
+        if (left.TypeParameters.Length != right.TypeParameters.Length)
+            return false;
+
+        for (var i = 0; i < left.Parameters.Length; i++)
+        {
+            if (!SymbolEqualityComparer.Default.Equals(left.Parameters[i].Type, right.Parameters[i].Type))
+                return false;
+            if (left.Parameters[i].RefKind != right.Parameters[i].RefKind)
+                return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// True when two indexers share parameter count, parameter types, and
+    /// <see cref="RefKind"/>.
+    /// </summary>
+    internal static bool IndexerSignaturesMatch(IPropertySymbol left, IPropertySymbol right)
+    {
+        if (left.Parameters.Length != right.Parameters.Length)
+            return false;
+
+        for (var i = 0; i < left.Parameters.Length; i++)
+        {
+            if (!SymbolEqualityComparer.Default.Equals(left.Parameters[i].Type, right.Parameters[i].Type))
+                return false;
+            if (left.Parameters[i].RefKind != right.Parameters[i].RefKind)
+                return false;
+        }
+
+        return true;
+    }
+}

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Utilities/HierarchyConflictHelpersTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Utilities/HierarchyConflictHelpersTests.cs
@@ -1,0 +1,257 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using RoslynMcp.Core.Refactoring.Utilities;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Refactoring.Utilities;
+
+public class HierarchyConflictHelpersTests
+{
+    [Fact]
+    public void SignaturesMatch_True_WhenParamCountTypeParamsAndRefKindsAlign()
+    {
+        var compilation = Compile("""
+            class C
+            {
+                public void M(int x, ref int y) { }
+                public void N(int a, ref int b) { }
+            }
+            """);
+        var type = compilation.GetTypeByMetadataName("C")!;
+        var m = type.GetMembers("M").OfType<IMethodSymbol>().Single();
+        var n = type.GetMembers("N").OfType<IMethodSymbol>().Single();
+
+        Assert.True(HierarchyConflictHelpers.SignaturesMatch(m, n));
+    }
+
+    [Fact]
+    public void SignaturesMatch_False_OnParamCountMismatch()
+    {
+        var compilation = Compile("""
+            class C
+            {
+                public void M(int x) { }
+                public void N(int x, int y) { }
+            }
+            """);
+        var type = compilation.GetTypeByMetadataName("C")!;
+        var m = type.GetMembers("M").OfType<IMethodSymbol>().Single();
+        var n = type.GetMembers("N").OfType<IMethodSymbol>().Single();
+
+        Assert.False(HierarchyConflictHelpers.SignaturesMatch(m, n));
+    }
+
+    [Fact]
+    public void SignaturesMatch_False_OnTypeParamCountMismatch()
+    {
+        var compilation = Compile("""
+            class C
+            {
+                public void M<T>(T x) { }
+                public void N(int x) { }
+            }
+            """);
+        var type = compilation.GetTypeByMetadataName("C")!;
+        var m = type.GetMembers("M").OfType<IMethodSymbol>().Single();
+        var n = type.GetMembers("N").OfType<IMethodSymbol>().Single();
+
+        Assert.False(HierarchyConflictHelpers.SignaturesMatch(m, n));
+    }
+
+    [Fact]
+    public void SignaturesMatch_False_OnRefKindMismatch()
+    {
+        var compilation = Compile("""
+            class C
+            {
+                public void M(ref int x) { }
+                public void N(out int x) { x = 0; }
+            }
+            """);
+        var type = compilation.GetTypeByMetadataName("C")!;
+        var m = type.GetMembers("M").OfType<IMethodSymbol>().Single();
+        var n = type.GetMembers("N").OfType<IMethodSymbol>().Single();
+
+        Assert.False(HierarchyConflictHelpers.SignaturesMatch(m, n));
+    }
+
+    [Fact]
+    public void SignaturesMatch_False_OnParameterTypeMismatch()
+    {
+        var compilation = Compile("""
+            class C
+            {
+                public void M(int x) { }
+                public void N(string x) { }
+            }
+            """);
+        var type = compilation.GetTypeByMetadataName("C")!;
+        var m = type.GetMembers("M").OfType<IMethodSymbol>().Single();
+        var n = type.GetMembers("N").OfType<IMethodSymbol>().Single();
+
+        Assert.False(HierarchyConflictHelpers.SignaturesMatch(m, n));
+    }
+
+    [Fact]
+    public void IndexerSignaturesMatch_True_WhenParamsAndRefKindsAlign()
+    {
+        var compilation = Compile("""
+            class A
+            {
+                public int this[int i, in int j] => i;
+            }
+            class B
+            {
+                public int this[int x, in int y] => x;
+            }
+            """);
+        var a = compilation.GetTypeByMetadataName("A")!;
+        var b = compilation.GetTypeByMetadataName("B")!;
+        var left = a.GetMembers().OfType<IPropertySymbol>().Single(p => p.IsIndexer);
+        var right = b.GetMembers().OfType<IPropertySymbol>().Single(p => p.IsIndexer);
+
+        Assert.True(HierarchyConflictHelpers.IndexerSignaturesMatch(left, right));
+    }
+
+    [Fact]
+    public void IndexerSignaturesMatch_False_OnParamCountOrRefKindMismatch()
+    {
+        var compilation = Compile("""
+            class A
+            {
+                public int this[int i] => i;
+            }
+            class B
+            {
+                public int this[int i, int j] => i;
+            }
+            class C
+            {
+                public int this[in int i] => i;
+            }
+            """);
+        var a = compilation.GetTypeByMetadataName("A")!;
+        var b = compilation.GetTypeByMetadataName("B")!;
+        var c = compilation.GetTypeByMetadataName("C")!;
+        var ia = a.GetMembers().OfType<IPropertySymbol>().Single(p => p.IsIndexer);
+        var ib = b.GetMembers().OfType<IPropertySymbol>().Single(p => p.IsIndexer);
+        var ic = c.GetMembers().OfType<IPropertySymbol>().Single(p => p.IsIndexer);
+
+        Assert.False(HierarchyConflictHelpers.IndexerSignaturesMatch(ia, ib));
+        Assert.False(HierarchyConflictHelpers.IndexerSignaturesMatch(ia, ic));
+    }
+
+    [Fact]
+    public void HasConflict_True_WhenSameMethodSignatureExists()
+    {
+        var compilation = Compile("""
+            class Base
+            {
+                public void M(int x) { }
+            }
+            class Derived
+            {
+                public void M(int y) { }
+            }
+            """);
+        var target = compilation.GetTypeByMetadataName("Base")!;
+        var member = compilation.GetTypeByMetadataName("Derived")!.GetMembers("M").OfType<IMethodSymbol>().Single();
+
+        Assert.True(HierarchyConflictHelpers.HasConflict(target, member));
+    }
+
+    [Fact]
+    public void HasConflict_False_WhenMethodOverloadDiffers()
+    {
+        var compilation = Compile("""
+            class Base
+            {
+                public void M(int x) { }
+            }
+            class Derived
+            {
+                public void M(string y) { }
+            }
+            """);
+        var target = compilation.GetTypeByMetadataName("Base")!;
+        var member = compilation.GetTypeByMetadataName("Derived")!.GetMembers("M").OfType<IMethodSymbol>().Single();
+
+        Assert.False(HierarchyConflictHelpers.HasConflict(target, member));
+    }
+
+    [Fact]
+    public void HasConflict_True_WhenSameIndexerSignatureExists()
+    {
+        var compilation = Compile("""
+            class Base
+            {
+                public int this[int i] => i;
+            }
+            class Derived
+            {
+                public int this[int j] => j;
+            }
+            """);
+        var target = compilation.GetTypeByMetadataName("Base")!;
+        var member = compilation.GetTypeByMetadataName("Derived")!
+            .GetMembers().OfType<IPropertySymbol>().Single(p => p.IsIndexer);
+
+        Assert.True(HierarchyConflictHelpers.HasConflict(target, member));
+    }
+
+    [Fact]
+    public void HasConflict_True_OnPropertyNameClash()
+    {
+        var compilation = Compile("""
+            class Base
+            {
+                public int P { get; set; }
+            }
+            class Derived
+            {
+                public string P { get; set; }
+            }
+            """);
+        var target = compilation.GetTypeByMetadataName("Base")!;
+        var member = compilation.GetTypeByMetadataName("Derived")!.GetMembers("P").OfType<IPropertySymbol>().Single();
+
+        Assert.True(HierarchyConflictHelpers.HasConflict(target, member));
+    }
+
+    [Fact]
+    public void HasConflict_False_WhenNoMatchingMember()
+    {
+        var compilation = Compile("""
+            class Base
+            {
+                public void Other() { }
+            }
+            class Derived
+            {
+                public void M() { }
+            }
+            """);
+        var target = compilation.GetTypeByMetadataName("Base")!;
+        var member = compilation.GetTypeByMetadataName("Derived")!.GetMembers("M").OfType<IMethodSymbol>().Single();
+
+        Assert.False(HierarchyConflictHelpers.HasConflict(target, member));
+    }
+
+    private static Compilation Compile(string source)
+    {
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var refs = new[]
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location),
+        };
+        var compilation = CSharpCompilation.Create(
+            "HierarchyConflictHelpersTests",
+            new[] { tree },
+            refs,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        var diagnostics = compilation.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.True(diagnostics.Length == 0, string.Join("\n", diagnostics.Select(d => d.ToString())));
+        return compilation;
+    }
+}


### PR DESCRIPTION
## Summary
Extract shared `HierarchyConflictHelpers.HasConflict` + `SignaturesMatch` + `IndexerSignaturesMatch` into `RoslynMcp.Core.Refactoring.Utilities` and replace 2 identical private copies in `PullMembersUpOperation` / `PushMembersDownOperation`. Retarget PullMembersUp dependency-walk `SignaturesMatch` call.

Closes #1078

## Changes
- New `HierarchyConflictHelpers` (HasConflict + SignaturesMatch + IndexerSignaturesMatch)
- Retarget call sites; delete private copies
- Unit tests for method/indexer signature match/mismatch and HasConflict true/false
- CHANGELOG Unreleased / Changed

## Test plan
- [x] `dotnet test` filter `HierarchyConflictHelpersTests` (12 passed)
- [ ] CI Build and Test + Code quality
- Dependabot untouched