### PR TITLE
Extract SymbolSelectionHelpers.ConfirmSymbolName + IsDefinitionLocation; replace 3 identical copies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- Extracted shared `SymbolSelectionHelpers.ConfirmSymbolName` + `IsDefinitionLocation` and replaced 3 identical copies (`make_static` / `make_non_static` / `safe_delete`) (#1081)
 - Extracted shared `HierarchyConflictHelpers.HasConflict` + `SignaturesMatch` + `IndexerSignaturesMatch` and replaced 2 identical copies (`pull_members_up` / `push_members_down`) (#1078)
 - Extracted shared `MemberDisplayHelpers.FormatIndexerParameterDisplay` + `DescribeMemberKind` and replaced 2 identical copies (`implement_abstract` / `implement_interface`) (#1076)
 - Extracted shared `DocumentForTreeHelpers.GetDocumentByFilePath` and replaced 2 identical copies (`pull_members_up` / `push_members_down`) (#1071)

--- a/src/RoslynMcp.Core/Refactoring/Extract/MakeNonStaticOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/MakeNonStaticOperation.cs
@@ -447,7 +447,6 @@ public sealed class MakeNonStaticOperation : RefactoringOperationBase<MakeNonSta
         }
     }
 
-
     private static bool PlanConflictsWithClaimedSpans(
         StaticPlan plan,
         HashSet<(SyntaxTree Tree, TextSpan Span)> claimedSpans)
@@ -505,13 +504,13 @@ public sealed class MakeNonStaticOperation : RefactoringOperationBase<MakeNonSta
             {
                 var declaredOnToken = semanticModel.GetDeclaredSymbol(tokenNode, cancellationToken);
                 if (declaredOnToken != null && DeclarationIdentifiers.IdentifierOverlaps(tokenNode, span))
-                    return ConfirmSymbolName(declaredOnToken, @params.SymbolName);
+                    return SymbolSelectionHelpers.ConfirmSymbolName(declaredOnToken, @params.SymbolName);
 
                 if (token.IsKind(SyntaxKind.IdentifierToken))
                 {
                     var tokenSymbol = semanticModel.GetSymbolInfo(tokenNode, cancellationToken).Symbol;
                     if (tokenSymbol != null)
-                        return ConfirmSymbolName(tokenSymbol, @params.SymbolName);
+                        return SymbolSelectionHelpers.ConfirmSymbolName(tokenSymbol, @params.SymbolName);
                 }
             }
         }
@@ -519,23 +518,11 @@ public sealed class MakeNonStaticOperation : RefactoringOperationBase<MakeNonSta
         var node = root.FindNode(span, getInnermostNodeForTie: true);
         var declared = semanticModel.GetDeclaredSymbol(node, cancellationToken);
         if (declared != null && DeclarationIdentifiers.IdentifierOverlaps(node, span))
-            return ConfirmSymbolName(declared, @params.SymbolName);
+            return SymbolSelectionHelpers.ConfirmSymbolName(declared, @params.SymbolName);
 
         throw new RefactoringException(
             ErrorCodes.SymbolNotFound,
             "No symbol found at the specified selection.");
-    }
-
-    private static ISymbol ConfirmSymbolName(ISymbol symbol, string? expectedName)
-    {
-        if (!string.IsNullOrWhiteSpace(expectedName) && symbol.Name != expectedName)
-        {
-            throw new RefactoringException(
-                ErrorCodes.SymbolNotFound,
-                $"No symbol named '{expectedName}' found at the specified selection.");
-        }
-
-        return symbol;
     }
 
     private static IMethodSymbol NormalizeMethodSymbol(ISymbol symbol)
@@ -759,7 +746,7 @@ public sealed class MakeNonStaticOperation : RefactoringOperationBase<MakeNonSta
                 if (location.Document == null || !location.Location.IsInSource)
                     continue;
 
-                if (IsDefinitionLocation(referencedSymbol.Definition, location.Location))
+                if (SymbolSelectionHelpers.IsDefinitionLocation(referencedSymbol.Definition, location.Location))
                     continue;
 
                 DocumentEditableHelpers.ValidateDocumentIsEditable(location.Document, Context.Workspace);
@@ -1239,14 +1226,6 @@ public sealed class MakeNonStaticOperation : RefactoringOperationBase<MakeNonSta
             SyntaxKind.SimpleMemberAccessExpression,
             receiver,
             (SimpleNameSyntax)name.WithoutTrivia());
-    }
-
-    private static bool IsDefinitionLocation(ISymbol symbol, Location location)
-    {
-        return symbol.Locations.Any(definition =>
-            definition.IsInSource &&
-            definition.SourceTree == location.SourceTree &&
-            definition.SourceSpan == location.SourceSpan);
     }
 
     private static async Task<Solution> ApplyPlanAsync(

--- a/src/RoslynMcp.Core/Refactoring/Extract/MakeStaticOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/MakeStaticOperation.cs
@@ -440,7 +440,6 @@ public sealed class MakeStaticOperation : RefactoringOperationBase<MakeStaticPar
         }
     }
 
-
     private static bool PlanConflictsWithClaimedSpans(
         StaticPlan plan,
         HashSet<(SyntaxTree Tree, TextSpan Span)> claimedSpans)
@@ -498,13 +497,13 @@ public sealed class MakeStaticOperation : RefactoringOperationBase<MakeStaticPar
             {
                 var declaredOnToken = semanticModel.GetDeclaredSymbol(tokenNode, cancellationToken);
                 if (declaredOnToken != null && DeclarationIdentifiers.IdentifierOverlaps(tokenNode, span))
-                    return ConfirmSymbolName(declaredOnToken, @params.SymbolName);
+                    return SymbolSelectionHelpers.ConfirmSymbolName(declaredOnToken, @params.SymbolName);
 
                 if (token.IsKind(SyntaxKind.IdentifierToken))
                 {
                     var tokenSymbol = semanticModel.GetSymbolInfo(tokenNode, cancellationToken).Symbol;
                     if (tokenSymbol != null)
-                        return ConfirmSymbolName(tokenSymbol, @params.SymbolName);
+                        return SymbolSelectionHelpers.ConfirmSymbolName(tokenSymbol, @params.SymbolName);
                 }
             }
         }
@@ -512,23 +511,11 @@ public sealed class MakeStaticOperation : RefactoringOperationBase<MakeStaticPar
         var node = root.FindNode(span, getInnermostNodeForTie: true);
         var declared = semanticModel.GetDeclaredSymbol(node, cancellationToken);
         if (declared != null && DeclarationIdentifiers.IdentifierOverlaps(node, span))
-            return ConfirmSymbolName(declared, @params.SymbolName);
+            return SymbolSelectionHelpers.ConfirmSymbolName(declared, @params.SymbolName);
 
         throw new RefactoringException(
             ErrorCodes.SymbolNotFound,
             "No symbol found at the specified selection.");
-    }
-
-    private static ISymbol ConfirmSymbolName(ISymbol symbol, string? expectedName)
-    {
-        if (!string.IsNullOrWhiteSpace(expectedName) && symbol.Name != expectedName)
-        {
-            throw new RefactoringException(
-                ErrorCodes.SymbolNotFound,
-                $"No symbol named '{expectedName}' found at the specified selection.");
-        }
-
-        return symbol;
     }
 
     private static IMethodSymbol NormalizeMethodSymbol(ISymbol symbol)
@@ -912,7 +899,7 @@ public sealed class MakeStaticOperation : RefactoringOperationBase<MakeStaticPar
                 if (location.Document == null || !location.Location.IsInSource)
                     continue;
 
-                if (IsDefinitionLocation(referencedSymbol.Definition, location.Location))
+                if (SymbolSelectionHelpers.IsDefinitionLocation(referencedSymbol.Definition, location.Location))
                     continue;
 
                 DocumentEditableHelpers.ValidateDocumentIsEditable(location.Document, Context.Workspace);
@@ -1008,14 +995,6 @@ public sealed class MakeStaticOperation : RefactoringOperationBase<MakeStaticPar
             SyntaxKind.SimpleMemberAccessExpression,
             typeSyntax,
             (SimpleNameSyntax)name.WithoutTrivia());
-    }
-
-    private static bool IsDefinitionLocation(ISymbol symbol, Location location)
-    {
-        return symbol.Locations.Any(definition =>
-            definition.IsInSource &&
-            definition.SourceTree == location.SourceTree &&
-            definition.SourceSpan == location.SourceSpan);
     }
 
     private static async Task<Solution> ApplyPlanAsync(

--- a/src/RoslynMcp.Core/Refactoring/Extract/SafeDeleteOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Extract/SafeDeleteOperation.cs
@@ -154,13 +154,13 @@ public sealed class SafeDeleteOperation : RefactoringOperationBase<SafeDeletePar
             {
                 var declaredOnToken = semanticModel.GetDeclaredSymbol(tokenNode, cancellationToken);
                 if (declaredOnToken != null && IdentifierOverlaps(tokenNode, span))
-                    return ConfirmSymbolName(declaredOnToken, @params.SymbolName);
+                    return SymbolSelectionHelpers.ConfirmSymbolName(declaredOnToken, @params.SymbolName);
 
                 if (token.IsKind(SyntaxKind.IdentifierToken))
                 {
                     var tokenSymbol = semanticModel.GetSymbolInfo(tokenNode, cancellationToken).Symbol;
                     if (tokenSymbol != null)
-                        return ConfirmSymbolName(tokenSymbol, @params.SymbolName);
+                        return SymbolSelectionHelpers.ConfirmSymbolName(tokenSymbol, @params.SymbolName);
                 }
             }
         }
@@ -168,23 +168,11 @@ public sealed class SafeDeleteOperation : RefactoringOperationBase<SafeDeletePar
         var node = root.FindNode(span, getInnermostNodeForTie: true);
         var declared = semanticModel.GetDeclaredSymbol(node, cancellationToken);
         if (declared != null && IdentifierOverlaps(node, span))
-            return ConfirmSymbolName(declared, @params.SymbolName);
+            return SymbolSelectionHelpers.ConfirmSymbolName(declared, @params.SymbolName);
 
         throw new RefactoringException(
             ErrorCodes.SymbolNotFound,
             "No symbol found at the specified selection.");
-    }
-
-    private static ISymbol ConfirmSymbolName(ISymbol symbol, string? expectedName)
-    {
-        if (!string.IsNullOrWhiteSpace(expectedName) && symbol.Name != expectedName)
-        {
-            throw new RefactoringException(
-                ErrorCodes.SymbolNotFound,
-                $"No symbol named '{expectedName}' found at the specified selection.");
-        }
-
-        return symbol;
     }
 
     private static bool IdentifierOverlaps(SyntaxNode node, TextSpan span)
@@ -299,7 +287,7 @@ public sealed class SafeDeleteOperation : RefactoringOperationBase<SafeDeletePar
                 if (location.Document == null || !location.Location.IsInSource)
                     continue;
 
-                if (IsDefinitionLocation(referencedSymbol.Definition, location.Location))
+                if (SymbolSelectionHelpers.IsDefinitionLocation(referencedSymbol.Definition, location.Location))
                     continue;
 
                 var lineSpan = location.Location.GetLineSpan();
@@ -401,14 +389,6 @@ public sealed class SafeDeleteOperation : RefactoringOperationBase<SafeDeletePar
     }
 
     private static bool CanSafelyDelete(IReadOnlyList<UsageLocation> usages) => usages.Count == 0;
-
-    private static bool IsDefinitionLocation(ISymbol symbol, Location location)
-    {
-        return symbol.Locations.Any(definition =>
-            definition.IsInSource &&
-            definition.SourceTree == location.SourceTree &&
-            definition.SourceSpan == location.SourceSpan);
-    }
 
     private static string? GetSnippet(Location location)
     {

--- a/src/RoslynMcp.Core/Refactoring/Utilities/SymbolSelectionHelpers.cs
+++ b/src/RoslynMcp.Core/Refactoring/Utilities/SymbolSelectionHelpers.cs
@@ -1,0 +1,41 @@
+using Microsoft.CodeAnalysis;
+using RoslynMcp.Contracts.Errors;
+
+namespace RoslynMcp.Core.Refactoring.Utilities;
+
+/// <summary>
+/// Shared selected-symbol confirmation and definition-location checks used by
+/// MakeStatic / MakeNonStatic / SafeDelete. Same bodies as the three private copies.
+/// </summary>
+internal static class SymbolSelectionHelpers
+{
+    /// <summary>
+    /// Returns <paramref name="symbol"/> when <paramref name="expectedName"/> is
+    /// null/whitespace or equals <see cref="ISymbol.Name"/>; otherwise throws
+    /// <see cref="RefactoringException"/> with <see cref="ErrorCodes.SymbolNotFound"/>.
+    /// </summary>
+    internal static ISymbol ConfirmSymbolName(ISymbol symbol, string? expectedName)
+    {
+        if (!string.IsNullOrWhiteSpace(expectedName) && symbol.Name != expectedName)
+        {
+            throw new RefactoringException(
+                ErrorCodes.SymbolNotFound,
+                $"No symbol named '{expectedName}' found at the specified selection.");
+        }
+
+        return symbol;
+    }
+
+    /// <summary>
+    /// True when any source location of <paramref name="symbol"/> shares the same
+    /// <see cref="Location.SourceTree"/> and <see cref="Location.SourceSpan"/> as
+    /// <paramref name="location"/>.
+    /// </summary>
+    internal static bool IsDefinitionLocation(ISymbol symbol, Location location)
+    {
+        return symbol.Locations.Any(definition =>
+            definition.IsInSource &&
+            definition.SourceTree == location.SourceTree &&
+            definition.SourceSpan == location.SourceSpan);
+    }
+}

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Utilities/SymbolSelectionHelpersTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Utilities/SymbolSelectionHelpersTests.cs
@@ -1,0 +1,109 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using RoslynMcp.Contracts.Errors;
+using RoslynMcp.Core.Refactoring;
+using RoslynMcp.Core.Refactoring.Utilities;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Refactoring.Utilities;
+
+public class SymbolSelectionHelpersTests
+{
+    [Fact]
+    public void ConfirmSymbolName_ReturnsSymbol_WhenExpectedNameNullOrWhitespace()
+    {
+        var compilation = Compile("""
+            class C
+            {
+                public void M() { }
+            }
+            """);
+        var method = compilation.GetTypeByMetadataName("C")!.GetMembers("M").OfType<IMethodSymbol>().Single();
+
+        Assert.Same(method, SymbolSelectionHelpers.ConfirmSymbolName(method, null));
+        Assert.Same(method, SymbolSelectionHelpers.ConfirmSymbolName(method, ""));
+        Assert.Same(method, SymbolSelectionHelpers.ConfirmSymbolName(method, "   "));
+    }
+
+    [Fact]
+    public void ConfirmSymbolName_ReturnsSymbol_WhenExpectedNameMatches()
+    {
+        var compilation = Compile("""
+            class C
+            {
+                public void M() { }
+            }
+            """);
+        var method = compilation.GetTypeByMetadataName("C")!.GetMembers("M").OfType<IMethodSymbol>().Single();
+
+        Assert.Same(method, SymbolSelectionHelpers.ConfirmSymbolName(method, "M"));
+    }
+
+    [Fact]
+    public void ConfirmSymbolName_Throws_WhenExpectedNameDiffers()
+    {
+        var compilation = Compile("""
+            class C
+            {
+                public void M() { }
+            }
+            """);
+        var method = compilation.GetTypeByMetadataName("C")!.GetMembers("M").OfType<IMethodSymbol>().Single();
+
+        var ex = Assert.Throws<RefactoringException>(() =>
+            SymbolSelectionHelpers.ConfirmSymbolName(method, "Other"));
+        Assert.Equal(ErrorCodes.SymbolNotFound, ex.ErrorCode);
+        Assert.Contains("Other", ex.Message);
+    }
+
+    [Fact]
+    public void IsDefinitionLocation_True_WhenSourceTreeAndSpanMatch()
+    {
+        var compilation = Compile("""
+            class C
+            {
+                public void M() { }
+            }
+            """);
+        var method = compilation.GetTypeByMetadataName("C")!.GetMembers("M").OfType<IMethodSymbol>().Single();
+        var location = method.Locations.Single(l => l.IsInSource);
+
+        Assert.True(SymbolSelectionHelpers.IsDefinitionLocation(method, location));
+    }
+
+    [Fact]
+    public void IsDefinitionLocation_False_WhenSourceSpanDiffers()
+    {
+        var compilation = Compile("""
+            class C
+            {
+                public void M() { }
+                public void N() { }
+            }
+            """);
+        var type = compilation.GetTypeByMetadataName("C")!;
+        var m = type.GetMembers("M").OfType<IMethodSymbol>().Single();
+        var n = type.GetMembers("N").OfType<IMethodSymbol>().Single();
+        var nLocation = n.Locations.Single(l => l.IsInSource);
+
+        Assert.False(SymbolSelectionHelpers.IsDefinitionLocation(m, nLocation));
+    }
+
+    private static Compilation Compile(string source)
+    {
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var refs = new[]
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location),
+        };
+        var compilation = CSharpCompilation.Create(
+            "SymbolSelectionHelpersTests",
+            new[] { tree },
+            refs,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        var diagnostics = compilation.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.True(diagnostics.Length == 0, string.Join("\n", diagnostics.Select(d => d.ToString())));
+        return compilation;
+    }
+}

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Utilities/SymbolSelectionHelpersTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Utilities/SymbolSelectionHelpersTests.cs
@@ -89,6 +89,41 @@ public class SymbolSelectionHelpersTests
         Assert.False(SymbolSelectionHelpers.IsDefinitionLocation(m, nLocation));
     }
 
+    [Fact]
+    public void IsDefinitionLocation_False_WhenSourceTreeDiffers()
+    {
+        var tree1 = CSharpSyntaxTree.ParseText("""
+            class C
+            {
+                public void M() { }
+            }
+            """);
+        var tree2 = CSharpSyntaxTree.ParseText("""
+            class D
+            {
+                public void M() { }
+            }
+            """);
+        var refs = new[]
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location),
+        };
+        var compilation = CSharpCompilation.Create(
+            "SymbolSelectionHelpersTests_Trees",
+            new[] { tree1, tree2 },
+            refs,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        var diagnostics = compilation.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.True(diagnostics.Length == 0, string.Join("\n", diagnostics.Select(d => d.ToString())));
+
+        var m = compilation.GetTypeByMetadataName("C")!.GetMembers("M").OfType<IMethodSymbol>().Single();
+        var other = compilation.GetTypeByMetadataName("D")!.GetMembers("M").OfType<IMethodSymbol>().Single();
+        var otherLocation = other.Locations.Single(l => l.IsInSource);
+
+        Assert.False(SymbolSelectionHelpers.IsDefinitionLocation(m, otherLocation));
+    }
+
     private static Compilation Compile(string source)
     {
         var tree = CSharpSyntaxTree.ParseText(source);


### PR DESCRIPTION
## Summary
Extract shared `SymbolSelectionHelpers.ConfirmSymbolName` + `IsDefinitionLocation` into `RoslynMcp.Core.Refactoring.Utilities` and replace 3 identical private copies in `MakeStaticOperation` / `MakeNonStaticOperation` / `SafeDeleteOperation`.

Closes #1081

## Changes
- New `SymbolSelectionHelpers` (ConfirmSymbolName + IsDefinitionLocation)
- Retarget call sites; delete private copies
- Unit tests for match / mismatch throw / whitespace passthrough and definition location true/false
- CHANGELOG Unreleased / Changed

## Test plan
- [x] `dotnet test` filter `SymbolSelectionHelpersTests` (5 passed)
- [ ] CI Build and Test + Code quality
- Dependabot untouched