### PR TITLE
Extract SyntaxIdentifierValidation.NormalizeIdentifier; replace 3 identical copies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- Extracted shared `SyntaxIdentifierValidation.NormalizeIdentifier` and replaced 3 identical copies (`inline_constant` / `add_parameter` / `remove_parameter`) (#1084)
 - Extracted shared `SymbolSelectionHelpers.ConfirmSymbolName` + `IsDefinitionLocation` and replaced 3 identical copies (`make_static` / `make_non_static` / `safe_delete`) (#1081)
 - Extracted shared `HierarchyConflictHelpers.HasConflict` + `SignaturesMatch` + `IndexerSignaturesMatch` and replaced 2 identical copies (`pull_members_up` / `push_members_down`) (#1078)
 - Extracted shared `MemberDisplayHelpers.FormatIndexerParameterDisplay` + `DescribeMemberKind` and replaced 2 identical copies (`implement_abstract` / `implement_interface`) (#1076)

--- a/src/RoslynMcp.Core/Refactoring/Inline/InlineConstantOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Inline/InlineConstantOperation.cs
@@ -963,11 +963,8 @@ public sealed class InlineConstantOperation : RefactoringOperationBase<InlineCon
 
     private static bool NamesMatch(SyntaxToken identifier, string constantName)
     {
-        return identifier.ValueText == NormalizeIdentifier(constantName);
+        return identifier.ValueText == SyntaxIdentifierValidation.NormalizeIdentifier(constantName);
     }
-
-    private static string NormalizeIdentifier(string name) =>
-        name.StartsWith('@') && name.Length > 1 ? name[1..] : name;
 
     private sealed class InlineConstantRewriter : CSharpSyntaxRewriter
     {

--- a/src/RoslynMcp.Core/Refactoring/Signature/AddParameterOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Signature/AddParameterOperation.cs
@@ -94,7 +94,7 @@ public sealed class AddParameterOperation : RefactoringOperationBase<AddParamete
         var methodSymbol = semanticModel.GetDeclaredSymbol(methodDecl, cancellationToken)
             ?? throw new RefactoringException(ErrorCodes.RoslynError, "Could not resolve method symbol.");
 
-        if (methodSymbol.Parameters.Any(p => p.Name == NormalizeIdentifier(@params.ParameterName)))
+        if (methodSymbol.Parameters.Any(p => p.Name == SyntaxIdentifierValidation.NormalizeIdentifier(@params.ParameterName)))
         {
             throw new RefactoringException(
                 ErrorCodes.ParameterAlreadyExists,
@@ -128,7 +128,7 @@ public sealed class AddParameterOperation : RefactoringOperationBase<AddParamete
             DocumentEditableHelpers.ValidateDocumentIsEditable(callSite.Document, Context.Workspace);
 
         var declarationDefault = attachDefaultToDeclaration ? @params.DefaultValue : null;
-        var newParameter = CreateParameter(NormalizeIdentifier(@params.ParameterName), @params.ParameterType, declarationDefault);
+        var newParameter = CreateParameter(SyntaxIdentifierValidation.NormalizeIdentifier(@params.ParameterName), @params.ParameterType, declarationDefault);
         var appending = insertIndex >= methodSymbol.Parameters.Length;
 
         var newSolution = await ApplyChangesAsync(
@@ -350,7 +350,7 @@ public sealed class AddParameterOperation : RefactoringOperationBase<AddParamete
     {
         var hypothetical = original.Parameters.ToList();
         hypothetical.Insert(insertIndex, CreateParameter(
-            NormalizeIdentifier(@params.ParameterName),
+            SyntaxIdentifierValidation.NormalizeIdentifier(@params.ParameterName),
             @params.ParameterType,
             attachDefaultToDeclaration ? @params.DefaultValue : null));
 
@@ -624,7 +624,7 @@ public sealed class AddParameterOperation : RefactoringOperationBase<AddParamete
         if (useNamedInsertion && newArg.NameColon == null)
         {
             newArg = newArg.WithNameColon(
-                SyntaxFactory.NameColon(SyntaxFactory.IdentifierName(NormalizeIdentifier(parameterName))));
+                SyntaxFactory.NameColon(SyntaxFactory.IdentifierName(SyntaxIdentifierValidation.NormalizeIdentifier(parameterName))));
         }
 
         var namedOriginal = new Dictionary<string, ArgumentSyntax>();
@@ -850,9 +850,6 @@ public sealed class AddParameterOperation : RefactoringOperationBase<AddParamete
     private static bool IsOptional(ParameterSyntax parameter) =>
         parameter.Default != null;
 
-
-    private static string NormalizeIdentifier(string name) =>
-        name.StartsWith('@') && name.Length > 1 ? name[1..] : name;
 
     private static SeparatedSyntaxList<T> SeparatedWithSpaces<T>(IReadOnlyList<T> nodes)
         where T : SyntaxNode

--- a/src/RoslynMcp.Core/Refactoring/Signature/RemoveParameterOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Signature/RemoveParameterOperation.cs
@@ -302,7 +302,7 @@ public sealed class RemoveParameterOperation : RefactoringOperationBase<RemovePa
 
     internal static IParameterSymbol FindParameter(IMethodSymbol method, string name)
     {
-        var normalized = NormalizeIdentifier(name);
+        var normalized = SyntaxIdentifierValidation.NormalizeIdentifier(name);
         var parameter = method.Parameters.FirstOrDefault(p => p.Name == normalized);
         if (parameter != null)
             return parameter;
@@ -762,9 +762,6 @@ public sealed class RemoveParameterOperation : RefactoringOperationBase<RemovePa
         return true;
     }
 
-
-    private static string NormalizeIdentifier(string name) =>
-        name.StartsWith('@') && name.Length > 1 ? name[1..] : name;
 
     private static string GetParameterTypeDisplay(IParameterSymbol parameter)
     {

--- a/src/RoslynMcp.Core/Refactoring/Utilities/SyntaxIdentifierValidation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Utilities/SyntaxIdentifierValidation.cs
@@ -3,8 +3,9 @@ using Microsoft.CodeAnalysis.CSharp;
 namespace RoslynMcp.Core.Refactoring.Utilities;
 
 /// <summary>
-/// Shared SyntaxFacts-based identifier validation used by inline_constant,
-/// generate_method_stub / generate_property, add_parameter, and
+/// Shared SyntaxFacts-based identifier validation and <c>@</c>-prefix
+/// normalization used by inline_constant, generate_method_stub /
+/// generate_property, add_parameter / remove_parameter, and
 /// convert_anonymous_to_class / convert_tuple_to_struct name checks.
 /// Applies verbatim <c>@</c>-keyword and reserved-keyword rules via
 /// <see cref="SyntaxFacts"/>. Distinct from char-based
@@ -37,4 +38,13 @@ internal static class SyntaxIdentifierValidation
         var keywordKind = SyntaxFacts.GetKeywordKind(name);
         return keywordKind == SyntaxKind.None || !SyntaxFacts.IsReservedKeyword(keywordKind);
     }
+
+    /// <summary>
+    /// Strips a leading verbatim <c>@</c> prefix when present (e.g.
+    /// <c>@class</c> → <c>class</c>); bare names and a lone <c>@</c> are
+    /// returned unchanged. Same body as the former InlineConstant /
+    /// AddParameter / RemoveParameter private copies.
+    /// </summary>
+    internal static string NormalizeIdentifier(string name) =>
+        name.StartsWith('@') && name.Length > 1 ? name[1..] : name;
 }

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Utilities/SyntaxIdentifierValidationTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Utilities/SyntaxIdentifierValidationTests.cs
@@ -40,4 +40,15 @@ public class SyntaxIdentifierValidationTests
     {
         Assert.False(SyntaxIdentifierValidation.IsValidIdentifier(name));
     }
+
+    [Theory]
+    [InlineData("@class", "class")]
+    [InlineData("@namespace", "namespace")]
+    [InlineData("MaxRetries", "MaxRetries")]
+    [InlineData("@", "@")]
+    [InlineData("", "")]
+    public void NormalizeIdentifier_StripsLeadingAtWhenLengthGreaterThanOne(string input, string expected)
+    {
+        Assert.Equal(expected, SyntaxIdentifierValidation.NormalizeIdentifier(input));
+    }
 }


### PR DESCRIPTION
## Summary
- Extract shared `SyntaxIdentifierValidation.NormalizeIdentifier` (strip leading `@` when length > 1) into the existing SyntaxIdentifierValidation helper.
- Replace identical private copies in `InlineConstantOperation`, `AddParameterOperation`, and `RemoveParameterOperation`.
- Extend `SyntaxIdentifierValidationTests` with `@class` / `@namespace` / bare / lone `@` / empty cases; CHANGELOG under Unreleased Changed.

Closes #1084

## Test plan
- [x] `dotnet test tests/RoslynMcp.Core.Tests/RoslynMcp.Core.Tests.csproj --filter FullyQualifiedName~SyntaxIdentifierValidationTests`
- [ ] CI Build and Test + Code Quality green
- [ ] Copilot/Codex review judged