### PR TITLE
Extract VisibilityTokenHelpers.ParseVisibilityTokens + ParseVisibilityKeyword; replace 2 identical copies (#1087)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- Extracted shared `VisibilityTokenHelpers.ParseVisibilityTokens` + `ParseVisibilityKeyword` and replaced 2 identical copies (`generate_constructor` / `generate_property`) (#1087)
 - Extracted shared `SyntaxIdentifierValidation.NormalizeIdentifier` and replaced 3 identical copies (`inline_constant` / `add_parameter` / `remove_parameter`) (#1084)
 - Extracted shared `SymbolSelectionHelpers.ConfirmSymbolName` + `IsDefinitionLocation` and replaced 3 identical copies (`make_static` / `make_non_static` / `safe_delete`) (#1081)
 - Extracted shared `HierarchyConflictHelpers.HasConflict` + `SignaturesMatch` + `IndexerSignaturesMatch` and replaced 2 identical copies (`pull_members_up` / `push_members_down`) (#1078)

--- a/src/RoslynMcp.Core/Refactoring/Generate/GenerateConstructorOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GenerateConstructorOperation.cs
@@ -1326,7 +1326,7 @@ public sealed class GenerateConstructorOperation : RefactoringOperationBase<Gene
 
         // Build constructor
         var constructor = SyntaxFactory.ConstructorDeclaration(typeDeclaration.Identifier)
-            .WithModifiers(SyntaxFactory.TokenList(ParseVisibilityTokens(visibility)))
+            .WithModifiers(SyntaxFactory.TokenList(VisibilityTokenHelpers.ParseVisibilityTokens(visibility)))
             .WithParameterList(SyntaxFactory.ParameterList(SyntaxFactory.SeparatedList(parameters)))
             .WithBody(SyntaxFactory.Block(statements));
 
@@ -1385,7 +1385,7 @@ public sealed class GenerateConstructorOperation : RefactoringOperationBase<Gene
         }
 
         var constructor = SyntaxFactory.ConstructorDeclaration(typeDeclaration.Identifier)
-            .WithModifiers(SyntaxFactory.TokenList(ParseVisibilityTokens(visibility)))
+            .WithModifiers(SyntaxFactory.TokenList(VisibilityTokenHelpers.ParseVisibilityTokens(visibility)))
             .WithParameterList(SyntaxFactory.ParameterList(SyntaxFactory.SingletonSeparatedList(parameter)))
             .WithBody(SyntaxFactory.Block(statements));
 
@@ -1741,33 +1741,6 @@ public sealed class GenerateConstructorOperation : RefactoringOperationBase<Gene
                                     SyntaxFactory.Argument(
                                         SyntaxFactory.IdentifierName(paramName)))))))))));
     }
-
-    /// <summary>
-    /// Same token split as generate_property / generate_method_stub: one token
-    /// per whitespace-separated keyword so <c>protected internal</c> and
-    /// <c>private protected</c> emit both modifiers.
-    /// </summary>
-    private static IEnumerable<SyntaxToken> ParseVisibilityTokens(string visibility)
-    {
-        var tokens = visibility
-            .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .Select(ParseVisibilityKeyword)
-            .ToList();
-
-        if (tokens.Count == 0)
-            tokens.Add(SyntaxFactory.Token(SyntaxKind.PublicKeyword));
-
-        return tokens;
-    }
-
-    private static SyntaxToken ParseVisibilityKeyword(string keyword) => keyword.ToLowerInvariant() switch
-    {
-        "public" => SyntaxFactory.Token(SyntaxKind.PublicKeyword),
-        "private" => SyntaxFactory.Token(SyntaxKind.PrivateKeyword),
-        "protected" => SyntaxFactory.Token(SyntaxKind.ProtectedKeyword),
-        "internal" => SyntaxFactory.Token(SyntaxKind.InternalKeyword),
-        _ => SyntaxFactory.Token(SyntaxKind.PublicKeyword)
-    };
 
     private static TypeDeclarationSyntax InsertConstructor(
         TypeDeclarationSyntax typeDeclaration,

--- a/src/RoslynMcp.Core/Refactoring/Generate/GeneratePropertyOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Generate/GeneratePropertyOperation.cs
@@ -511,7 +511,7 @@ public sealed class GeneratePropertyOperation : RefactoringOperationBase<Generat
         return SyntaxFactory.PropertyDeclaration(
                 SyntaxFactory.ParseTypeName(type).WithTrailingTrivia(SyntaxFactory.Space),
                 name)
-            .WithModifiers(SyntaxFactory.TokenList(ParseVisibilityTokens(visibility)))
+            .WithModifiers(SyntaxFactory.TokenList(VisibilityTokenHelpers.ParseVisibilityTokens(visibility)))
             .WithAccessorList(SyntaxFactory.AccessorList(SyntaxFactory.List(accessors)))
             .NormalizeWhitespace();
     }
@@ -544,7 +544,7 @@ public sealed class GeneratePropertyOperation : RefactoringOperationBase<Generat
         return SyntaxFactory.PropertyDeclaration(
                 SyntaxFactory.ParseTypeName(type).WithTrailingTrivia(SyntaxFactory.Space),
                 name)
-            .WithModifiers(SyntaxFactory.TokenList(ParseVisibilityTokens(visibility)))
+            .WithModifiers(SyntaxFactory.TokenList(VisibilityTokenHelpers.ParseVisibilityTokens(visibility)))
             .WithAccessorList(SyntaxFactory.AccessorList(SyntaxFactory.List(new[] { getAccessor, setAccessor })))
             .NormalizeWhitespace();
     }
@@ -824,25 +824,4 @@ public sealed class GeneratePropertyOperation : RefactoringOperationBase<Generat
         return RefactoringResult.PreviewResult(operationId, pendingChanges);
     }
 
-    private static IEnumerable<SyntaxToken> ParseVisibilityTokens(string visibility)
-    {
-        var tokens = visibility
-            .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .Select(ParseVisibilityKeyword)
-            .ToList();
-
-        if (tokens.Count == 0)
-            tokens.Add(SyntaxFactory.Token(SyntaxKind.PublicKeyword));
-
-        return tokens;
-    }
-
-    private static SyntaxToken ParseVisibilityKeyword(string keyword) => keyword.ToLowerInvariant() switch
-    {
-        "public" => SyntaxFactory.Token(SyntaxKind.PublicKeyword),
-        "private" => SyntaxFactory.Token(SyntaxKind.PrivateKeyword),
-        "protected" => SyntaxFactory.Token(SyntaxKind.ProtectedKeyword),
-        "internal" => SyntaxFactory.Token(SyntaxKind.InternalKeyword),
-        _ => SyntaxFactory.Token(SyntaxKind.PublicKeyword)
-    };
 }

--- a/src/RoslynMcp.Core/Refactoring/Utilities/VisibilityTokenHelpers.cs
+++ b/src/RoslynMcp.Core/Refactoring/Utilities/VisibilityTokenHelpers.cs
@@ -1,0 +1,46 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace RoslynMcp.Core.Refactoring.Utilities;
+
+/// <summary>
+/// Shared visibility-string → <see cref="SyntaxToken"/> parsing used by
+/// generate_constructor / generate_property. Same bodies as the two private
+/// copies. Distinct from generate_method_stub (PrivateKeyword empty/unknown
+/// default + trailing Space trivia).
+/// </summary>
+internal static class VisibilityTokenHelpers
+{
+    /// <summary>
+    /// Splits <paramref name="visibility"/> on whitespace into modifier
+    /// tokens so <c>protected internal</c> and <c>private protected</c>
+    /// emit both modifiers. Empty / whitespace-only defaults to
+    /// <see cref="SyntaxKind.PublicKeyword"/>.
+    /// </summary>
+    internal static IEnumerable<SyntaxToken> ParseVisibilityTokens(string visibility)
+    {
+        var tokens = visibility
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(ParseVisibilityKeyword)
+            .ToList();
+
+        if (tokens.Count == 0)
+            tokens.Add(SyntaxFactory.Token(SyntaxKind.PublicKeyword));
+
+        return tokens;
+    }
+
+    /// <summary>
+    /// Maps a single case-insensitive visibility keyword to a
+    /// <see cref="SyntaxToken"/>; unknown keywords become
+    /// <see cref="SyntaxKind.PublicKeyword"/>.
+    /// </summary>
+    internal static SyntaxToken ParseVisibilityKeyword(string keyword) => keyword.ToLowerInvariant() switch
+    {
+        "public" => SyntaxFactory.Token(SyntaxKind.PublicKeyword),
+        "private" => SyntaxFactory.Token(SyntaxKind.PrivateKeyword),
+        "protected" => SyntaxFactory.Token(SyntaxKind.ProtectedKeyword),
+        "internal" => SyntaxFactory.Token(SyntaxKind.InternalKeyword),
+        _ => SyntaxFactory.Token(SyntaxKind.PublicKeyword)
+    };
+}

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Utilities/VisibilityTokenHelpersTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Utilities/VisibilityTokenHelpersTests.cs
@@ -1,0 +1,76 @@
+using Microsoft.CodeAnalysis.CSharp;
+using RoslynMcp.Core.Refactoring.Utilities;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Refactoring.Utilities;
+
+public class VisibilityTokenHelpersTests
+{
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    public void ParseVisibilityTokens_EmptyOrWhitespace_DefaultsToPublic(string visibility)
+    {
+        var tokens = VisibilityTokenHelpers.ParseVisibilityTokens(visibility).ToArray();
+        Assert.Single(tokens);
+        Assert.Equal(SyntaxKind.PublicKeyword, tokens[0].Kind());
+    }
+
+    [Theory]
+    [InlineData("public", SyntaxKind.PublicKeyword)]
+    [InlineData("private", SyntaxKind.PrivateKeyword)]
+    [InlineData("protected", SyntaxKind.ProtectedKeyword)]
+    [InlineData("internal", SyntaxKind.InternalKeyword)]
+    [InlineData("PUBLIC", SyntaxKind.PublicKeyword)]
+    [InlineData("Private", SyntaxKind.PrivateKeyword)]
+    [InlineData("PROTECTED", SyntaxKind.ProtectedKeyword)]
+    [InlineData("Internal", SyntaxKind.InternalKeyword)]
+    public void ParseVisibilityTokens_SingleKeyword_CaseInsensitive(string visibility, SyntaxKind expected)
+    {
+        var tokens = VisibilityTokenHelpers.ParseVisibilityTokens(visibility).ToArray();
+        Assert.Single(tokens);
+        Assert.Equal(expected, tokens[0].Kind());
+    }
+
+    [Fact]
+    public void ParseVisibilityTokens_ProtectedInternal_EmitsBothTokens()
+    {
+        var tokens = VisibilityTokenHelpers.ParseVisibilityTokens("protected internal").ToArray();
+        Assert.Equal(2, tokens.Length);
+        Assert.Equal(SyntaxKind.ProtectedKeyword, tokens[0].Kind());
+        Assert.Equal(SyntaxKind.InternalKeyword, tokens[1].Kind());
+    }
+
+    [Fact]
+    public void ParseVisibilityTokens_PrivateProtected_EmitsBothTokens()
+    {
+        var tokens = VisibilityTokenHelpers.ParseVisibilityTokens("private protected").ToArray();
+        Assert.Equal(2, tokens.Length);
+        Assert.Equal(SyntaxKind.PrivateKeyword, tokens[0].Kind());
+        Assert.Equal(SyntaxKind.ProtectedKeyword, tokens[1].Kind());
+    }
+
+    [Theory]
+    [InlineData("unknown")]
+    [InlineData("foo")]
+    [InlineData("pubic")]
+    public void ParseVisibilityTokens_UnknownKeyword_DefaultsToPublic(string visibility)
+    {
+        var tokens = VisibilityTokenHelpers.ParseVisibilityTokens(visibility).ToArray();
+        Assert.Single(tokens);
+        Assert.Equal(SyntaxKind.PublicKeyword, tokens[0].Kind());
+    }
+
+    [Theory]
+    [InlineData("public", SyntaxKind.PublicKeyword)]
+    [InlineData("PRIVATE", SyntaxKind.PrivateKeyword)]
+    [InlineData("Protected", SyntaxKind.ProtectedKeyword)]
+    [InlineData("INTERNAL", SyntaxKind.InternalKeyword)]
+    [InlineData("nope", SyntaxKind.PublicKeyword)]
+    public void ParseVisibilityKeyword_MapsKnownAndUnknown(string keyword, SyntaxKind expected)
+    {
+        Assert.Equal(expected, VisibilityTokenHelpers.ParseVisibilityKeyword(keyword).Kind());
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1087

Extract shared `VisibilityTokenHelpers.ParseVisibilityTokens` + `ParseVisibilityKeyword` into `RoslynMcp.Core.Refactoring.Utilities` and replace the 2 identical private copies in `GenerateConstructorOperation` / `GeneratePropertyOperation`.

Behavior unchanged: empty/whitespace → public; unknown keyword → public; case-insensitive; `protected internal` / `private protected` emit both tokens.

**Out of scope:** `GenerateMethodStubOperation` private copy (PrivateKeyword empty/unknown + trailing Space trivia) left alone. Dependabot untouched.

## Test plan

- [x] `dotnet test … --filter FullyQualifiedName~VisibilityTokenHelpersTests` — 22 passed
- [x] `dotnet format RoslynMcp.sln --verify-no-changes` — clean
- [ ] CI Build and Test + Code Quality green
- [ ] MethodStub private ParseVisibility* still present / unchanged