### PR TITLE
Extract NamespaceEqualityHelpers.NamespacesEqual + ToNamespaceName + TypeNameBindsToDifferentType; replace 2 identical copies (#1090)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- Extracted shared `NamespaceEqualityHelpers.NamespacesEqual` + `ToNamespaceName` + `TypeNameBindsToDifferentType` and replaced 2 identical copies (`convert_anonymous_to_class` / `convert_tuple_to_struct`) (#1090)
 - Extracted shared `VisibilityTokenHelpers.ParseVisibilityTokens` + `ParseVisibilityKeyword` and replaced 2 identical copies (`generate_constructor` / `generate_property`) (#1087)
 - Extracted shared `SyntaxIdentifierValidation.NormalizeIdentifier` and replaced 3 identical copies (`inline_constant` / `add_parameter` / `remove_parameter`) (#1084)
 - Extracted shared `SymbolSelectionHelpers.ConfirmSymbolName` + `IsDefinitionLocation` and replaced 3 identical copies (`make_static` / `make_non_static` / `safe_delete`) (#1081)

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertAnonymousToClassOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertAnonymousToClassOperation.cs
@@ -149,7 +149,6 @@ public sealed class ConvertAnonymousToClassOperation : RefactoringOperationBase<
             0);
     }
 
-
     internal static AnonymousObjectCreationExpressionSyntax FindAnonymousCreation(
         SyntaxNode root,
         ConvertAnonymousToClassParams @params)
@@ -349,7 +348,7 @@ public sealed class ConvertAnonymousToClassOperation : RefactoringOperationBase<
     internal static string ToContextValidTypeName(ITypeSymbol type, SemanticModel model, int position)
     {
         var display = type.ToMinimalDisplayString(model, position);
-        if (string.IsNullOrWhiteSpace(display) || TypeNameBindsToDifferentType(display, type, model, position))
+        if (string.IsNullOrWhiteSpace(display) || NamespaceEqualityHelpers.TypeNameBindsToDifferentType(display, type, model, position))
         {
             display = type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat
                 .WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted));
@@ -387,7 +386,7 @@ public sealed class ConvertAnonymousToClassOperation : RefactoringOperationBase<
             return false;
 
         var display = ToContextValidTypeName(type, model, position);
-        return !TypeNameBindsToDifferentType(display, type, model, position);
+        return !NamespaceEqualityHelpers.TypeNameBindsToDifferentType(display, type, model, position);
     }
 
     internal static bool ContainsTypeParameter(ITypeSymbol type)
@@ -458,7 +457,7 @@ public sealed class ConvertAnonymousToClassOperation : RefactoringOperationBase<
     internal static string? GetContainingNamespaceName(SemanticModel semanticModel, SyntaxNode node)
     {
         var enclosing = semanticModel.GetEnclosingSymbol(node.SpanStart);
-        var fromSymbol = ToNamespaceName(enclosing?.ContainingNamespace);
+        var fromSymbol = NamespaceEqualityHelpers.ToNamespaceName(enclosing?.ContainingNamespace);
         if (!string.IsNullOrEmpty(fromSymbol))
             return fromSymbol;
 
@@ -511,7 +510,7 @@ public sealed class ConvertAnonymousToClassOperation : RefactoringOperationBase<
 
         foreach (var symbol in simpleMatches.OfType<INamedTypeSymbol>())
         {
-            if (NamespacesEqual(symbol.ContainingNamespace, targetNamespace))
+            if (NamespaceEqualityHelpers.NamespacesEqual(symbol.ContainingNamespace, targetNamespace))
             {
                 throw new RefactoringException(
                     ErrorCodes.NameConflictScope,
@@ -676,7 +675,7 @@ public sealed class ConvertAnonymousToClassOperation : RefactoringOperationBase<
     private static string TypeNameForCreation(SyntaxNode creation, string newTypeName, string? targetNamespace)
     {
         var creationNamespace = GetContainingNamespaceName(creation);
-        if (NamespacesEqual(creationNamespace, targetNamespace))
+        if (NamespaceEqualityHelpers.NamespacesEqual(creationNamespace, targetNamespace))
             return newTypeName;
 
         var root = creation.SyntaxTree.GetRoot();
@@ -686,13 +685,6 @@ public sealed class ConvertAnonymousToClassOperation : RefactoringOperationBase<
         return string.IsNullOrEmpty(targetNamespace)
             ? newTypeName
             : $"{targetNamespace}.{newTypeName}";
-    }
-
-    private static bool NamespacesEqual(string? left, string? right)
-    {
-        if (string.IsNullOrEmpty(left) && string.IsNullOrEmpty(right))
-            return true;
-        return string.Equals(left, right, StringComparison.Ordinal);
     }
 
     internal static string? GetFullNamespaceName(BaseNamespaceDeclarationSyntax? ns)
@@ -717,22 +709,6 @@ public sealed class ConvertAnonymousToClassOperation : RefactoringOperationBase<
             .Any(u => u.Name != null && u.Name.ToString() == namespaceName);
     }
 
-    private static string? ToNamespaceName(INamespaceSymbol? symbol)
-    {
-        if (symbol == null || symbol.IsGlobalNamespace)
-            return null;
-
-        var name = symbol.ToDisplayString();
-        return string.IsNullOrEmpty(name) ? null : name;
-    }
-
-    private static bool NamespacesEqual(INamespaceSymbol? symbol, string? name)
-    {
-        if (symbol == null || symbol.IsGlobalNamespace)
-            return string.IsNullOrEmpty(name);
-        return string.Equals(symbol.ToDisplayString(), name, StringComparison.Ordinal);
-    }
-
     private static bool MembersMatch(IReadOnlyList<AnonymousMember> left, IReadOnlyList<AnonymousMember> right)
     {
         if (left.Count != right.Count)
@@ -747,20 +723,6 @@ public sealed class ConvertAnonymousToClassOperation : RefactoringOperationBase<
         }
 
         return true;
-    }
-
-    private static bool TypeNameBindsToDifferentType(
-        string display,
-        ITypeSymbol expected,
-        SemanticModel model,
-        int position)
-    {
-        var parsed = SyntaxFactory.ParseTypeName(display);
-        var spec = model.GetSpeculativeTypeInfo(position, parsed, SpeculativeBindingOption.BindAsTypeOrNamespace);
-        if (spec.Type == null || spec.Type.TypeKind == TypeKind.Error)
-            return true;
-
-        return !SymbolEqualityComparer.Default.Equals(spec.Type, expected);
     }
 
     private static Accessibility MinAccessibility(Accessibility left, Accessibility right)

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertTupleToStructOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertTupleToStructOperation.cs
@@ -153,7 +153,6 @@ public sealed class ConvertTupleToStructOperation : RefactoringOperationBase<Con
             0);
     }
 
-
     internal static ExpressionSyntax FindTupleCreation(
         SyntaxNode root,
         SemanticModel semanticModel,
@@ -331,7 +330,7 @@ public sealed class ConvertTupleToStructOperation : RefactoringOperationBase<Con
     internal static string ToContextValidTypeName(ITypeSymbol type, SemanticModel model, int position)
     {
         var display = type.ToMinimalDisplayString(model, position);
-        if (string.IsNullOrWhiteSpace(display) || TypeNameBindsToDifferentType(display, type, model, position))
+        if (string.IsNullOrWhiteSpace(display) || NamespaceEqualityHelpers.TypeNameBindsToDifferentType(display, type, model, position))
         {
             display = type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat
                 .WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted));
@@ -369,7 +368,7 @@ public sealed class ConvertTupleToStructOperation : RefactoringOperationBase<Con
             return false;
 
         var display = ToContextValidTypeName(type, model, position);
-        return !TypeNameBindsToDifferentType(display, type, model, position);
+        return !NamespaceEqualityHelpers.TypeNameBindsToDifferentType(display, type, model, position);
     }
 
     internal static bool ContainsTypeParameter(ITypeSymbol type)
@@ -456,7 +455,7 @@ public sealed class ConvertTupleToStructOperation : RefactoringOperationBase<Con
     internal static string? GetContainingNamespaceName(SemanticModel semanticModel, SyntaxNode node)
     {
         var enclosing = semanticModel.GetEnclosingSymbol(node.SpanStart);
-        var fromSymbol = ToNamespaceName(enclosing?.ContainingNamespace);
+        var fromSymbol = NamespaceEqualityHelpers.ToNamespaceName(enclosing?.ContainingNamespace);
         if (!string.IsNullOrEmpty(fromSymbol))
             return fromSymbol;
 
@@ -529,7 +528,7 @@ public sealed class ConvertTupleToStructOperation : RefactoringOperationBase<Con
 
         foreach (var symbol in simpleMatches.OfType<INamedTypeSymbol>())
         {
-            if (NamespacesEqual(symbol.ContainingNamespace, targetNamespace))
+            if (NamespaceEqualityHelpers.NamespacesEqual(symbol.ContainingNamespace, targetNamespace))
             {
                 throw new RefactoringException(
                     ErrorCodes.NameConflictScope,
@@ -686,7 +685,7 @@ public sealed class ConvertTupleToStructOperation : RefactoringOperationBase<Con
     private static string TypeNameForCreation(SyntaxNode creation, string newTypeName, string? targetNamespace)
     {
         var creationNamespace = GetContainingNamespaceName(creation);
-        if (NamespacesEqual(creationNamespace, targetNamespace))
+        if (NamespaceEqualityHelpers.NamespacesEqual(creationNamespace, targetNamespace))
             return newTypeName;
 
         if (!string.IsNullOrEmpty(targetNamespace) && HasUsingInScope(creation, targetNamespace))
@@ -695,13 +694,6 @@ public sealed class ConvertTupleToStructOperation : RefactoringOperationBase<Con
         return string.IsNullOrEmpty(targetNamespace)
             ? newTypeName
             : $"{targetNamespace}.{newTypeName}";
-    }
-
-    private static bool NamespacesEqual(string? left, string? right)
-    {
-        if (string.IsNullOrEmpty(left) && string.IsNullOrEmpty(right))
-            return true;
-        return string.Equals(left, right, StringComparison.Ordinal);
     }
 
     /// <summary>
@@ -825,22 +817,6 @@ public sealed class ConvertTupleToStructOperation : RefactoringOperationBase<Con
         }
 
         return false;
-    }
-
-    private static string? ToNamespaceName(INamespaceSymbol? symbol)
-    {
-        if (symbol == null || symbol.IsGlobalNamespace)
-            return null;
-
-        var name = symbol.ToDisplayString();
-        return string.IsNullOrEmpty(name) ? null : name;
-    }
-
-    private static bool NamespacesEqual(INamespaceSymbol? symbol, string? name)
-    {
-        if (symbol == null || symbol.IsGlobalNamespace)
-            return string.IsNullOrEmpty(name);
-        return string.Equals(symbol.ToDisplayString(), name, StringComparison.Ordinal);
     }
 
     private static bool MembersMatch(IReadOnlyList<TupleMember> left, IReadOnlyList<TupleMember> right)
@@ -982,20 +958,6 @@ public sealed class ConvertTupleToStructOperation : RefactoringOperationBase<Con
         }
 
         return -1;
-    }
-
-    private static bool TypeNameBindsToDifferentType(
-        string display,
-        ITypeSymbol expected,
-        SemanticModel model,
-        int position)
-    {
-        var parsed = SyntaxFactory.ParseTypeName(display);
-        var spec = model.GetSpeculativeTypeInfo(position, parsed, SpeculativeBindingOption.BindAsTypeOrNamespace);
-        if (spec.Type == null || spec.Type.TypeKind == TypeKind.Error)
-            return true;
-
-        return !SymbolEqualityComparer.Default.Equals(spec.Type, expected);
     }
 
     private static Accessibility MinAccessibility(Accessibility left, Accessibility right)

--- a/src/RoslynMcp.Core/Refactoring/Utilities/NamespaceEqualityHelpers.cs
+++ b/src/RoslynMcp.Core/Refactoring/Utilities/NamespaceEqualityHelpers.cs
@@ -1,0 +1,66 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace RoslynMcp.Core.Refactoring.Utilities;
+
+/// <summary>
+/// Shared namespace-name equality and type-name speculative binding used by
+/// convert_anonymous_to_class / convert_tuple_to_struct. Same bodies as the
+/// two private copies. Distinct from change_return_type
+/// (<c>TypesEquivalent</c> instead of <see cref="SymbolEqualityComparer"/>).
+/// </summary>
+internal static class NamespaceEqualityHelpers
+{
+    /// <summary>
+    /// Ordinal equality for namespace name strings; both null/empty count as equal.
+    /// </summary>
+    internal static bool NamespacesEqual(string? left, string? right)
+    {
+        if (string.IsNullOrEmpty(left) && string.IsNullOrEmpty(right))
+            return true;
+        return string.Equals(left, right, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Ordinal equality of a namespace symbol's display string against
+    /// <paramref name="name"/>; null/global namespace equals an empty/null name.
+    /// </summary>
+    internal static bool NamespacesEqual(INamespaceSymbol? symbol, string? name)
+    {
+        if (symbol == null || symbol.IsGlobalNamespace)
+            return string.IsNullOrEmpty(name);
+        return string.Equals(symbol.ToDisplayString(), name, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Display string for <paramref name="symbol"/>, or null when the symbol
+    /// is null, global, or has an empty display string.
+    /// </summary>
+    internal static string? ToNamespaceName(INamespaceSymbol? symbol)
+    {
+        if (symbol == null || symbol.IsGlobalNamespace)
+            return null;
+
+        var name = symbol.ToDisplayString();
+        return string.IsNullOrEmpty(name) ? null : name;
+    }
+
+    /// <summary>
+    /// True when <paramref name="display"/> does not speculative-bind at
+    /// <paramref name="position"/> to <paramref name="expected"/> (null or
+    /// error type counts as different).
+    /// </summary>
+    internal static bool TypeNameBindsToDifferentType(
+        string display,
+        ITypeSymbol expected,
+        SemanticModel model,
+        int position)
+    {
+        var parsed = SyntaxFactory.ParseTypeName(display);
+        var spec = model.GetSpeculativeTypeInfo(position, parsed, SpeculativeBindingOption.BindAsTypeOrNamespace);
+        if (spec.Type == null || spec.Type.TypeKind == TypeKind.Error)
+            return true;
+
+        return !SymbolEqualityComparer.Default.Equals(spec.Type, expected);
+    }
+}

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Utilities/NamespaceEqualityHelpersTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Utilities/NamespaceEqualityHelpersTests.cs
@@ -1,0 +1,160 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using RoslynMcp.Core.Refactoring.Utilities;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Refactoring.Utilities;
+
+public class NamespaceEqualityHelpersTests
+{
+    [Theory]
+    [InlineData(null, null, true)]
+    [InlineData(null, "", true)]
+    [InlineData("", null, true)]
+    [InlineData("", "", true)]
+    [InlineData("A", "A", true)]
+    [InlineData("A.B", "A.B", true)]
+    [InlineData("A", "B", false)]
+    [InlineData("A", "a", false)]
+    [InlineData("A", "", false)]
+    [InlineData(null, "A", false)]
+    public void NamespacesEqual_Strings_OrdinalEmptyNullRules(string? left, string? right, bool expected)
+    {
+        Assert.Equal(expected, NamespaceEqualityHelpers.NamespacesEqual(left, right));
+    }
+
+    [Fact]
+    public void NamespacesEqual_Symbol_NullOrGlobal_EqualsEmptyName()
+    {
+        var compilation = Compile("""
+            namespace Sample.Ns
+            {
+                public class C { }
+            }
+            """);
+        var global = compilation.GlobalNamespace;
+        Assert.True(NamespaceEqualityHelpers.NamespacesEqual((INamespaceSymbol?)null, null));
+        Assert.True(NamespaceEqualityHelpers.NamespacesEqual((INamespaceSymbol?)null, ""));
+        Assert.True(NamespaceEqualityHelpers.NamespacesEqual(global, null));
+        Assert.True(NamespaceEqualityHelpers.NamespacesEqual(global, ""));
+        Assert.False(NamespaceEqualityHelpers.NamespacesEqual(global, "Sample"));
+    }
+
+    [Fact]
+    public void NamespacesEqual_Symbol_MatchingAndMismatchDisplay()
+    {
+        var compilation = Compile("""
+            namespace Sample.Ns
+            {
+                public class C { }
+            }
+            """);
+        var type = compilation.GetTypeByMetadataName("Sample.Ns.C")!;
+        var ns = type.ContainingNamespace;
+        Assert.True(NamespaceEqualityHelpers.NamespacesEqual(ns, "Sample.Ns"));
+        Assert.False(NamespaceEqualityHelpers.NamespacesEqual(ns, "Sample"));
+        Assert.False(NamespaceEqualityHelpers.NamespacesEqual(ns, "sample.ns"));
+        Assert.False(NamespaceEqualityHelpers.NamespacesEqual(ns, null));
+        Assert.False(NamespaceEqualityHelpers.NamespacesEqual(ns, ""));
+    }
+
+    [Fact]
+    public void ToNamespaceName_NullGlobalNamed()
+    {
+        var compilation = Compile("""
+            namespace Sample.Ns
+            {
+                public class C { }
+            }
+            """);
+        var type = compilation.GetTypeByMetadataName("Sample.Ns.C")!;
+        Assert.Null(NamespaceEqualityHelpers.ToNamespaceName(null));
+        Assert.Null(NamespaceEqualityHelpers.ToNamespaceName(compilation.GlobalNamespace));
+        Assert.Equal("Sample.Ns", NamespaceEqualityHelpers.ToNamespaceName(type.ContainingNamespace));
+    }
+
+    [Fact]
+    public void TypeNameBindsToDifferentType_ErrorName_IsDifferent()
+    {
+        var (model, position, expected) = BuildModelAtMarker("""
+            class C
+            {
+                void M()
+                {
+                    /*pos*/int x = 0;
+                }
+            }
+            """, "/*pos*/");
+        Assert.True(NamespaceEqualityHelpers.TypeNameBindsToDifferentType("DoesNotExist", expected, model, position));
+    }
+
+    [Fact]
+    public void TypeNameBindsToDifferentType_MatchingInt_IsSame()
+    {
+        var (model, position, expected) = BuildModelAtMarker("""
+            class C
+            {
+                void M()
+                {
+                    /*pos*/int x = 0;
+                }
+            }
+            """, "/*pos*/");
+        Assert.False(NamespaceEqualityHelpers.TypeNameBindsToDifferentType("int", expected, model, position));
+    }
+
+    [Fact]
+    public void TypeNameBindsToDifferentType_WrongType_IsDifferent()
+    {
+        var (model, position, expected) = BuildModelAtMarker("""
+            class C
+            {
+                void M()
+                {
+                    /*pos*/int x = 0;
+                }
+            }
+            """, "/*pos*/");
+        Assert.True(NamespaceEqualityHelpers.TypeNameBindsToDifferentType("string", expected, model, position));
+    }
+
+    private static (SemanticModel Model, int Position, ITypeSymbol Expected) BuildModelAtMarker(string source, string marker)
+    {
+        var markerIndex = source.IndexOf(marker, StringComparison.Ordinal);
+        Assert.True(markerIndex >= 0);
+        var cleaned = source.Remove(markerIndex, marker.Length);
+        var tree = CSharpSyntaxTree.ParseText(cleaned);
+        var refs = new[]
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location),
+        };
+        var compilation = CSharpCompilation.Create(
+            "NamespaceEqualityHelpersTests_Bind",
+            new[] { tree },
+            refs,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        var model = compilation.GetSemanticModel(tree);
+        var position = markerIndex;
+        var expected = compilation.GetSpecialType(SpecialType.System_Int32);
+        return (model, position, expected);
+    }
+
+    private static Compilation Compile(string source)
+    {
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var refs = new[]
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location),
+        };
+        var compilation = CSharpCompilation.Create(
+            "NamespaceEqualityHelpersTests",
+            new[] { tree },
+            refs,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        var diagnostics = compilation.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.True(diagnostics.Length == 0, string.Join("\n", diagnostics.Select(d => d.ToString())));
+        return compilation;
+    }
+}


### PR DESCRIPTION
## Summary

Extract shared `NamespaceEqualityHelpers.NamespacesEqual` (string + symbol overloads) + `ToNamespaceName` + `TypeNameBindsToDifferentType` into `RoslynMcp.Core.Refactoring.Utilities` and replace the 2 identical private copies in `ConvertAnonymousToClassOperation` / `ConvertTupleToStructOperation`.

Closes #1090

## Changes

- New `internal static class NamespaceEqualityHelpers` (Utilities)
- Anonymous + Tuple call sites retargeted; private copies deleted
- `NamespaceEqualityHelpersTests` (string/symbol equality, ToNamespaceName, speculative TypeNameBinds)
- CHANGELOG Unreleased / Changed

## Out of scope (unchanged)

- `TypeNameForCreation` / `HasUsing` / `HasUsingInScope` / `GetFullNamespaceName`
- `MembersMatch` / `MinAccessibility` / `AccessibilityRank`
- `ChangeReturnTypeOperation.TypeNameBindsToDifferentType` (`TypesEquivalent`)
- Dependabot; no product behavior changes

## Test plan

- [x] `dotnet test` filtered to `NamespaceEqualityHelpersTests` (16 passed)
- [ ] CI Build & Test + CodeQL green
- [ ] Dependabot PRs untouched