### PR TITLE
Extract AccessibilityRankHelpers.MinAccessibility + AccessibilityRank; replace 2 identical copies (#1094)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Changed
+- Extracted shared `AccessibilityRankHelpers.MinAccessibility` + `AccessibilityRank` and replaced 2 identical copies (`convert_anonymous_to_class` / `convert_tuple_to_struct`) (#1094)
 - Extracted shared `NamespaceEqualityHelpers.NamespacesEqual` + `ToNamespaceName` + `TypeNameBindsToDifferentType` and replaced 2 identical copies (`convert_anonymous_to_class` / `convert_tuple_to_struct`) (#1090)
 - Extracted shared `VisibilityTokenHelpers.ParseVisibilityTokens` + `ParseVisibilityKeyword` and replaced 2 identical copies (`generate_constructor` / `generate_property`) (#1087)
 - Extracted shared `SyntaxIdentifierValidation.NormalizeIdentifier` and replaced 3 identical copies (`inline_constant` / `add_parameter` / `remove_parameter`) (#1084)

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertAnonymousToClassOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertAnonymousToClassOperation.cs
@@ -439,7 +439,7 @@ public sealed class ConvertAnonymousToClassOperation : RefactoringOperationBase<
     {
         var current = symbol.DeclaredAccessibility;
         for (var container = symbol.ContainingType; container != null; container = container.ContainingType)
-            current = MinAccessibility(current, container.DeclaredAccessibility);
+            current = AccessibilityRankHelpers.MinAccessibility(current, container.DeclaredAccessibility);
 
         return current;
     }
@@ -724,22 +724,6 @@ public sealed class ConvertAnonymousToClassOperation : RefactoringOperationBase<
 
         return true;
     }
-
-    private static Accessibility MinAccessibility(Accessibility left, Accessibility right)
-    {
-        return AccessibilityRank(left) <= AccessibilityRank(right) ? left : right;
-    }
-
-    private static int AccessibilityRank(Accessibility accessibility) => accessibility switch
-    {
-        Accessibility.Private => 0,
-        Accessibility.ProtectedAndInternal => 1,
-        Accessibility.Protected => 2,
-        Accessibility.Internal => 3,
-        Accessibility.ProtectedOrInternal => 4,
-        Accessibility.Public => 5,
-        _ => 5
-    };
 
     private static async Task<RefactoringResult> CreatePreviewResultAsync(
         Guid operationId,

--- a/src/RoslynMcp.Core/Refactoring/Convert/ConvertTupleToStructOperation.cs
+++ b/src/RoslynMcp.Core/Refactoring/Convert/ConvertTupleToStructOperation.cs
@@ -421,7 +421,7 @@ public sealed class ConvertTupleToStructOperation : RefactoringOperationBase<Con
     {
         var current = symbol.DeclaredAccessibility;
         for (var container = symbol.ContainingType; container != null; container = container.ContainingType)
-            current = MinAccessibility(current, container.DeclaredAccessibility);
+            current = AccessibilityRankHelpers.MinAccessibility(current, container.DeclaredAccessibility);
 
         return current;
     }
@@ -959,22 +959,6 @@ public sealed class ConvertTupleToStructOperation : RefactoringOperationBase<Con
 
         return -1;
     }
-
-    private static Accessibility MinAccessibility(Accessibility left, Accessibility right)
-    {
-        return AccessibilityRank(left) <= AccessibilityRank(right) ? left : right;
-    }
-
-    private static int AccessibilityRank(Accessibility accessibility) => accessibility switch
-    {
-        Accessibility.Private => 0,
-        Accessibility.ProtectedAndInternal => 1,
-        Accessibility.Protected => 2,
-        Accessibility.Internal => 3,
-        Accessibility.ProtectedOrInternal => 4,
-        Accessibility.Public => 5,
-        _ => 5
-    };
 
     private static async Task<RefactoringResult> CreatePreviewResultAsync(
         Guid operationId,

--- a/src/RoslynMcp.Core/Refactoring/Utilities/AccessibilityRankHelpers.cs
+++ b/src/RoslynMcp.Core/Refactoring/Utilities/AccessibilityRankHelpers.cs
@@ -1,0 +1,37 @@
+using Microsoft.CodeAnalysis;
+
+namespace RoslynMcp.Core.Refactoring.Utilities;
+
+/// <summary>
+/// Shared accessibility ranking used by convert_anonymous_to_class /
+/// convert_tuple_to_struct when computing effective accessibility through
+/// containing types. Same bodies as the two private copies. Distinct from
+/// <see cref="EqualityMemberCollector"/> / generate_constructor (different
+/// AccessibilityRank ordering).
+/// </summary>
+internal static class AccessibilityRankHelpers
+{
+    /// <summary>
+    /// Returns the less-accessible of <paramref name="left"/> and
+    /// <paramref name="right"/> using <see cref="AccessibilityRank"/>.
+    /// </summary>
+    internal static Accessibility MinAccessibility(Accessibility left, Accessibility right)
+    {
+        return AccessibilityRank(left) <= AccessibilityRank(right) ? left : right;
+    }
+
+    /// <summary>
+    /// Ordinal rank from most restrictive (0) to least (5). Unknown /
+    /// <see cref="Accessibility.NotApplicable"/> map to 5.
+    /// </summary>
+    internal static int AccessibilityRank(Accessibility accessibility) => accessibility switch
+    {
+        Accessibility.Private => 0,
+        Accessibility.ProtectedAndInternal => 1,
+        Accessibility.Protected => 2,
+        Accessibility.Internal => 3,
+        Accessibility.ProtectedOrInternal => 4,
+        Accessibility.Public => 5,
+        _ => 5
+    };
+}

--- a/tests/RoslynMcp.Core.Tests/Refactoring/Utilities/AccessibilityRankHelpersTests.cs
+++ b/tests/RoslynMcp.Core.Tests/Refactoring/Utilities/AccessibilityRankHelpersTests.cs
@@ -1,0 +1,40 @@
+using Microsoft.CodeAnalysis;
+using RoslynMcp.Core.Refactoring.Utilities;
+using Xunit;
+
+namespace RoslynMcp.Core.Tests.Refactoring.Utilities;
+
+public class AccessibilityRankHelpersTests
+{
+    [Theory]
+    [InlineData(Accessibility.Private, Accessibility.Public, Accessibility.Private)]
+    [InlineData(Accessibility.Public, Accessibility.Private, Accessibility.Private)]
+    [InlineData(Accessibility.Protected, Accessibility.Internal, Accessibility.Protected)]
+    [InlineData(Accessibility.Internal, Accessibility.Protected, Accessibility.Protected)]
+    [InlineData(Accessibility.Private, Accessibility.Private, Accessibility.Private)]
+    [InlineData(Accessibility.Public, Accessibility.Public, Accessibility.Public)]
+    [InlineData(Accessibility.ProtectedAndInternal, Accessibility.Protected, Accessibility.ProtectedAndInternal)]
+    [InlineData(Accessibility.ProtectedOrInternal, Accessibility.Public, Accessibility.ProtectedOrInternal)]
+    [InlineData(Accessibility.NotApplicable, Accessibility.Private, Accessibility.Private)]
+    [InlineData(Accessibility.Private, Accessibility.NotApplicable, Accessibility.Private)]
+    public void MinAccessibility_ReturnsLessAccessible(
+        Accessibility left,
+        Accessibility right,
+        Accessibility expected)
+    {
+        Assert.Equal(expected, AccessibilityRankHelpers.MinAccessibility(left, right));
+    }
+
+    [Theory]
+    [InlineData(Accessibility.Private, 0)]
+    [InlineData(Accessibility.ProtectedAndInternal, 1)]
+    [InlineData(Accessibility.Protected, 2)]
+    [InlineData(Accessibility.Internal, 3)]
+    [InlineData(Accessibility.ProtectedOrInternal, 4)]
+    [InlineData(Accessibility.Public, 5)]
+    [InlineData(Accessibility.NotApplicable, 5)]
+    public void AccessibilityRank_KnownValues(Accessibility accessibility, int expected)
+    {
+        Assert.Equal(expected, AccessibilityRankHelpers.AccessibilityRank(accessibility));
+    }
+}


### PR DESCRIPTION
## Summary
- Extracted shared `AccessibilityRankHelpers.MinAccessibility` + `AccessibilityRank` into `src/RoslynMcp.Core/Refactoring/Utilities/AccessibilityRankHelpers.cs`
- Retargeted `convert_anonymous_to_class` / `convert_tuple_to_struct` `GetEffectiveAccessibility` and deleted the 2 identical private copies
- Added focused unit tests for MinAccessibility pairs and AccessibilityRank (including NotApplicable → 5)

Closes #1094

## Out of scope
- `EqualityMemberCollector` / `GenerateConstructorOperation` (different AccessibilityRank ordering) — untouched
- Dependabot
- Product behavior changes
- No merge / auto-merge from this PR workflow

## Test plan
- [x] `dotnet test tests/RoslynMcp.Core.Tests/RoslynMcp.Core.Tests.csproj --filter AccessibilityRankHelpers` — 17 passed locally
- [ ] CI green on PR